### PR TITLE
Fix: Re-draw drawing thread boundary on path change

### DIFF
--- a/src/doc/DocDrawingThread.js
+++ b/src/doc/DocDrawingThread.js
@@ -123,7 +123,7 @@ class DocDrawingThread extends DrawingThread {
             this.dialog.hide();
         }
 
-        this.drawBoundary();
+        this.render();
         this.emitAvailableActions();
         this.pendingPath = null;
     }

--- a/src/doc/DocHighlightThread.js
+++ b/src/doc/DocHighlightThread.js
@@ -503,12 +503,12 @@ class DocHighlightThread extends AnnotationThread {
             context.save();
             context.globalCompositeOperation = 'destination-out';
             context.fillStyle = HIGHLIGHT_FILL.erase;
-            context.fillRect(x1, y3, x2 - x1, y2 - y3);
+            context.fill();
             context.restore();
 
             // Draw actual highlight rectangle if needed
             if (fillStyle !== HIGHLIGHT_FILL.erase) {
-                context.fillRect(x1, y3, x2 - x1, y2 - y3);
+                context.fill();
 
                 // Update highlight icon hover to appropriate color
                 if (this.dialog && this.dialog.element) {

--- a/src/doc/DocHighlightThread.js
+++ b/src/doc/DocHighlightThread.js
@@ -503,12 +503,12 @@ class DocHighlightThread extends AnnotationThread {
             context.save();
             context.globalCompositeOperation = 'destination-out';
             context.fillStyle = HIGHLIGHT_FILL.erase;
-            context.fill();
+            context.fillRect(x1, y3, x2 - x1, y2 - y3);
             context.restore();
 
             // Draw actual highlight rectangle if needed
             if (fillStyle !== HIGHLIGHT_FILL.erase) {
-                context.fill();
+                context.fillRect(x1, y3, x2 - x1, y2 - y3);
 
                 // Update highlight icon hover to appropriate color
                 if (this.dialog && this.dialog.element) {

--- a/src/doc/__tests__/DocDrawingThread-test.js
+++ b/src/doc/__tests__/DocDrawingThread-test.js
@@ -134,7 +134,7 @@ describe('doc/DocDrawingThread', () => {
             stubs.emitAvailableActions = sandbox.stub(thread, 'emitAvailableActions');
             stubs.updateBoundary = sandbox.stub(thread, 'updateBoundary');
             stubs.regenerateBoundary = sandbox.stub(thread, 'regenerateBoundary');
-            stubs.drawBoundary = sandbox.stub(thread, 'drawBoundary');
+            stubs.render = sandbox.stub(thread, 'render');
             stubs.createDialog = sandbox.stub(thread, 'createDialog');
             thread.drawingFlag = DRAW_STATES.drawing;
             thread.pendingPath = {
@@ -152,7 +152,7 @@ describe('doc/DocDrawingThread', () => {
             expect(stubs.emitAvailableActions).to.be.called;
             expect(stubs.updateBoundary).to.be.called;
             expect(stubs.regenerateBoundary).to.be.called;
-            expect(stubs.drawBoundary).to.be.called;
+            expect(stubs.render).to.be.called;
             expect(stubs.createDialog).to.be.called;
             expect(thread.pathContainer.insert).to.be.called;
             expect(thread.drawingFlag).to.equal(DRAW_STATES.idle);

--- a/src/drawing/DrawingThread.js
+++ b/src/drawing/DrawingThread.js
@@ -284,9 +284,14 @@ class DrawingThread extends AnnotationThread {
             return;
         }
 
+        /* OPTIMIZE (@minhnguyen): Render only what has been obstructed by the new drawing
+         *           rather than every single line in the thread. If we do end
+         *           up splitting saves into multiple requests, we can buffer
+         *           the amount of re-renders onto a temporary memory canvas.
+         */
         if (clearCanvas) {
-            const [x, y, width, height] = this.getBrowserRectangularBoundary();
-            context.clearRect(x, y, width, height);
+            const { canvas } = context;
+            context.clearRect(0, 0, canvas.width, canvas.height);
         }
 
         context.beginPath();

--- a/src/drawing/DrawingThread.js
+++ b/src/drawing/DrawingThread.js
@@ -360,6 +360,7 @@ class DrawingThread extends AnnotationThread {
         const elapsed = timestamp - (this.lastRenderTimestamp || 0);
         if (elapsed >= DRAW_RENDER_THRESHOLD) {
             this.draw(this.drawingContext, true);
+            this.drawBoundary();
 
             this.lastRenderTimestamp = timestamp;
             renderAgain = this.drawingFlag === DRAW_STATES.drawing;

--- a/src/drawing/DrawingThread.js
+++ b/src/drawing/DrawingThread.js
@@ -284,14 +284,9 @@ class DrawingThread extends AnnotationThread {
             return;
         }
 
-        /* OPTIMIZE (@minhnguyen): Render only what has been obstructed by the new drawing
-         *           rather than every single line in the thread. If we do end
-         *           up splitting saves into multiple requests, we can buffer
-         *           the amount of re-renders onto a temporary memory canvas.
-         */
         if (clearCanvas) {
-            const { canvas } = context;
-            context.clearRect(0, 0, canvas.width, canvas.height);
+            const [x, y, width, height] = this.getBrowserRectangularBoundary();
+            context.clearRect(x, y, width, height);
         }
 
         context.beginPath();

--- a/src/drawing/__tests__/DrawingThread-test.js
+++ b/src/drawing/__tests__/DrawingThread-test.js
@@ -124,12 +124,14 @@ describe('drawing/DrawingThread', () => {
     describe('render()', () => {
         beforeEach(() => {
             sandbox.stub(thread, 'draw');
+            sandbox.stub(thread, 'drawBoundary');
         });
 
         it('should draw the pending path when the context is not empty', () => {
             const timeStamp = 20000;
             thread.render(timeStamp);
             expect(thread.draw).to.be.called;
+            expect(thread.drawBoundary).to.be.called;
         });
 
         it('should do nothing when the timeElapsed is less than the refresh rate', () => {
@@ -137,6 +139,7 @@ describe('drawing/DrawingThread', () => {
             thread.lastRenderTimestamp = 100;
             thread.render(timeStamp);
             expect(thread.draw).to.not.be.called;
+            expect(thread.drawBoundary).to.not.be.called;
         });
     });
 


### PR DESCRIPTION
Fixes bug where drawing boundary was not re-drawn when a drawing was added to an already pending drawing. 