### PR TITLE
Fix: Extra padding on escaped comment newlines

### DIFF
--- a/src/Annotator.scss
+++ b/src/Annotator.scss
@@ -230,6 +230,10 @@ $tablet: 'max-width: 768px';
 
         .bp-annotation-comment-text {
             margin-bottom: 0;
+
+            & p {
+                margin: 0;
+            }
         }
     }
 


### PR DESCRIPTION
The margins for each `<p>` tag inside the comment in addition to the `<br\>` tags caused double newline breaks to appear in the comments