### PR TITLE
Fix: Safety checks if no threads are registered in the draw controller

### DIFF
--- a/src/controllers/DrawingModeController.js
+++ b/src/controllers/DrawingModeController.js
@@ -136,6 +136,10 @@ class DrawingModeController extends AnnotationModeController {
         }
 
         const page = thread.location.page || 1; // Defaults to page 1 if thread has no page'
+        if (!this.threads[page]) {
+            return;
+        }
+
         this.threads[page].remove(thread);
         this.emit(CONTROLLER_EVENT.unregister, thread);
         thread.removeListener('threadevent', this.handleThreadEvents);

--- a/src/controllers/__tests__/DrawingModeController-test.js
+++ b/src/controllers/__tests__/DrawingModeController-test.js
@@ -160,6 +160,13 @@ describe('controllers/DrawingModeController', () => {
             expect(controller.emit).to.not.be.calledWith(CONTROLLER_EVENT.unregister, sinon.match.object);
         });
 
+        it('should do nothing if no threads exist on the specified page', () => {
+            stubs.thread.location = { page: 1 };
+            controller.threads = {};
+            controller.unregisterThread(stubs.thread);
+            expect(controller.emit).to.not.be.calledWith(CONTROLLER_EVENT.unregister, sinon.match.object);
+        });
+
         it('should internally keep track of the registered thread', () => {
             const pageThreads = controller.threads[1];
             controller.unregisterThread(stubs.thread);

--- a/src/doc/DocDrawingThread.js
+++ b/src/doc/DocDrawingThread.js
@@ -62,6 +62,10 @@ class DocDrawingThread extends DrawingThread {
      * @return {void}
      */
     handleStart(location) {
+        if (!location) {
+            return;
+        }
+
         const pageChanged = this.hasPageChanged(location);
         if (pageChanged) {
             this.onPageChange(location);

--- a/src/doc/__tests__/DocDrawingThread-test.js
+++ b/src/doc/__tests__/DocDrawingThread-test.js
@@ -88,15 +88,23 @@ describe('doc/DocDrawingThread', () => {
 
 
     describe('handleStart()', () => {
-        it('should set the drawingFlag, pendingPath, and context if they do not exist', () => {
+        beforeEach(() => {
             const context = "I'm a real context";
 
             sandbox.stub(window, 'requestAnimationFrame');
             sandbox.stub(thread, 'checkAndHandleScaleUpdate');
-            sandbox.stub(thread, 'hasPageChanged').returns(false);
-            sandbox.stub(docUtil, 'getPageEl')
-                   .returns(context);
+            sandbox.stub(thread, 'onPageChange');
+            sandbox.stub(docUtil, 'getPageEl').returns(context);
+            stubs.pageChange = sandbox.stub(thread, 'hasPageChanged');
+        });
 
+        it('should do nothing if no location is provided', () => {
+            thread.handleStart();
+            expect(stubs.pageChange).to.not.be.called;
+        });
+
+        it('should set the drawingFlag, pendingPath, and context if they do not exist', () => {
+            stubs.pageChange.returns(false);
             thread.drawingFlag = DRAW_STATES.idle;
             thread.pendingPath = undefined;
             thread.handleStart(thread.location);
@@ -108,9 +116,7 @@ describe('doc/DocDrawingThread', () => {
         });
 
         it('should commit the thread when the page changes', () => {
-            sandbox.stub(thread, 'hasPageChanged').returns(true);
-            sandbox.stub(thread, 'checkAndHandleScaleUpdate');
-            sandbox.stub(thread, 'onPageChange');
+            stubs.pageChange.returns(true);
 
             thread.pendingPath = undefined;
             thread.location = {};


### PR DESCRIPTION
This PR and https://github.com/box/box-annotations/pull/87 fix https://github.com/box/box-annotations/issues/86