### PR TITLE
Fix: Move dependencies to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,6 @@
     "type": "git",
     "url": "git@github.com:box/box-annotations.git"
   },
-  "dependencies": {
-    "box-react-ui": "^22.3.0",
-    "rangy": "^1.3.0",
-    "rbush": "^2.0.1"
-  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
@@ -31,6 +26,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-es2016": "^6.24.1",
     "babel-preset-react": "^6.24.1",
+    "box-react-ui": "^22.3.0",
     "chai": "^4.1.2",
     "chai-dom": "^1.6.0",
     "commitlint": "^6.1.2",
@@ -75,7 +71,9 @@
     "postcss-loader": "^2.0.9",
     "prettier": "^1.8.2",
     "prettier-eslint-cli": "^4.4.2",
+    "rangy": "^1.3.0",
     "raw-loader": "^0.5.1",
+    "rbush": "^2.0.1",
     "sass-loader": "^6.0.6",
     "sinon": "^4.1.2",
     "sinon-chai": "^2.14.0",


### PR DESCRIPTION
Since box-annotations isn't meant to be imported from npm as a node module, it doesn't need any package.json dependencies. Moving box-react-ui, rangy, and rbush to devDependencies fixes peer dependency warnings in preview.