### PR TITLE
Fix: Do not destroy pending point threads on mobile re-render

### DIFF
--- a/src/Annotator.js
+++ b/src/Annotator.js
@@ -497,7 +497,6 @@ class Annotator extends EventEmitter {
         Object.keys(this.modeControllers).forEach((mode) => {
             const controller = this.modeControllers[mode];
             controller.render();
-            controller.destroyPendingThreads();
         });
     }
 

--- a/src/__tests__/Annotator-test.js
+++ b/src/__tests__/Annotator-test.js
@@ -264,20 +264,16 @@ describe('Annotator', () => {
             it('should call hide on each thread in map', () => {
                 annotator.modeControllers = {
                     'type': {
-                        render: sandbox.stub(),
-                        destroyPendingThreads: sandbox.stub()
+                        render: sandbox.stub()
                     },
                     'type2': {
-                        render: sandbox.stub(),
-                        destroyPendingThreads: sandbox.stub()
+                        render: sandbox.stub()
                     }
                 };
 
                 annotator.render();
                 expect(annotator.modeControllers['type'].render).to.be.called;
-                expect(annotator.modeControllers['type'].destroyPendingThreads).to.be.called;
                 expect(annotator.modeControllers['type2'].render).to.be.called;
-                expect(annotator.modeControllers['type2'].destroyPendingThreads).to.be.called;
             });
         });
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -157,6 +157,7 @@ export const CONTROLLER_EVENT = {
     toggleMode: 'togglemode',
     enter: 'annotationmodeenter',
     exit: 'annotationmodeexit',
+    createThread: 'createannotationthread',
     register: 'registerthread',
     unregister: 'unregisterthread',
     bindDOMListeners: 'binddomlisteners',

--- a/src/controllers/HighlightModeController.js
+++ b/src/controllers/HighlightModeController.js
@@ -68,6 +68,18 @@ class HighlightModeController extends AnnotationModeController {
     }
 
     /**
+     * Renders annotations from memory.
+     *
+     * @inheritdoc
+     * @private
+     * @return {void}
+     */
+    render() {
+        super.render();
+        this.destroyPendingThreads();
+    }
+
+    /**
      * Renders annotations from memory for a specified page.
      *
      * @inheritdoc

--- a/src/controllers/__tests__/HighlightModeController-test.js
+++ b/src/controllers/__tests__/HighlightModeController-test.js
@@ -90,6 +90,26 @@ describe('controllers/HighlightModeController', () => {
         });
     });
 
+    describe('render()', () => {
+        beforeEach(() => {
+            sandbox.stub(controller, 'renderPage');
+            sandbox.stub(controller, 'destroyPendingThreads');
+        });
+
+        it('should do nothing if no threads exist', () => {
+            controller.render();
+            expect(controller.renderPage).to.not.be.called;
+            expect(controller.destroyPendingThreads).to.be.called;
+        });
+
+        it('should render the annotations on every page', () => {
+            controller.threads = { 1: {}, 2: {} };
+            controller.render();
+            expect(controller.renderPage).to.be.calledTwice;
+            expect(controller.destroyPendingThreads).to.be.called;
+        });
+    });
+
     describe('renderPage()', () => {
         beforeEach(() => {
             controller.annotatedElement = document.createElement('div');

--- a/src/doc/DocHighlightThread.js
+++ b/src/doc/DocHighlightThread.js
@@ -204,7 +204,7 @@ class DocHighlightThread extends AnnotationThread {
 
         // Setup the dialog element if it has not already been created
         if (!this.dialog.element) {
-            this.dialog.setup(this.annotations);
+            this.dialog.setup(this.annotations, this.showComment);
         }
         this.dialog.mouseenterHandler();
         clearTimeout(this.hoverTimeoutHandler);


### PR DESCRIPTION
Fixes issue caused when the page is resized while creating a point annotation on mobile (from #71)