### PR TITLE
Fix: Hide createHighlightDialog on mobile page re-render

### DIFF
--- a/src/doc/DocAnnotator.js
+++ b/src/doc/DocAnnotator.js
@@ -331,6 +331,10 @@ class DocAnnotator extends Annotator {
                 thread.destroy();
             }
         });
+
+        if (this.createHighlightDialog && this.createHighlightDialog.isVisible) {
+            this.createHighlightDialog.hide();
+        }
     }
 
     /**

--- a/src/doc/__tests__/DocAnnotator-test.js
+++ b/src/doc/__tests__/DocAnnotator-test.js
@@ -584,6 +584,17 @@ describe('doc/DocAnnotator', () => {
 
             annotator.threads = {};
         });
+
+        it('should clear and hide createHighlightDialog on page render', () => {
+            annotator.createHighlightDialog = {
+                isVisible: true,
+                hide: () => {},
+                destroy: () => {}
+            };
+            const createMock = sandbox.mock(annotator.createHighlightDialog);
+            createMock.expects('hide');
+            annotator.renderAnnotationsOnPage(1);
+        });
     });
 
     describe('scaleAnnotationCanvases()', () => {


### PR DESCRIPTION
Highlight gets removed so there is no longer a selection to create a highlight, therefore the createHighlightDialog should be hidden and cleared on mobile zoom