### PR TITLE
Fix: Create point dialog doesn't stop propagating click event on mobile

### DIFF
--- a/src/CommentBox.js
+++ b/src/CommentBox.js
@@ -284,10 +284,13 @@ class CommentBox extends EventEmitter {
             this.postEl.addEventListener('touchend', this.onPost);
         }
 
-        this.textAreaEl.addEventListener('focus', this.focus);
+        if (!this.isMobile) {
+            this.textAreaEl.addEventListener('focus', this.focus);
+            this.cancelEl.addEventListener('click', this.onCancel);
+            this.postEl.addEventListener('click', this.onPost);
+        }
+
         containerEl.addEventListener('click', this.preventDefaultAndPropagation.bind(this));
-        this.cancelEl.addEventListener('click', this.onCancel);
-        this.postEl.addEventListener('click', this.onPost);
 
         return containerEl;
     }

--- a/src/__tests__/CommentBox-test.js
+++ b/src/__tests__/CommentBox-test.js
@@ -273,7 +273,7 @@ describe('CommentBox', () => {
             expect(commentBox.postEl).to.exist;
         });
 
-        it('should add an event listener on the textarea, cancel and post buttons', () => {
+        it('should add an event listener on the textarea, cancel and post buttons for desktop devices', () => {
             const uiElement = {
                 addEventListener: sandbox.stub(),
                 removeEventListener: sandbox.stub()
@@ -286,9 +286,14 @@ describe('CommentBox', () => {
             expect(uiElement.addEventListener).to.be.calledWith('click', commentBox.onCancel);
             expect(uiElement.addEventListener).to.be.calledWith('click', commentBox.onPost);
             expect(uiElement.addEventListener).to.be.calledWith('focus', commentBox.focus);
+            expect(uiElement.addEventListener).to.be.calledWith('focus', sinon.match.func);
+
+            expect(uiElement.addEventListener).to.not.be.calledWith('touchend', sinon.match.func);
+            expect(uiElement.addEventListener).to.not.be.calledWith('touchend', sinon.match.func);
+            expect(uiElement.addEventListener).to.not.be.calledWith('touchend', sinon.match.func);
         });
 
-        it('should add an event listener on the textarea, cancel and post buttons if the user is on a touch-enabled device', () => {
+        it('should add an event listener on the textarea, cancel and post buttons if the user is on a touch-enabled non-mobile device', () => {
             const uiElement = {
                 addEventListener: sandbox.stub(),
                 removeEventListener: sandbox.stub()
@@ -299,14 +304,38 @@ describe('CommentBox', () => {
             commentBox.hasTouch = true;
 
             commentBox.createCommentBox();
-            expect(uiElement.addEventListener).to.be.calledWith('focus', sinon.match.func);
             expect(uiElement.addEventListener).to.be.calledWith('touchend', sinon.match.func);
             expect(uiElement.addEventListener).to.be.calledWith('touchend', sinon.match.func);
             expect(uiElement.addEventListener).to.be.calledWith('touchend', sinon.match.func);
 
+            expect(uiElement.addEventListener).to.be.calledWith('focus', sinon.match.func);
             expect(uiElement.addEventListener).to.be.calledWith('click', commentBox.onCancel);
             expect(uiElement.addEventListener).to.be.calledWith('click', commentBox.onPost);
             expect(uiElement.addEventListener).to.be.calledWith('focus', commentBox.focus);
+
+            commentBox.containerEl = null;
+        });
+
+        it('should add an event listener on the textarea, cancel and post buttons if the user is on a touch-enabled mobile device', () => {
+            const uiElement = {
+                addEventListener: sandbox.stub(),
+                removeEventListener: sandbox.stub()
+            };
+            const el = document.createElement('section');
+            sandbox.stub(el, 'querySelector').returns(uiElement);
+            sandbox.stub(commentBox, 'createHTML').returns(el);
+            commentBox.hasTouch = true;
+            commentBox.isMobile = true;
+
+            commentBox.createCommentBox();
+            expect(uiElement.addEventListener).to.be.calledWith('touchend', sinon.match.func);
+            expect(uiElement.addEventListener).to.be.calledWith('touchend', sinon.match.func);
+            expect(uiElement.addEventListener).to.be.calledWith('touchend', sinon.match.func);
+
+            expect(uiElement.addEventListener).to.not.be.calledWith('focus', sinon.match.func);
+            expect(uiElement.addEventListener).to.not.be.calledWith('click', commentBox.onCancel);
+            expect(uiElement.addEventListener).to.not.be.calledWith('click', commentBox.onPost);
+            expect(uiElement.addEventListener).to.not.be.calledWith('focus', commentBox.focus);
 
             commentBox.containerEl = null;
         });


### PR DESCRIPTION
Closes https://github.com/box/box-annotations/issues/110