### PR TITLE
Fix: Don't deactivate dialog when canceling new annotation

### DIFF
--- a/src/AnnotationDialog.js
+++ b/src/AnnotationDialog.js
@@ -553,8 +553,6 @@ class AnnotationDialog extends EventEmitter {
                     // Cancels + destroys the annotation thread
                     this.cancelAnnotation();
                 }
-
-                this.deactivateReply(true);
                 break;
             // Clicking inside reply text area
             case constants.DATA_TYPE_REPLY_TEXTAREA:

--- a/src/__tests__/AnnotationDialog-test.js
+++ b/src/__tests__/AnnotationDialog-test.js
@@ -688,7 +688,6 @@ describe('AnnotationDialog', () => {
             dialog.clickHandler(stubs.event);
             expect(stubs.cancel).to.be.called;
             expect(stubs.hideMobile).to.not.be.called;
-            expect(stubs.deactivate).to.be.calledWith(true);
         });
 
         it('should only hide the mobile dialog when the cancel annotation button is clicked on mobile', () => {
@@ -698,7 +697,6 @@ describe('AnnotationDialog', () => {
             dialog.clickHandler(stubs.event);
             expect(stubs.cancel).to.not.be.called;
             expect(stubs.hideMobile).to.be.called;
-            expect(stubs.deactivate).to.be.calledWith(true);
         });
 
         it('should activate reply area when textarea is clicked', () => {


### PR DESCRIPTION
This would cause `dialog.scrollToLastComment()` to be called even after the creation of a new annotation was cancelled. This method should only be called on cancel when cancelling a reply not a new annotation 