### PR TITLE
Chore: Remove redundant point dialog positioning

### DIFF
--- a/src/doc/DocPointThread.js
+++ b/src/doc/DocPointThread.js
@@ -63,11 +63,6 @@ class DocPointThread extends AnnotationThread {
         }
 
         this.showDialog();
-
-        // Force dialogs to reposition on re-render
-        if (!this.isMobile) {
-            this.dialog.position();
-        }
     }
 
     /**

--- a/src/doc/__tests__/DocPointThread-test.js
+++ b/src/doc/__tests__/DocPointThread-test.js
@@ -79,10 +79,9 @@ describe('doc/DocPointThread', () => {
         beforeEach(() => {
             sandbox.stub(annotatorUtil, 'showElement');
             sandbox.stub(thread, 'showDialog');
-            sandbox.stub(thread.dialog, 'position');
         });
 
-        it('should position and show the thread', () => {
+        it('should show the thread', () => {
             sandbox.stub(docAnnotatorUtil, 'getBrowserCoordinatesFromLocation').returns([1, 2]);
 
             thread.show();
@@ -92,7 +91,6 @@ describe('doc/DocPointThread', () => {
                 thread.annotatedElement
             );
             expect(annotatorUtil.showElement).to.be.calledWith(thread.element);
-            expect(thread.dialog.position).to.be.called;
         });
 
         it('should show the dialog if the state is pending', () => {
@@ -121,16 +119,6 @@ describe('doc/DocPointThread', () => {
             thread.show();
 
             expect(thread.showDialog).to.not.be.called;
-        });
-
-        it('should not position dialog if user is on a mobile device', () => {
-            thread.isMobile = true;
-            thread.annotations = { '123abc': {} };
-
-            thread.show();
-
-            expect(thread.showDialog).to.be.called;
-            expect(thread.dialog.position).to.not.be.called;
         });
     });
 

--- a/src/image/ImagePointThread.js
+++ b/src/image/ImagePointThread.js
@@ -37,11 +37,6 @@ class ImagePointThread extends AnnotationThread {
         }
 
         this.showDialog();
-
-        // Force dialogs to reposition on re-render
-        if (!this.isMobile) {
-            this.dialog.position();
-        }
     }
 
     /**

--- a/src/image/__tests__/ImagePointThread-test.js
+++ b/src/image/__tests__/ImagePointThread-test.js
@@ -29,9 +29,6 @@ describe('image/ImagePointThread', () => {
             }
         });
 
-        thread.dialog = {
-            position: sandbox.stub()
-        };
         thread.isMobile = false;
     });
 
@@ -45,7 +42,7 @@ describe('image/ImagePointThread', () => {
             sandbox.stub(thread, 'showDialog');
         });
 
-        it('should position and show the thread', () => {
+        it('should show the thread', () => {
             sandbox.stub(imageAnnotatorUtil, 'getBrowserCoordinatesFromLocation').returns([1, 2]);
 
             thread.show();
@@ -64,7 +61,6 @@ describe('image/ImagePointThread', () => {
             thread.show();
 
             expect(thread.showDialog).to.be.called;
-            expect(thread.dialog.position).to.be.called;
         });
 
         it('should not show the dialog if the state is not pending', () => {
@@ -76,24 +72,6 @@ describe('image/ImagePointThread', () => {
             expect(thread.showDialog).to.not.be.called;
         });
 
-        it('should not re-position the dialog if pending but on a mobile device', () => {
-            thread.isMobile = true;
-            thread.state = STATES.pending;
-
-            sandbox.stub(imageAnnotatorUtil, 'getBrowserCoordinatesFromLocation').returns([1, 2]);
-
-            thread.show();
-
-            expect(imageAnnotatorUtil.getBrowserCoordinatesFromLocation).to.be.calledWith(
-                thread.location,
-                thread.annotatedElement
-            );
-
-            expect(thread.dialog.position).to.not.be.called;
-            expect(annotatorUtil.showElement).to.be.calledWith(thread.element);
-            expect()
-        });
-
         it('should not show dialog if user is on a mobile device and the thread has no annotations yet', () => {
             thread.isMobile = true;
             thread.annotations = {};
@@ -102,16 +80,6 @@ describe('image/ImagePointThread', () => {
             thread.show();
 
             expect(thread.showDialog).to.not.be.called;
-        });
-
-        it('should not position dialog if user is on a mobile device', () => {
-            thread.isMobile = true;
-            thread.annotations = { '123abc': {} };
-
-            thread.show();
-
-            expect(thread.showDialog).to.be.called;
-            expect(thread.dialog.position).to.not.be.called;
         });
     });
 


### PR DESCRIPTION
* Dialogs are already positioned once in dialog.show() so calling dialog.position() afterwards on desktop browsers is redundant