### PR TITLE
Fix: Only registering thread with controller on save

### DIFF
--- a/src/controllers/DrawingModeController.js
+++ b/src/controllers/DrawingModeController.js
@@ -264,15 +264,13 @@ class DrawingModeController extends AnnotationModeController {
     handleThreadEvents(thread, data = {}) {
         const { eventData } = data;
         switch (data.event) {
-            case 'locationassigned':
-                // Register the thread to the threadmap when a starting location is assigned. Should only occur once.
-                this.registerThread(thread);
-                break;
             case 'softcommit':
                 // Save the original thread, create a new thread and
                 // start drawing at the location indicating the page change
                 this.currentThread = undefined;
                 thread.saveAnnotation(TYPES.draw);
+                this.registerThread(thread);
+
                 this.unbindListeners();
                 this.bindListeners();
 

--- a/src/controllers/__tests__/DrawingModeController-test.js
+++ b/src/controllers/__tests__/DrawingModeController-test.js
@@ -279,6 +279,7 @@ describe('controllers/DrawingModeController', () => {
         it('should restart mode listeners from the thread on softcommit', () => {
             sandbox.stub(controller, 'unbindListeners');
             sandbox.stub(controller, 'bindListeners');
+            sandbox.stub(controller, 'registerThread');
             controller.handleThreadEvents(stubs.thread, {
                 event: 'softcommit'
             });
@@ -318,6 +319,7 @@ describe('controllers/DrawingModeController', () => {
                     location: 'not empty'
                 }
             };
+            sandbox.stub(controller, 'registerThread');
             sandbox.stub(controller, 'unbindListeners');
             sandbox.stub(controller, 'bindListeners', () => {
                 controller.currentThread = thread2;

--- a/src/controllers/__tests__/DrawingModeController-test.js
+++ b/src/controllers/__tests__/DrawingModeController-test.js
@@ -276,14 +276,6 @@ describe('controllers/DrawingModeController', () => {
             stubs.thread.dialog = {};
         });
 
-        it('should add thread to map on locationassigned', () => {
-            sandbox.stub(controller, 'registerThread');
-            controller.handleThreadEvents(stubs.thread, {
-                event: 'locationassigned'
-            });
-            expect(controller.registerThread).to.be.called;
-        });
-
         it('should restart mode listeners from the thread on softcommit', () => {
             sandbox.stub(controller, 'unbindListeners');
             sandbox.stub(controller, 'bindListeners');
@@ -293,6 +285,7 @@ describe('controllers/DrawingModeController', () => {
             expect(controller.unbindListeners).to.be.called;
             expect(controller.bindListeners).to.be.called;
             expect(stubs.thread.saveAnnotation).to.be.called;
+            expect(controller.registerThread).to.be.called;
             expect(stubs.thread.handleStart).to.not.be.called;
         });
 

--- a/src/doc/DocDrawingThread.js
+++ b/src/doc/DocDrawingThread.js
@@ -75,7 +75,6 @@ class DocDrawingThread extends DrawingThread {
                 dimensions: location.dimensions
             };
             this.checkAndHandleScaleUpdate();
-            this.emit('locationassigned');
         }
 
         this.drawingFlag = DRAW_STATES.drawing;

--- a/src/drawing/DrawingThread.js
+++ b/src/drawing/DrawingThread.js
@@ -69,7 +69,6 @@ class DrawingThread extends AnnotationThread {
         // Recreate stored paths
         if (this.location && this.location.paths) {
             this.setBoundary();
-            this.emit('locationassigned');
 
             this.location.paths.forEach((drawingPathData) => {
                 const pathInstance = new DrawingPath(drawingPathData);


### PR DESCRIPTION
- Annotations should only be registered with the controller on save when
  the location is finalized. They no longer need to be saved in the
  annotator threadMap, therefore we no longer care when the location was
  initially assigned