### PR TITLE
Fix: Ensure isMobile and hasTouch gets passed on to all dialogs

### DIFF
--- a/src/AnnotationDialog.js
+++ b/src/AnnotationDialog.js
@@ -177,6 +177,10 @@ class AnnotationDialog extends EventEmitter {
         this.hideMobileDialog = this.hideMobileDialog.bind(this);
         dialogCloseButtonEl.addEventListener('click', this.hideMobileDialog);
 
+        if (this.hasTouch) {
+            dialogCloseButtonEl.addEventListener('touchstart', this.hideMobileDialog);
+        }
+
         this.element.classList.add(constants.CLASS_ANIMATE_DIALOG);
 
         this.bindDOMListeners();

--- a/src/AnnotationDialog.js
+++ b/src/AnnotationDialog.js
@@ -63,6 +63,8 @@ class AnnotationDialog extends EventEmitter {
         if (!this.isMobile) {
             this.mouseenterHandler = this.mouseenterHandler.bind(this);
             this.mouseleaveHandler = this.mouseleaveHandler.bind(this);
+        } else {
+            this.hideMobileDialog = this.hideMobileDialog.bind(this);
         }
     }
 
@@ -389,8 +391,6 @@ class AnnotationDialog extends EventEmitter {
         }
 
         const dialogCloseButtonEl = this.element.querySelector(constants.SELECTOR_DIALOG_CLOSE);
-
-        this.hideMobileDialog = this.hideMobileDialog.bind(this);
         dialogCloseButtonEl.addEventListener('click', this.hideMobileDialog);
 
         if (this.hasTouch) {

--- a/src/AnnotationDialog.js
+++ b/src/AnnotationDialog.js
@@ -448,8 +448,6 @@ class AnnotationDialog extends EventEmitter {
         }
 
         const dialogCloseButtonEl = this.element.querySelector(constants.SELECTOR_DIALOG_CLOSE);
-
-        this.hideMobileDialog = this.hideMobileDialog.bind(this);
         dialogCloseButtonEl.removeEventListener('click', this.hideMobileDialog);
 
         if (this.hasTouch) {

--- a/src/AnnotationDialog.js
+++ b/src/AnnotationDialog.js
@@ -172,15 +172,6 @@ class AnnotationDialog extends EventEmitter {
             headerEl.classList.add(constants.CLASS_HIDDEN);
         }
 
-        const dialogCloseButtonEl = this.element.querySelector(constants.SELECTOR_DIALOG_CLOSE);
-
-        this.hideMobileDialog = this.hideMobileDialog.bind(this);
-        dialogCloseButtonEl.addEventListener('click', this.hideMobileDialog);
-
-        if (this.hasTouch) {
-            dialogCloseButtonEl.addEventListener('touchstart', this.hideMobileDialog);
-        }
-
         this.element.classList.add(constants.CLASS_ANIMATE_DIALOG);
 
         this.bindDOMListeners();
@@ -208,9 +199,6 @@ class AnnotationDialog extends EventEmitter {
                 <button class="${constants.CLASS_DIALOG_CLOSE}">${ICON_CLOSE}</button>
             </div>`.trim();
         this.element.classList.remove(constants.CLASS_ANNOTATION_PLAIN_HIGHLIGHT);
-
-        const dialogCloseButtonEl = this.element.querySelector(constants.SELECTOR_DIALOG_CLOSE);
-        dialogCloseButtonEl.removeEventListener('click', this.hideMobileDialog);
 
         util.hideElement(this.element);
         this.unbindDOMListeners();
@@ -397,6 +385,16 @@ class AnnotationDialog extends EventEmitter {
         if (!this.isMobile) {
             this.element.addEventListener('mouseenter', this.mouseenterHandler);
             this.element.addEventListener('mouseleave', this.mouseleaveHandler);
+            return;
+        }
+
+        const dialogCloseButtonEl = this.element.querySelector(constants.SELECTOR_DIALOG_CLOSE);
+
+        this.hideMobileDialog = this.hideMobileDialog.bind(this);
+        dialogCloseButtonEl.addEventListener('click', this.hideMobileDialog);
+
+        if (this.hasTouch) {
+            dialogCloseButtonEl.addEventListener('touchstart', this.hideMobileDialog);
         }
     }
 
@@ -446,6 +444,16 @@ class AnnotationDialog extends EventEmitter {
         if (!this.isMobile) {
             this.element.removeEventListener('mouseenter', this.mouseenterHandler);
             this.element.removeEventListener('mouseleave', this.mouseleaveHandler);
+            return;
+        }
+
+        const dialogCloseButtonEl = this.element.querySelector(constants.SELECTOR_DIALOG_CLOSE);
+
+        this.hideMobileDialog = this.hideMobileDialog.bind(this);
+        dialogCloseButtonEl.removeEventListener('click', this.hideMobileDialog);
+
+        if (this.hasTouch) {
+            dialogCloseButtonEl.removeEventListener('touchstart', this.hideMobileDialog);
         }
     }
 

--- a/src/AnnotationThread.js
+++ b/src/AnnotationThread.js
@@ -8,7 +8,8 @@ import {
     TYPES,
     CLASS_ANNOTATION_POINT_MARKER,
     DATA_TYPE_ANNOTATION_INDICATOR,
-    THREAD_EVENT
+    THREAD_EVENT,
+    CLASS_HIDDEN
 } from './constants';
 
 class AnnotationThread extends EventEmitter {
@@ -53,8 +54,8 @@ class AnnotationThread extends EventEmitter {
         this.threadNumber = data.threadNumber || '';
         this.type = data.type;
         this.locale = data.locale;
-        this.isMobile = data.isMobile;
-        this.hasTouch = data.hasTouch;
+        this.isMobile = data.isMobile || false;
+        this.hasTouch = data.hasTouch || false;
         this.permissions = data.permissions;
         this.localized = data.localized;
         this.state = STATES.inactive;
@@ -114,6 +115,15 @@ class AnnotationThread extends EventEmitter {
      */
     reset() {
         this.state = STATES.inactive;
+    }
+
+    /**
+     * Whether or not thread dialog is visible
+     *
+     * @return {void}
+     */
+    isDialogVisible() {
+        return !!(this.dialog && this.dialog.element && !this.dialog.element.classList.contains(CLASS_HIDDEN));
     }
 
     /**

--- a/src/CommentBox.js
+++ b/src/CommentBox.js
@@ -62,6 +62,9 @@ class CommentBox extends EventEmitter {
     /** Whether or not we should use touch events */
     hasTouch;
 
+    /** Whether or not user is on a mobile device */
+    isMobile;
+
     /* Events that the comment box can emit. */
     static CommentEvents = {
         cancel: 'comment_cancel',
@@ -79,7 +82,8 @@ class CommentBox extends EventEmitter {
         super();
 
         this.parentEl = parentEl;
-        this.hasTouch = config.hasTouch;
+        this.hasTouch = config.hasTouch || false;
+        this.isMobile = config.isMobile || false;
 
         this.localized = config.localized;
         this.cancelText = config.localized.cancelButton;

--- a/src/CreateAnnotationDialog.js
+++ b/src/CreateAnnotationDialog.js
@@ -250,6 +250,7 @@ class CreateAnnotationDialog extends EventEmitter {
         // Create comment boxt
         const commentBox = new CommentBox(containerEl, {
             hasTouch: this.hasTouch,
+            isMobile: this.isMobile,
             localized: this.localized
         });
         containerEl.appendChild(commentBox.containerEl);

--- a/src/__tests__/AnnotationDialog-test.js
+++ b/src/__tests__/AnnotationDialog-test.js
@@ -51,6 +51,8 @@ describe('AnnotationDialog', () => {
             dialogEl.parentNode.removeChild(dialogEl);
         }
 
+        dialog.element = null;
+
         sandbox.verifyAndRestore();
         if (typeof dialog.destroy === 'function') {
             dialog.destroy();
@@ -77,6 +79,7 @@ describe('AnnotationDialog', () => {
             stubs.scroll = sandbox.stub(dialog, 'scrollToLastComment');
             sandbox.stub(dialog, 'showMobileDialog');
             dialog.canAnnotate = true;
+            dialog.element.classList.add(constants.CLASS_HIDDEN);
         });
 
         it('should show the mobile dialog if on a mobile device', () => {
@@ -238,6 +241,7 @@ describe('AnnotationDialog', () => {
     describe('hide()', () => {
         beforeEach(() => {
             dialog.element.classList.remove(constants.CLASS_HIDDEN);
+            stubs.unbind = sandbox.stub(dialog, 'unbindDOMListeners');
         });
 
         it('should do nothing if element is already hidden', () => {
@@ -261,6 +265,7 @@ describe('AnnotationDialog', () => {
             dialog.hide();
             expect(dialog.hideMobileDialog).to.be.called;
             expect(dialog.toggleFlippedThreadEl).to.be.called;
+            dialog.element = null;
         });
     });
 
@@ -322,6 +327,7 @@ describe('AnnotationDialog', () => {
             sandbox.stub(dialog, 'generateDialogEl').returns(dialogEl);
             stubs.bind = sandbox.stub(dialog, 'bindDOMListeners');
             stubs.addSorted = sandbox.stub(dialog, 'addSortedAnnotations');
+            stubs.unbind = sandbox.stub(dialog, 'unbindDOMListeners');
 
             stubs.annotation = new Annotation({
                 annotationID: 'someID',
@@ -352,6 +358,7 @@ describe('AnnotationDialog', () => {
             dialog.setup([stubs.annotation, stubs.annotation], {});
             expect(stubs.bind).to.not.be.called;
             expect(stubs.addSorted).to.be.called;
+            dialog.element = null;
         });
     });
 
@@ -408,12 +415,15 @@ describe('AnnotationDialog', () => {
     });
 
     describe('bindDOMListeners()', () => {
-        it('should bind DOM listeners', () => {
+        beforeEach(() => {
+            stubs.replyTextEl = dialog.element.querySelector(`.${CLASS_REPLY_TEXTAREA}`);
+            stubs.annotationTextEl = dialog.element.querySelector(constants.SELECTOR_ANNOTATION_TEXTAREA);
             stubs.add = sandbox.stub(dialog.element, 'addEventListener');
-            const replyTextEl = dialog.element.querySelector(`.${CLASS_REPLY_TEXTAREA}`);
-            sandbox.stub(replyTextEl, 'addEventListener');
-            const annotationTextEl = dialog.element.querySelector(constants.SELECTOR_ANNOTATION_TEXTAREA);
-            sandbox.stub(annotationTextEl, 'addEventListener');
+            sandbox.stub(stubs.replyTextEl, 'addEventListener');
+            sandbox.stub(stubs.annotationTextEl, 'addEventListener');
+        });
+
+        it('should bind DOM listeners', () => {
             dialog.hasTouch = true;
 
             dialog.bindDOMListeners();
@@ -425,13 +435,11 @@ describe('AnnotationDialog', () => {
             expect(stubs.add).to.be.calledWith('wheel', sinon.match.func);
             expect(stubs.add).to.be.calledWith('touchstart', dialog.clickHandler);
             expect(stubs.add).to.be.calledWith('touchstart', dialog.stopPropagation);
-            expect(replyTextEl.addEventListener).to.be.calledWith('focus', sinon.match.func);
-            expect(annotationTextEl.addEventListener).to.be.calledWith('focus', sinon.match.func);
+            expect(stubs.replyTextEl.addEventListener).to.be.calledWith('focus', sinon.match.func);
+            expect(stubs.annotationTextEl.addEventListener).to.be.calledWith('focus', sinon.match.func);
         });
 
         it('should not bind touch events if not on a touch enabled devices', () => {
-            stubs.add = sandbox.stub(dialog.element, 'addEventListener');
-
             dialog.bindDOMListeners();
             expect(stubs.add).to.be.calledWith('keydown', sinon.match.func);
             expect(stubs.add).to.be.calledWith('click', sinon.match.func);
@@ -443,8 +451,9 @@ describe('AnnotationDialog', () => {
         });
 
         it('should not bind mouseenter/leave events for mobile browsers', () => {
-            stubs.add = sandbox.stub(dialog.element, 'addEventListener');
             dialog.isMobile = true;
+            dialog.showMobileDialog();
+            stubs.add = sandbox.stub(dialog.element, 'addEventListener');
 
             dialog.bindDOMListeners();
             expect(stubs.add).to.be.calledWith('keydown', sinon.match.func);
@@ -482,12 +491,15 @@ describe('AnnotationDialog', () => {
     });
 
     describe('unbindDOMListeners()', () => {
-        it('should unbind DOM listeners', () => {
+        beforeEach(() => {
+            stubs.replyTextEl = dialog.element.querySelector(`.${CLASS_REPLY_TEXTAREA}`);
+            stubs.annotationTextEl = dialog.element.querySelector(constants.SELECTOR_ANNOTATION_TEXTAREA);
             stubs.remove = sandbox.stub(dialog.element, 'removeEventListener');
-            const replyTextEl = dialog.element.querySelector(`.${CLASS_REPLY_TEXTAREA}`);
-            sandbox.stub(replyTextEl, 'removeEventListener');
-            const annotationTextEl = dialog.element.querySelector(constants.SELECTOR_ANNOTATION_TEXTAREA);
-            sandbox.stub(annotationTextEl, 'removeEventListener');
+            sandbox.stub(stubs.replyTextEl, 'removeEventListener');
+            sandbox.stub(stubs.annotationTextEl, 'removeEventListener');
+        });
+
+        it('should unbind DOM listeners', () => {
             dialog.hasTouch = true;
 
             dialog.unbindDOMListeners();
@@ -499,13 +511,11 @@ describe('AnnotationDialog', () => {
             expect(stubs.remove).to.be.calledWith('touchstart', dialog.clickHandler);
             expect(stubs.remove).to.be.calledWith('touchstart', dialog.stopPropagation);
             expect(stubs.remove).to.be.calledWith('wheel', sinon.match.func);
-            expect(replyTextEl.removeEventListener).to.be.calledWith('focus', dialog.validateTextArea);
-            expect(annotationTextEl.removeEventListener).to.be.calledWith('focus', dialog.validateTextArea);
+            expect(stubs.replyTextEl.removeEventListener).to.be.calledWith('focus', dialog.validateTextArea);
+            expect(stubs.annotationTextEl.removeEventListener).to.be.calledWith('focus', dialog.validateTextArea);
         });
 
         it('should not bind touch events if not on a touch enabled devices', () => {
-            stubs.remove = sandbox.stub(dialog.element, 'removeEventListener');
-
             dialog.unbindDOMListeners();
             expect(stubs.remove).to.be.calledWith('keydown', sinon.match.func);
             expect(stubs.remove).to.be.calledWith('click', sinon.match.func);
@@ -517,8 +527,9 @@ describe('AnnotationDialog', () => {
         });
 
         it('should not bind mouseenter/leave events for mobile browsers', () => {
-            stubs.remove = sandbox.stub(dialog.element, 'removeEventListener');
             dialog.isMobile = true;
+            dialog.showMobileDialog();
+            stubs.remove = sandbox.stub(dialog.element, 'removeEventListener');
 
             dialog.unbindDOMListeners();
             expect(stubs.remove).to.be.calledWith('keydown', sinon.match.func);

--- a/src/__tests__/AnnotationDialog-test.js
+++ b/src/__tests__/AnnotationDialog-test.js
@@ -414,6 +414,7 @@ describe('AnnotationDialog', () => {
             sandbox.stub(replyTextEl, 'addEventListener');
             const annotationTextEl = dialog.element.querySelector(constants.SELECTOR_ANNOTATION_TEXTAREA);
             sandbox.stub(annotationTextEl, 'addEventListener');
+            dialog.hasTouch = true;
 
             dialog.bindDOMListeners();
             expect(stubs.add).to.be.calledWith('keydown', sinon.match.func);
@@ -422,8 +423,23 @@ describe('AnnotationDialog', () => {
             expect(stubs.add).to.be.calledWith('mouseenter', sinon.match.func);
             expect(stubs.add).to.be.calledWith('mouseleave', sinon.match.func);
             expect(stubs.add).to.be.calledWith('wheel', sinon.match.func);
+            expect(stubs.add).to.be.calledWith('touchstart', dialog.clickHandler);
+            expect(stubs.add).to.be.calledWith('touchstart', dialog.stopPropagation);
             expect(replyTextEl.addEventListener).to.be.calledWith('focus', sinon.match.func);
             expect(annotationTextEl.addEventListener).to.be.calledWith('focus', sinon.match.func);
+        });
+
+        it('should not bind touch events if not on a touch enabled devices', () => {
+            stubs.add = sandbox.stub(dialog.element, 'addEventListener');
+
+            dialog.bindDOMListeners();
+            expect(stubs.add).to.be.calledWith('keydown', sinon.match.func);
+            expect(stubs.add).to.be.calledWith('click', sinon.match.func);
+            expect(stubs.add).to.be.calledWith('mouseup', sinon.match.func);
+            expect(stubs.add).to.be.calledWith('wheel', sinon.match.func);
+            expect(stubs.add).to.not.be.calledWith('touchstart', dialog.clickHandler);
+            expect(stubs.add).to.not.be.calledWith('touchstart', dialog.stopPropagation);
+            dialog.element = null;
         });
 
         it('should not bind mouseenter/leave events for mobile browsers', () => {
@@ -472,6 +488,7 @@ describe('AnnotationDialog', () => {
             sandbox.stub(replyTextEl, 'removeEventListener');
             const annotationTextEl = dialog.element.querySelector(constants.SELECTOR_ANNOTATION_TEXTAREA);
             sandbox.stub(annotationTextEl, 'removeEventListener');
+            dialog.hasTouch = true;
 
             dialog.unbindDOMListeners();
             expect(stubs.remove).to.be.calledWith('keydown', sinon.match.func);
@@ -479,9 +496,24 @@ describe('AnnotationDialog', () => {
             expect(stubs.remove).to.be.calledWith('mouseup', sinon.match.func);
             expect(stubs.remove).to.be.calledWith('mouseenter', sinon.match.func);
             expect(stubs.remove).to.be.calledWith('mouseleave', sinon.match.func);
+            expect(stubs.remove).to.be.calledWith('touchstart', dialog.clickHandler);
+            expect(stubs.remove).to.be.calledWith('touchstart', dialog.stopPropagation);
             expect(stubs.remove).to.be.calledWith('wheel', sinon.match.func);
             expect(replyTextEl.removeEventListener).to.be.calledWith('focus', dialog.validateTextArea);
             expect(annotationTextEl.removeEventListener).to.be.calledWith('focus', dialog.validateTextArea);
+        });
+
+        it('should not bind touch events if not on a touch enabled devices', () => {
+            stubs.remove = sandbox.stub(dialog.element, 'removeEventListener');
+
+            dialog.unbindDOMListeners();
+            expect(stubs.remove).to.be.calledWith('keydown', sinon.match.func);
+            expect(stubs.remove).to.be.calledWith('click', sinon.match.func);
+            expect(stubs.remove).to.be.calledWith('mouseup', sinon.match.func);
+            expect(stubs.remove).to.be.calledWith('wheel', sinon.match.func);
+            expect(stubs.remove).to.not.be.calledWith('touchstart', dialog.clickHandler);
+            expect(stubs.remove).to.not.be.calledWith('touchstart', dialog.stopPropagation);
+            dialog.element = null;
         });
 
         it('should not bind mouseenter/leave events for mobile browsers', () => {
@@ -672,6 +704,7 @@ describe('AnnotationDialog', () => {
         beforeEach(() => {
             stubs.event = {
                 stopPropagation: () => {},
+                preventDefault: () => {},
                 target: document.createElement('div')
             };
             stubs.post = sandbox.stub(dialog, 'postAnnotation');

--- a/src/__tests__/AnnotationThread-test.js
+++ b/src/__tests__/AnnotationThread-test.js
@@ -114,6 +114,23 @@ describe('AnnotationThread', () => {
         });
     });
 
+    describe('isDialogVisible()', () => {
+        beforeEach(() => {
+            thread.dialog = {
+                element: document.createElement('div')
+            };
+        });
+
+        it('returns true if thread\'s dialog is visible', () => {
+            expect(thread.isDialogVisible()).to.be.true;
+        });
+
+        it('returns false if thread\'s dialog is hidden', () => {
+            thread.dialog.element.classList.add(CLASS_HIDDEN);
+            expect(thread.isDialogVisible()).to.be.false;
+        });
+    });
+
     describe('showDialog()', () => {
         it('should setup the thread dialog if the dialog element does not already exist', () => {
             thread.dialog.element = null;

--- a/src/controllers/AnnotationModeController.js
+++ b/src/controllers/AnnotationModeController.js
@@ -446,6 +446,8 @@ class AnnotationModeController extends EventEmitter {
                     /* eslint-enable no-console */
 
                     thread.destroy();
+                } else if (thread.isDialogVisible()) {
+                    thread.hideDialog();
                 }
             });
         });

--- a/src/controllers/__tests__/AnnotationModeController-test.js
+++ b/src/controllers/__tests__/AnnotationModeController-test.js
@@ -34,6 +34,8 @@ describe('controllers/AnnotationModeController', () => {
             handleStart: () => {},
             destroy: () => {},
             deleteThread: () => {},
+            hideDialog: () => {},
+            isDialogVisible: () => {},
             show: () => {},
             minX: 1,
             minY: 2,
@@ -519,7 +521,18 @@ describe('controllers/AnnotationModeController', () => {
 
         it('should not destroy and return false if the threads are not pending', () => {
             stubs.thread.state = 'NOT_PENDING';
+            stubs.threadMock.expects('isDialogVisible').returns(false);
             stubs.threadMock.expects('destroy').never();
+            stubs.threadMock.expects('hideDialog').never();
+            const destroyed = controller.destroyPendingThreads();
+            expect(destroyed).to.be.false;
+        });
+
+        it('should hide non-pending thread dialogs that are visible', () => {
+            stubs.thread.state = 'NOT_PENDING';
+            stubs.threadMock.expects('isDialogVisible').returns(true);
+            stubs.threadMock.expects('destroy').never();
+            stubs.threadMock.expects('hideDialog');
             const destroyed = controller.destroyPendingThreads();
             expect(destroyed).to.be.false;
         });

--- a/src/doc/DocHighlightThread.js
+++ b/src/doc/DocHighlightThread.js
@@ -302,6 +302,8 @@ class DocHighlightThread extends AnnotationThread {
             annotations: this.annotations,
             locale: this.locale,
             location: this.location,
+            isMobile: this.isMobile,
+            hasTouch: this.hasTouch,
             canAnnotate: this.permissions.canAnnotate
         });
 

--- a/src/doc/DocPointThread.js
+++ b/src/doc/DocPointThread.js
@@ -75,6 +75,8 @@ class DocPointThread extends AnnotationThread {
             annotations: this.annotations,
             locale: this.locale,
             location: this.location,
+            isMobile: this.isMobile,
+            hasTouch: this.hasTouch,
             canAnnotate: this.permissions.canAnnotate
         });
     }

--- a/src/image/ImagePointThread.js
+++ b/src/image/ImagePointThread.js
@@ -49,6 +49,8 @@ class ImagePointThread extends AnnotationThread {
             annotations: this.annotations,
             location: this.location,
             locale: this.locale,
+            isMobile: this.isMobile,
+            hasTouch: this.hasTouch,
             canAnnotate: this.permissions.canAnnotate
         });
     }


### PR DESCRIPTION
- Instantiates all annotation dialogs with the proper variables for isMobile/hasTouch
- Binds touch events to annotation dialogs on touch enabled desktop devices
- Hides all newly created non-pending dialogs on touch enabled desktop devices