### PR TITLE
Fix: Clarify separation between plain and comment highlights

### DIFF
--- a/src/Annotator.js
+++ b/src/Annotator.js
@@ -282,7 +282,6 @@ class Annotator extends EventEmitter {
                 options
             });
 
-            this.handleControllerEvents = this.handleControllerEvents.bind(this);
             controller.addListener('annotationcontrollerevent', this.handleControllerEvents);
         });
     }
@@ -362,12 +361,17 @@ class Annotator extends EventEmitter {
         // Generate map of page to threads
         Object.keys(threadMap).forEach((threadID) => {
             const annotations = threadMap[threadID];
-            const firstAnnotation = util.getFirstAnnotation(annotations);
-            if (!firstAnnotation || !this.isModeAnnotatable(firstAnnotation.type)) {
+
+            // NOTE: Using the last annotation to evaluate if the annotation type
+            // is enabled because highlight comment annotations may have a plain
+            // highlight as the first annotation in the thread.
+            const lastAnnotation = util.getLastAnnotation(annotations);
+            if (!lastAnnotation || !this.isModeAnnotatable(lastAnnotation.type)) {
                 return;
             }
 
             // Bind events on valid annotation thread
+            const firstAnnotation = util.getLastAnnotation(annotations);
             const thread = this.createAnnotationThread(annotations, firstAnnotation.location, firstAnnotation.type);
             const controller = this.modeControllers[firstAnnotation.type];
             if (controller) {
@@ -542,13 +546,9 @@ class Annotator extends EventEmitter {
 
         const pageThreads = this.threads[pageNum] || {};
         Object.keys(pageThreads).forEach((threadID) => {
-            const thread = pageThreads[threadID];
-            if (!this.isModeAnnotatable(thread.type)) {
-                return;
-            }
-
             // Sets the annotatedElement if the thread was fetched before the
             // dependent document/viewer finished loading
+            const thread = pageThreads[threadID];
             if (!thread.annotatedElement) {
                 thread.annotatedElement = this.annotatedElement;
             }

--- a/src/__tests__/util-test.js
+++ b/src/__tests__/util-test.js
@@ -14,6 +14,7 @@ import {
     getAvatarHtml,
     getScale,
     getFirstAnnotation,
+    getLastAnnotation,
     isPlainHighlight,
     isHighlightAnnotation,
     getDimensionScale,
@@ -295,6 +296,16 @@ describe('util', () => {
                 abc456: { id: 2 }
             };
             expect(getFirstAnnotation(annotations)).to.deep.equal({ id: 1 });
+        });
+    });
+
+    describe('getLastAnnotation()', () => {
+        it('should return the last annotation in thread', () => {
+            const annotations = {
+                def123: { id: 1 },
+                abc456: { id: 2 }
+            };
+            expect(getLastAnnotation(annotations)).to.deep.equal({ id: 2 });
         });
     });
 

--- a/src/doc/CreateHighlightDialog.js
+++ b/src/doc/CreateHighlightDialog.js
@@ -224,16 +224,6 @@ class CreateHighlightDialog extends CreateAnnotationDialog {
             buttonsEl.appendChild(highlightEl);
         }
 
-        if (this.allowComment) {
-            const commentEl = generateBtn(
-                [CLASS_BUTTON_PLAIN, CLASS_ADD_HIGHLIGHT_COMMENT_BTN],
-                this.localized.highlightComment,
-                ICON_HIGHLIGHT_COMMENT,
-                DATA_TYPE_ADD_HIGHLIGHT_COMMENT
-            );
-            buttonsEl.appendChild(commentEl);
-        }
-
         const dialogEl = document.createElement('div');
         dialogEl.classList.add(CLASS_ANNOTATION_HIGHLIGHT_DIALOG);
         dialogEl.appendChild(buttonsEl);
@@ -266,8 +256,16 @@ class CreateHighlightDialog extends CreateAnnotationDialog {
             }
         }
 
-        // Events for comment button
         if (this.allowComment) {
+            const commentEl = generateBtn(
+                [CLASS_BUTTON_PLAIN, CLASS_ADD_HIGHLIGHT_COMMENT_BTN],
+                this.localized.highlightComment,
+                ICON_HIGHLIGHT_COMMENT,
+                DATA_TYPE_ADD_HIGHLIGHT_COMMENT
+            );
+            buttonsEl.appendChild(commentEl);
+
+            // Events for comment button
             this.commentBox = this.setupCommentBox(highlightDialogEl);
 
             this.commentCreateEl = highlightDialogEl.querySelector(SELECTOR_ADD_HIGHLIGHT_COMMENT_BTN);

--- a/src/doc/CreateHighlightDialog.js
+++ b/src/doc/CreateHighlightDialog.js
@@ -79,8 +79,8 @@ class CreateHighlightDialog extends CreateAnnotationDialog {
     constructor(parentEl, config = {}) {
         super(parentEl, config);
 
-        this.allowHighlight = !!config.allowHighlight || true;
-        this.allowComment = !!config.allowComment || true;
+        this.allowHighlight = config.allowHighlight || false;
+        this.allowComment = config.allowComment || false;
 
         // Explicit scope binding for event listeners
         if (this.allowHighlight) {
@@ -92,6 +92,8 @@ class CreateHighlightDialog extends CreateAnnotationDialog {
             this.onCommentPost = this.onCommentPost.bind(this);
             this.onCommentCancel = this.onCommentCancel.bind(this);
         }
+
+        this.createElement();
     }
 
     /**

--- a/src/doc/DocAnnotator.js
+++ b/src/doc/DocAnnotator.js
@@ -384,7 +384,6 @@ class DocAnnotator extends Annotator {
             allowHighlight: this.plainHighlightEnabled,
             localized: this.localized
         });
-        this.createHighlightDialog.createElement();
 
         this.createHighlightDialog.addListener(CREATE_EVENT.init, () =>
             this.emit(THREAD_EVENT.pending, TYPES.highlight)

--- a/src/doc/__tests__/CreateHighlightDialog-test.js
+++ b/src/doc/__tests__/CreateHighlightDialog-test.js
@@ -30,7 +30,11 @@ describe('doc/CreateHighlightDialog', () => {
 
         const parentEl = document.createElement('div');
         parentEl.classList.add('bp-create-dialog-container');
-        dialog = new CreateHighlightDialog(parentEl, { localized });
+        dialog = new CreateHighlightDialog(parentEl, {
+            allowHighlight: true,
+            allowComment: true,
+            localized
+        });
     });
 
     afterEach(() => {
@@ -40,10 +44,10 @@ describe('doc/CreateHighlightDialog', () => {
     });
 
     describe('contructor()', () => {
-        it('should default to enable highlights and comments if no config passed in', () => {
+        it('should default to disable highlights and comments if no config passed in', () => {
             const instance = new CreateHighlightDialog(document.createElement('div'));
-            expect(instance.allowHighlight).to.be.true;
-            expect(instance.allowComment).to.be.true;
+            expect(instance.allowHighlight).to.be.false;
+            expect(instance.allowComment).to.be.false;
         });
 
         it('should take config falsey value to disable highlights and comments, when passed in', () => {
@@ -228,6 +232,7 @@ describe('doc/CreateHighlightDialog', () => {
 
         it('should not create a comment box or button if comments are disabled', () => {
             dialog.allowComment = false;
+            dialog.commentBox = undefined;
             dialog.createElement();
 
             expect(dialog.containerEl.querySelector(`.${CLASS_ADD_HIGHLIGHT_COMMENT_BTN}`)).to.not.exist;

--- a/src/util.js
+++ b/src/util.js
@@ -357,6 +357,18 @@ export function getFirstAnnotation(annotations) {
 }
 
 /**
+ * Return first annotation in thread
+ *
+ * @param {Object} annotations - Annotations in thread
+ * @return {Annotation} First annotation in thread
+ */
+export function getLastAnnotation(annotations) {
+    const numAnnotations = Object.keys(annotations).length;
+    const lastAnnotationID = Object.keys(annotations)[numAnnotations - 1];
+    return annotations[lastAnnotationID];
+}
+
+/**
  * Whether or not a highlight annotation has comments or is a plain highlight
  *
  * @param {Object} annotations Annotations in highlight thread


### PR DESCRIPTION
* Using the last annotation to determine whether or not the current annotation is of a valid and enabled type is problematic because because highlight comment annotations may have a plain highlight as the first annotation in the thread, resulting in a false positive for the thread.
* Fixes bug where both highlight and comment buttons were displayed in the create dialog despite only plain highlights being enabled