### PR TITLE
Fix: Draw annotation mode bugs

### DIFF
--- a/src/AnnotationThread.js
+++ b/src/AnnotationThread.js
@@ -93,7 +93,9 @@ class AnnotationThread extends EventEmitter {
             this.element = null;
         }
 
-        this.emit(THREAD_EVENT.threadDelete);
+        if (this.state !== STATES.pending) {
+            this.emit(THREAD_EVENT.threadDelete);
+        }
     }
 
     /**

--- a/src/__tests__/AnnotationThread-test.js
+++ b/src/__tests__/AnnotationThread-test.js
@@ -67,9 +67,22 @@ describe('AnnotationThread', () => {
     });
 
     describe('destroy()', () => {
-        it('should unbind listeners and remove thread element and broadcast that the thread was deleted', () => {
+        beforeEach(() => {
+            thread.state = STATES.pending;
             stubs.unbindCustom = sandbox.stub(thread, 'unbindCustomListenersOnDialog');
             stubs.unbindDOM = sandbox.stub(thread, 'unbindDOMListeners');
+            stubs.destroyDialog = sandbox.stub(thread.dialog, 'destroy');
+        });
+
+        it('should unbind listeners and remove thread element and broadcast that the thread was deleted', () => {
+            thread.destroy();
+            expect(stubs.unbindCustom).to.be.called;
+            expect(stubs.unbindDOM).to.be.called;
+            expect(stubs.emit).to.not.be.calledWith(THREAD_EVENT.threadDelete);
+        });
+
+        it('should emit annotationthreaddeleted only if thread is not in a pending state', () => {
+            thread.state = STATES.inactive;
 
             thread.destroy();
             expect(stubs.unbindCustom).to.be.called;
@@ -78,8 +91,6 @@ describe('AnnotationThread', () => {
         });
 
         it('should not destroy the dialog on mobile', () => {
-            stubs.unbindCustom = sandbox.stub(thread, 'unbindCustomListenersOnDialog');
-            stubs.destroyDialog = sandbox.stub(thread.dialog, 'destroy');
             thread.element = null;
             thread.isMobile = true;
 

--- a/src/controllers/DrawingModeController.js
+++ b/src/controllers/DrawingModeController.js
@@ -127,7 +127,9 @@ class DrawingModeController extends AnnotationModeController {
         );
 
         this.pushElementHandler(this.cancelButtonEl, 'click', () => {
-            this.currentThread.cancelUnsavedAnnotation();
+            if (this.currentThread) {
+                this.currentThread.cancelUnsavedAnnotation();
+            }
             this.toggleMode();
         });
 
@@ -157,12 +159,11 @@ class DrawingModeController extends AnnotationModeController {
             case 'softcommit':
                 this.currentThread = undefined;
                 this.saveThread(thread);
+                this.unbindListeners();
+                this.bindListeners();
 
                 // Given a location (page change) start drawing at the provided location
                 if (eventData && eventData.location) {
-                    this.unbindListeners();
-                    this.bindListeners();
-
                     this.currentThread.handleStart(eventData.location);
                 }
 

--- a/src/controllers/__tests__/DrawingModeController-test.js
+++ b/src/controllers/__tests__/DrawingModeController-test.js
@@ -212,8 +212,8 @@ describe('controllers/DrawingModeController', () => {
             controller.handleThreadEvents(stubs.thread, {
                 event: 'softcommit'
             });
-            expect(controller.unbindListeners).to.not.be.called;
-            expect(controller.bindListeners).to.not.be.called;
+            expect(controller.unbindListeners).to.be.called;
+            expect(controller.bindListeners).to.be.called;
             expect(stubs.thread.handleStart).to.not.be.called;
             expect(controller.saveThread).to.be.called;
         });

--- a/src/doc/DocAnnotator.js
+++ b/src/doc/DocAnnotator.js
@@ -148,7 +148,10 @@ class DocAnnotator extends Annotator {
 
         if (annotationType === TYPES.point) {
             let clientEvent = event;
-            if (this.hasTouch && event.targetTouches && event.targetTouches.length > 0) {
+            if (this.hasTouch && event.targetTouches) {
+                if (event.targetTouches.length <= 0) {
+                    return location;
+                }
                 clientEvent = event.targetTouches[0];
             }
 

--- a/src/drawing/DrawingThread.js
+++ b/src/drawing/DrawingThread.js
@@ -99,8 +99,12 @@ class DrawingThread extends AnnotationThread {
         }
 
         super.destroy();
+
+        if (this.state !== STATES.pending) {
+            this.emit(THREAD_EVENT.threadCleanup);
+        }
+
         this.reset();
-        this.emit(THREAD_EVENT.threadCleanup);
     }
 
     /**

--- a/src/drawing/__tests__/DrawingThread-test.js
+++ b/src/drawing/__tests__/DrawingThread-test.js
@@ -60,7 +60,6 @@ describe('drawing/DrawingThread', () => {
 
             expect(window.cancelAnimationFrame).to.be.calledWith(1);
             expect(thread.reset).to.be.called;
-            expect(thread.emit).to.be.calledWith(THREAD_EVENT.threadCleanup);
         })
     });
 


### PR DESCRIPTION
Fixes the following issues: 
1. Drawing a second annotation after saving a previous one will continue adding the drawings to the previous path. 
2. Error notification was thrown on "touchend" for invalid locations