### PR TITLE
Respect symbols and newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+<a name="0.7.0"></a>
+# 0.7.0 (2017-12-12)
+
+*  New: Generate webpack build for annotations.js/css (#59) ([0b6e44d](https://github.com/box/box-annotations/commit/0b6e44d))
+* Update release.sh ([02baf38](https://github.com/box/box-annotations/commit/02baf38))
+* Fix: BoxAnnotations module export (#66) ([443dcbe](https://github.com/box/box-annotations/commit/443dcbe))
+* Fix: Don't add text areas without canAnnotate permissions (#62) ([9d1db9e](https://github.com/box/box-annotations/commit/9d1db9e))
+* Fix: Enable drawingSelection & highlightMouseMove handlers for read-only permissions (#61) ([33bda6a](https://github.com/box/box-annotations/commit/33bda6a))
+* Fix: Ensure annotation layer is before point annotations (#63) ([8e0f27b](https://github.com/box/box-annotations/commit/8e0f27b))
+* Fix: Ensure mobile header doesn't get hidden when keyboard hides (#69) ([e5a1749](https://github.com/box/box-annotations/commit/e5a1749))
+* Fix: Scroll to bottom of mobile dialogs (#70) ([7a33849](https://github.com/box/box-annotations/commit/7a33849))
+* Fix: Use correct build script in publish.sh (#64) ([4e8fe9d](https://github.com/box/box-annotations/commit/4e8fe9d))
+* New: Allow BoxAnnotations to be instantiated independently and passed into Preview as an option (#68 ([8c1637a](https://github.com/box/box-annotations/commit/8c1637a))
+* Chore: Ignore proper files in .ignore files (#67) ([36606cc](https://github.com/box/box-annotations/commit/36606cc))
+* Update: Exporting BoxAnnotations correctly in npm package (#65) ([f501edc](https://github.com/box/box-annotations/commit/f501edc))
+
+
+
 <a name="0.6.0"></a>
 # 0.6.0 (2017-12-05)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Project Status](https://img.shields.io/badge/status-active-brightgreen.svg?style=flat-square)](http://opensource.box.com/badges/)
 [![Styled With Prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 [![build status](https://img.shields.io/travis/box/box-content-preview/master.svg?style=flat-square)](https://travis-ci.org/box/box-annotations)
-[![version](https://img.shields.io/badge/version-v0.6.0-blue.svg?style=flat-square)](https://github.com/box/box-annotations)
+[![version](https://img.shields.io/badge/version-v0.7.0-blue.svg?style=flat-square)](https://github.com/box/box-annotations)
 [![npm version](https://img.shields.io/npm/v/box-ui-elements.svg?style=flat-square)](https://www.npmjs.com/package/box-ui-elements)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "box-annotations",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Box Annotations",
   "author": "Box (https://www.box.com/)",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/AnnotationDialog.js
+++ b/src/AnnotationDialog.js
@@ -614,7 +614,27 @@ class AnnotationDialog extends EventEmitter {
             hour: '2-digit',
             minute: '2-digit'
         });
-        const text = util.htmlEscape(annotation.text);
+        const annotationText = annotation.text;
+        // Respect newline characters
+        const newlineRegex = /\r\n|\n\r|\n|\r/g;
+        const newlineList = annotationText.replace(newlineRegex, '\n').split('\n');
+        const textEl = document.createElement('p');
+
+        // If newlines are present, add in breaks for each one
+        if (newlineList.length > 1) {
+            newlineList.forEach((text) => {
+                if (text === '') {
+                    textEl.appendChild(document.createElement('br'));
+                } else {
+                    const contentEl = document.createElement('p');
+                    contentEl.textContent = text;
+                    textEl.appendChild(contentEl);
+                }
+            });
+        } else {
+            // Otherwise just use the textContent
+            textEl.textContent = annotationText;
+        }
 
         const annotationEl = document.createElement('div');
         annotationEl.classList.add(CLASS_COMMENT);
@@ -647,7 +667,7 @@ class AnnotationDialog extends EventEmitter {
         // Comment
         const commentTextEl = document.createElement('div');
         commentTextEl.classList.add('comment-text');
-        commentTextEl.textContent = text;
+        commentTextEl.appendChild(textEl);
         annotationEl.appendChild(commentTextEl);
 
         // Delete button

--- a/src/Annotator.scss
+++ b/src/Annotator.scss
@@ -226,6 +226,10 @@ $tablet: 'max-width: 768px';
         &:last-child {
             border-bottom: 0;
         }
+
+        p {
+            margin-bottom: 0;
+        }
     }
 
     .profile-image-container {

--- a/src/__tests__/AnnotationDialog-test.js
+++ b/src/__tests__/AnnotationDialog-test.js
@@ -772,7 +772,7 @@ describe('AnnotationDialog', () => {
                     permissions: {}
                 })
             );
-            const annotationComment = document.querySelector('.comment-text');
+            const annotationComment = document.querySelector('.comment-text p');
             expect(annotationComment).to.contain.html('the preview sdk is awesome!');
         });
 
@@ -869,6 +869,39 @@ describe('AnnotationDialog', () => {
                 })
             );
             expect(stubs.locale).to.be.calledWith('en-GB');
+        });
+
+        it('should add a <br> for each newline', () => {
+            const withBreaks = `
+
+
+            yay, three breaks!`;
+
+            dialog.addAnnotationElement(
+                new Annotation({
+                    annotationID: 1,
+                    text: withBreaks,
+                    user: { id: 1, name: 'user' },
+                    permissions: { can_delete: true }
+                })
+            );
+            const breaks = document.querySelectorAll('.comment-text p br');
+            expect(breaks.length === 3).to.be.true;
+        });
+
+        it('should respect symbols added to the text', () => {
+            const text = 'I can add symbols &&&';
+            dialog.addAnnotationElement(
+                new Annotation({
+                    annotationID: 1,
+                    text,
+                    user: {},
+                    permissions: {}
+                })
+            );
+            const annotationComment = document.querySelector('.comment-text p');
+            expect(annotationComment.textContent).equals(text);
+            expect(annotationComment.textContent.includes('&amp;')).to.be.false;
         });
     });
 


### PR DESCRIPTION
This PR allows comment dialogs to respect symbols and newlines added by users. We no longer have to HTML Escape our strings because we're using `textContent`.

The result:

<img width="354" alt="screen shot 2017-12-13 at 5 08 16 pm" src="https://user-images.githubusercontent.com/763560/33967240-3d174786-e028-11e7-9123-3d1a4157f341.png">
