### PR TITLE
Fix: Clear both highlight canvases when deleting highlights

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -160,7 +160,8 @@ export const CONTROLLER_EVENT = {
     register: 'registerthread',
     unregister: 'unregisterthread',
     bindDOMListeners: 'binddomlisteners',
-    unbindDOMListeners: 'unbinddomlisteners'
+    unbindDOMListeners: 'unbinddomlisteners',
+    renderPage: 'annotationsrenderpage'
 };
 
 export const CREATE_EVENT = {

--- a/src/controllers/HighlightModeController.js
+++ b/src/controllers/HighlightModeController.js
@@ -35,7 +35,7 @@ class HighlightModeController extends AnnotationModeController {
                 }
                 break;
             case THREAD_EVENT.threadCleanup:
-                this.renderPage(thread.location.page);
+                this.emit(CONTROLLER_EVENT.renderPage, thread.location.page);
                 break;
             default:
         }

--- a/src/controllers/__tests__/HighlightModeController-test.js
+++ b/src/controllers/__tests__/HighlightModeController-test.js
@@ -50,12 +50,11 @@ describe('controllers/HighlightModeController', () => {
             expect(controller.renderPage).to.be.calledWith(1);
         });
 
-        it('should render page on threadCleanup', () => {
+        it('should emit annotationsrenderpage with page number on threadCleanup', () => {
             sandbox.stub(controller, 'unregisterThread');
-            sandbox.stub(controller, 'renderPage');
             controller.handleThreadEvents(stubs.thread, { event: THREAD_EVENT.threadCleanup, data: {} });
             expect(controller.unregisterThread).to.be.called;
-            expect(controller.renderPage).to.be.calledWith(1);
+            expect(controller.emit).to.be.calledWith(CONTROLLER_EVENT.renderPage, stubs.thread.location.page);
         });
     });
 

--- a/src/doc/DocAnnotator.js
+++ b/src/doc/DocAnnotator.js
@@ -1021,6 +1021,9 @@ class DocAnnotator extends Annotator {
                     this.createHighlightDialog.hide();
                 }
                 break;
+            case CONTROLLER_EVENT.renderPage:
+                this.renderPage(data.data);
+                break;
             default:
         }
         super.handleControllerEvents(data);

--- a/src/doc/__tests__/DocAnnotator-test.js
+++ b/src/doc/__tests__/DocAnnotator-test.js
@@ -1488,6 +1488,7 @@ describe('doc/DocAnnotator', () => {
                 isVisible: true,
                 hide: sandbox.stub(),
             };
+            sandbox.stub(annotator, 'renderPage');
         });
 
         afterEach(() => {
@@ -1519,6 +1520,11 @@ describe('doc/DocAnnotator', () => {
             annotator.createHighlightDialog.isVisible = false
             annotator.handleControllerEvents({ event: CONTROLLER_EVENT.bindDOMListeners });
             expect(annotator.createHighlightDialog.hide).to.not.be.called;
+        });
+
+        it('should render the specified page on annotationsrenderpage', () => {
+            annotator.handleControllerEvents({ event: CONTROLLER_EVENT.renderPage });
+            expect(annotator.renderPage).to.be.called;
         });
     });
 });


### PR DESCRIPTION
- Ensures that when a plain highlight that was converted into a highlight comment is deleted, the correct canvas is cleared and re-rendered