### PR TITLE
Fix: Ensure point annotations are set up even when highlights are disabled

### DIFF
--- a/src/Annotator.js
+++ b/src/Annotator.js
@@ -261,8 +261,6 @@ class Annotator extends EventEmitter {
      * @return {void}
      */
     setupControllers() {
-        const { CONTROLLERS } = this.options.annotator || {};
-        this.modeControllers = CONTROLLERS || {};
         this.modeButtons = this.options.modeButtons || {};
 
         const options = {

--- a/src/__tests__/Annotator-test.js
+++ b/src/__tests__/Annotator-test.js
@@ -227,13 +227,8 @@ describe('Annotator', () => {
 
     describe('setupControllers()', () => {
         it('should instantiate controllers for enabled types', () => {
-            annotator.options = {
-                annotator: {
-                    NAME: 'name',
-                    CONTROLLERS: { 'something': stubs.controller }
-                },
-                modeButtons: { 'something': {} }
-            };
+            annotator.modeControllers = { 'something': stubs.controller };
+            annotator.options = { modeButtons: { 'something': {} } }
 
             stubs.controllerMock.expects('init');
             stubs.controllerMock.expects('addListener').withArgs('annotationcontrollerevent', sinon.match.func);

--- a/src/doc/DocAnnotator.js
+++ b/src/doc/DocAnnotator.js
@@ -365,6 +365,7 @@ class DocAnnotator extends Annotator {
 
         // Don't bind to highlight specific handlers if we cannot highlight
         if (!this.plainHighlightEnabled && !this.commentHighlightEnabled) {
+            super.setupAnnotations();
             return;
         }
 
@@ -425,7 +426,9 @@ class DocAnnotator extends Annotator {
     bindDOMListeners() {
         super.bindDOMListeners();
 
-        this.annotatedElement.addEventListener('mouseup', this.highlightMouseupHandler);
+        if (this.plainHighlightEnabled || this.commentHighlightEnabled) {
+            this.annotatedElement.addEventListener('mouseup', this.highlightMouseupHandler);
+        }
 
         // Prevent all forms of highlight annotations if annotating (or plain AND comment highlights) is disabled
         if (!this.permissions.canAnnotate) {

--- a/src/doc/__tests__/DocAnnotator-test.js
+++ b/src/doc/__tests__/DocAnnotator-test.js
@@ -723,8 +723,8 @@ describe('doc/DocAnnotator', () => {
             annotator.commentHighlightEnabled = false;
             annotator.drawEnabled = true;
 
-            stubs.elMock.expects('addEventListener').withArgs('mouseup', sinon.match.func);
             stubs.elMock.expects('addEventListener').withArgs('click', sinon.match.func);
+            stubs.elMock.expects('addEventListener').never().withArgs('mouseup', sinon.match.func);
             stubs.elMock.expects('addEventListener').never().withArgs('dblclick', sinon.match.func);
             stubs.elMock.expects('addEventListener').never().withArgs('mousedown', sinon.match.func);
             stubs.elMock.expects('addEventListener').never().withArgs('contextmenu', sinon.match.func);


### PR DESCRIPTION
When plain and comment highlights are disabled and point annotations were enabled, the proper controllers and listeners were not set up. 