### PR TITLE
Fix: Match width of reply textarea with comments

### DIFF
--- a/src/Annotator.scss
+++ b/src/Annotator.scss
@@ -194,12 +194,12 @@ $tablet: 'max-width: 768px';
         height: 34px;
         line-height: 13px;
         margin: 0;
-        max-width: 235px;
+        max-width: 250px;
         min-height: 34px;
         padding: 7px;
         resize: vertical;
         transition: border-color linear .15s, box-shadow linear .1s, min-height .1s;
-        width: 235px;
+        width: 100%;
 
         &.bp-is-active {
             min-height: 68px;


### PR DESCRIPTION
Fixes width of reply text area from this 
<img width="310" alt="screen_shot_2017-05-24_at_6 51 49_pm" src="https://user-images.githubusercontent.com/3299001/32762671-9d46b654-c8af-11e7-9cc9-b5fa3490c619.png">
