### PR TITLE
Fix: Publish script to reset to latest tag instead of to master

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -178,6 +178,7 @@ push_new_release() {
         echo "----------------------------------------------------------------------"
         reset_to_master || return 1
     fi
+
     # Install node modules
     if ! install_dependencies; then
         echo "----------------------------------------------------"


### PR DESCRIPTION
Since npm does not allow the publishing of existing versions, the publish script will assume the latest version is the desired version and reset to that tag rather than to master. This fixes the case where the publish script would reset to master on a patch release, which would result in attempting to publish the previous minor version rather than the desired patch version. 