### PR TITLE
Fix: Mobile cleanup

### DIFF
--- a/src/Annotator.js
+++ b/src/Annotator.js
@@ -301,6 +301,7 @@ class Annotator extends EventEmitter {
 
         // Resets the mobile dialog
         util.hideElement(this.mobileDialogEl);
+        util.showElement(`.${CLASS_MOBILE_DIALOG_HEADER}`);
         this.mobileDialogEl.removeChild(this.mobileDialogEl.lastChild);
     }
 

--- a/src/Annotator.js
+++ b/src/Annotator.js
@@ -252,6 +252,15 @@ class Annotator extends EventEmitter {
 
             controller.addListener('annotationcontrollerevent', this.handleControllerEvents);
         });
+
+        const pointController = this.modeControllers[TYPES.point];
+        if (pointController && this.isMobile) {
+            pointController.setupSharedDialog(this.container, {
+                isMobile: this.isMobile,
+                hasTouch: this.hasTouch,
+                localized: this.localized
+            });
+        }
     }
 
     /**
@@ -274,16 +283,24 @@ class Annotator extends EventEmitter {
                 <button class="${CLASS_DIALOG_CLOSE}">${ICON_CLOSE}</button>
             </div>`.trim();
 
-        this.container.appendChild(this.mobileDialogEl);
-
-        const pointController = this.modeControllers[TYPES.point];
-        if (pointController) {
-            pointController.setupSharedDialog(this.container, {
-                isMobile: this.isMobile,
-                hasTouch: this.hasTouch,
-                localized: this.localized
-            });
+        // Only append the mobile dialog once
+        if (!this.container.querySelector(`.${CLASS_MOBILE_ANNOTATION_DIALOG}`)) {
+            this.container.appendChild(this.mobileDialogEl);
         }
+    }
+
+    /**
+     * Hides and resets the shared mobile dialog.
+     *
+     * @return {void}
+     */
+    resetMobileDialog() {
+        if (!this.mobileDialogEl || this.mobileDialogEl.classList.contains(CLASS_HIDDEN)) {
+            return;
+        }
+
+        // Set up new mobile dialog
+        this.setupMobileDialog();
     }
 
     /**

--- a/src/Annotator.js
+++ b/src/Annotator.js
@@ -283,10 +283,7 @@ class Annotator extends EventEmitter {
                 <button class="${CLASS_DIALOG_CLOSE}">${ICON_CLOSE}</button>
             </div>`.trim();
 
-        // Only append the mobile dialog once
-        if (!this.container.querySelector(`.${CLASS_MOBILE_ANNOTATION_DIALOG}`)) {
-            this.container.appendChild(this.mobileDialogEl);
-        }
+        this.container.appendChild(this.mobileDialogEl);
     }
 
     /**
@@ -299,8 +296,12 @@ class Annotator extends EventEmitter {
             return;
         }
 
-        // Set up new mobile dialog
-        this.setupMobileDialog();
+        // Reset the mobile dialog
+        util.hideElement(this.mobileDialogEl);
+        this.mobileDialogEl.innerHTML = `
+            <div class="${CLASS_MOBILE_DIALOG_HEADER}">
+                <button class="${CLASS_DIALOG_CLOSE}">${ICON_CLOSE}</button>
+            </div>`.trim();
     }
 
     /**

--- a/src/Annotator.js
+++ b/src/Annotator.js
@@ -18,6 +18,8 @@ import {
     CONTROLLER_EVENT
 } from './constants';
 
+const MOBILE_DIALOG_CLOSE = 'mobile-dialog-close';
+
 class Annotator extends EventEmitter {
     //--------------------------------------------------------------------------
     // Typedef
@@ -277,13 +279,14 @@ class Annotator extends EventEmitter {
         this.mobileDialogEl.classList.add(CLASS_ANNOTATION_DIALOG);
         this.mobileDialogEl.classList.add(CLASS_HIDDEN);
         this.mobileDialogEl.id = ID_MOBILE_ANNOTATION_DIALOG;
-
-        this.mobileDialogEl.innerHTML = `
-            <div class="${CLASS_MOBILE_DIALOG_HEADER}">
-                <button class="${CLASS_DIALOG_CLOSE}">${ICON_CLOSE}</button>
-            </div>`.trim();
-
         this.container.appendChild(this.mobileDialogEl);
+
+        const mobileHeader = document.createElement('div');
+        mobileHeader.classList.add(CLASS_MOBILE_DIALOG_HEADER);
+        this.mobileDialogEl.appendChild(mobileHeader);
+
+        const closeBtn = util.generateBtn([CLASS_DIALOG_CLOSE], MOBILE_DIALOG_CLOSE, ICON_CLOSE, MOBILE_DIALOG_CLOSE);
+        mobileHeader.appendChild(closeBtn);
     }
 
     /**
@@ -296,12 +299,9 @@ class Annotator extends EventEmitter {
             return;
         }
 
-        // Reset the mobile dialog
+        // Resets the mobile dialog
         util.hideElement(this.mobileDialogEl);
-        this.mobileDialogEl.innerHTML = `
-            <div class="${CLASS_MOBILE_DIALOG_HEADER}">
-                <button class="${CLASS_DIALOG_CLOSE}">${ICON_CLOSE}</button>
-            </div>`.trim();
+        this.mobileDialogEl.removeChild(this.mobileDialogEl.lastChild);
     }
 
     /**

--- a/src/__tests__/Annotator-test.js
+++ b/src/__tests__/Annotator-test.js
@@ -39,7 +39,8 @@ describe('Annotator', () => {
             isEnabled: () => {},
             getButton: () => {},
             enter: () => {},
-            exit: () => {}
+            exit: () => {},
+            setupSharedDialog: () => {}
         };
         stubs.controllerMock = sandbox.mock(stubs.controller);
 
@@ -158,23 +159,39 @@ describe('Annotator', () => {
             };
             annotator.setupMobileDialog();
             expect(annotator.container.appendChild).to.be.called;
+            expect(annotator.mobileDialogEl.children.length).equals(1);
+        });
+    });
+
+    describe('resetMobileDialog()', () => {
+        beforeEach(() => {
+            sandbox.stub(util, 'hideElement');
+            sandbox.stub(util, 'showElement');
         });
 
-        it('should setup shared point dialog in the point controller', () => {
-            annotator.container = {
-                appendChild: sandbox.mock()
-            };
-            annotator.modeControllers = {
-                'point': { setupSharedDialog: sandbox.stub() }
-            };
-            const pointController = annotator.modeControllers['point'];
+        it('should do nothing if the mobile dialog does not exist or is hidden', () => {
+            annotator.resetMobileDialog();
+            expect(util.hideElement).to.not.be.called;
 
-            annotator.setupMobileDialog();
-            expect(pointController.setupSharedDialog).to.be.calledWith(annotator.container, {
-                isMobile: annotator.isMobile,
-                hasTouch: annotator.hasTouch,
-                localized: annotator.localized
-            });
+            annotator.mobileDialogEl = {
+                classList: {
+                    contains: sandbox.stub().returns(true)
+                },
+                removeChild: sandbox.stub(),
+                lastChild: {}
+            };
+            annotator.resetMobileDialog();
+            expect(util.hideElement).to.not.be.called;
+        });
+
+        it('should generate mobile annotations dialog and append to container', () => {
+            annotator.mobileDialogEl = document.createElement('div');
+            annotator.mobileDialogEl.appendChild(document.createElement('div'));
+
+            annotator.resetMobileDialog();
+            expect(util.hideElement).to.be.called;
+            expect(util.showElement).to.be.called;
+            expect(annotator.mobileDialogEl.children.length).equals(0);
         });
     });
 
@@ -230,6 +247,19 @@ describe('Annotator', () => {
 
             stubs.controllerMock.expects('init');
             stubs.controllerMock.expects('addListener').withArgs('annotationcontrollerevent', sinon.match.func);
+            annotator.setupControllers();
+        });
+
+        it('should setup shared point dialog in the point controller', () => {
+            annotator.modeControllers = { 'point': stubs.controller };
+            annotator.isMobile = true;
+
+            stubs.controllerMock.expects('init');
+            stubs.controllerMock.expects('setupSharedDialog').withArgs(annotator.container, {
+                isMobile: annotator.isMobile,
+                hasTouch: annotator.hasTouch,
+                localized: annotator.localized
+            });
             annotator.setupControllers();
         });
     });

--- a/src/doc/DocAnnotator.js
+++ b/src/doc/DocAnnotator.js
@@ -465,12 +465,12 @@ class DocAnnotator extends Annotator {
      * @return {void}
      */
     resetMobileDialog() {
-        if (!this.mobileDialogEl || this.mobileDialogEl.classList.contains(CLASS_HIDDEN)) {
+        if (!this.mobileDialogEl) {
             return;
         }
 
-        super.resetMobileDialog();
         this.mobileDialogEl.classList.remove(CLASS_ANNOTATION_PLAIN_HIGHLIGHT);
+        super.resetMobileDialog();
     }
 
     //--------------------------------------------------------------------------
@@ -920,7 +920,7 @@ class DocAnnotator extends Annotator {
         // Show active thread last
         if (this.activeThread) {
             this.activeThread.show();
-        } else {
+        } else if (this.isMobile) {
             this.resetMobileDialog();
         }
     }

--- a/src/doc/DocAnnotator.js
+++ b/src/doc/DocAnnotator.js
@@ -396,7 +396,7 @@ class DocAnnotator extends Annotator {
             this.annotatedElement.addEventListener('mouseup', this.highlightMouseupHandler);
         }
 
-        if (this.hasTouch && this.isMobile && this.drawEnabled) {
+        if (this.hasTouch && this.drawEnabled) {
             this.annotatedElement.addEventListener('touchstart', this.drawingSelectionHandler);
         } else {
             if (this.drawEnabled) {
@@ -404,7 +404,7 @@ class DocAnnotator extends Annotator {
             }
 
             // Desktop-only highlight listeners
-            if (this.plainHighlightEnabled || this.commentHighlightEnabled) {
+            if (!this.isMobile && (this.plainHighlightEnabled || this.commentHighlightEnabled)) {
                 this.annotatedElement.addEventListener('mousemove', this.getHighlightMouseMoveHandler());
             }
         }

--- a/src/doc/DocAnnotator.js
+++ b/src/doc/DocAnnotator.js
@@ -22,6 +22,7 @@ import {
     CLASS_ANNOTATION_LAYER_HIGHLIGHT,
     CLASS_ANNOTATION_LAYER_HIGHLIGHT_COMMENT,
     CLASS_ANNOTATION_LAYER_DRAW,
+    CLASS_ANNOTATION_PLAIN_HIGHLIGHT,
     CLASS_HIDDEN,
     THREAD_EVENT,
     ANNOTATOR_EVENT,
@@ -146,7 +147,7 @@ class DocAnnotator extends Annotator {
 
         if (annotationType === TYPES.point) {
             let clientEvent = event;
-            if (this.isMobile && event.targetTouches && event.targetTouches.length > 0) {
+            if (this.hasTouch && event.targetTouches && event.targetTouches.length > 0) {
                 clientEvent = event.targetTouches[0];
             }
 
@@ -456,6 +457,20 @@ class DocAnnotator extends Annotator {
             this.annotatedElement.removeEventListener('mousemove', this.highlightMousemoveHandler);
             this.highlightMousemoveHandler = null;
         }
+    }
+
+    /**
+     * Hides and resets the shared mobile dialog.
+     *
+     * @return {void}
+     */
+    resetMobileDialog() {
+        if (!this.mobileDialogEl || this.mobileDialogEl.classList.contains(CLASS_HIDDEN)) {
+            return;
+        }
+
+        super.resetMobileDialog();
+        this.mobileDialogEl.classList.remove(CLASS_ANNOTATION_PLAIN_HIGHLIGHT);
     }
 
     //--------------------------------------------------------------------------

--- a/src/doc/DocAnnotator.js
+++ b/src/doc/DocAnnotator.js
@@ -146,10 +146,7 @@ class DocAnnotator extends Annotator {
 
         if (annotationType === TYPES.point) {
             let clientEvent = event;
-            if (this.isMobile) {
-                if (!event.targetTouches || event.targetTouches.length === 0) {
-                    return location;
-                }
+            if (this.isMobile && event.targetTouches && event.targetTouches.length > 0) {
                 clientEvent = event.targetTouches[0];
             }
 
@@ -908,6 +905,8 @@ class DocAnnotator extends Annotator {
         // Show active thread last
         if (this.activeThread) {
             this.activeThread.show();
+        } else {
+            this.resetMobileDialog();
         }
     }
 

--- a/src/image/ImageAnnotator.js
+++ b/src/image/ImageAnnotator.js
@@ -37,10 +37,7 @@ class ImageAnnotator extends Annotator {
         let location = null;
 
         let clientEvent = event;
-        if (this.isMobile) {
-            if (!event.targetTouches || event.targetTouches.length === 0) {
-                return location;
-            }
+        if (this.isMobile && event.targetTouches && event.targetTouches.length > 0) {
             clientEvent = event.targetTouches[0];
         }
 

--- a/src/image/ImageAnnotator.js
+++ b/src/image/ImageAnnotator.js
@@ -41,7 +41,6 @@ class ImageAnnotator extends Annotator {
             if (!event.targetTouches || event.targetTouches.length === 0) {
                 return location;
             }
-
             clientEvent = event.targetTouches[0];
         }
 

--- a/src/image/ImageAnnotator.js
+++ b/src/image/ImageAnnotator.js
@@ -37,7 +37,11 @@ class ImageAnnotator extends Annotator {
         let location = null;
 
         let clientEvent = event;
-        if (this.isMobile && event.targetTouches && event.targetTouches.length > 0) {
+        if (this.hasTouch) {
+            if (!event.targetTouches || event.targetTouches.length === 0) {
+                return location;
+            }
+
             clientEvent = event.targetTouches[0];
         }
 

--- a/src/image/__tests__/ImageAnnotator-test.js
+++ b/src/image/__tests__/ImageAnnotator-test.js
@@ -73,7 +73,7 @@ describe('image/ImageAnnotator', () => {
         };
 
         beforeEach(() => {
-            annotator.isMobile = false;
+            annotator.hasTouch = false;
             imageEl = annotator.annotatedElement.querySelector('img');
             event = {
                 targetTouches: [{
@@ -95,17 +95,17 @@ describe('image/ImageAnnotator', () => {
         });
 
         it('should not return a location if no touch event is available and user is on a mobile device', () => {
-            annotator.isMobile = true;
+            annotator.hasTouch = true;
             expect(annotator.getLocationFromEvent({ targetTouches: [] })).to.be.null;
         });
 
         it('should replace event with mobile touch event if user is on a mobile device', () => {
-            annotator.isMobile = true;
+            annotator.hasTouch = true;
             annotator.getLocationFromEvent(event);
         });
 
         it('should not return a location if there are no touch event and the user is on a mobile device', () => {
-            annotator.isMobile = true;
+            annotator.hasTouch = true;
             const location = annotator.getLocationFromEvent({
                 target: {
                     nodeName: 'not-annotated'


### PR DESCRIPTION
- Use the proper mouse event for point annotations in getLocationFromEvent
- Hide the mobile dialog on outside click for highlight annotations