### PR TITLE
Breaking: Prototype for simplifying annotations

### DIFF
--- a/src/AnnotationDialog.js
+++ b/src/AnnotationDialog.js
@@ -59,10 +59,10 @@ class AnnotationDialog extends EventEmitter {
         this.stopPropagation = this.stopPropagation.bind(this);
         this.validateTextArea = this.validateTextArea.bind(this);
 
-        if (!this.isMobile) {
-            this.mouseenterHandler = this.mouseenterHandler.bind(this);
-            this.mouseleaveHandler = this.mouseleaveHandler.bind(this);
-        }
+        // if (!this.isMobile) {
+        //     this.mouseenterHandler = this.mouseenterHandler.bind(this);
+        //     this.mouseleaveHandler = this.mouseleaveHandler.bind(this);
+        // }
     }
 
     /**
@@ -384,10 +384,10 @@ class AnnotationDialog extends EventEmitter {
             annotationTextEl.addEventListener('focus', this.validateTextArea);
         }
 
-        if (!this.isMobile) {
-            this.element.addEventListener('mouseenter', this.mouseenterHandler);
-            this.element.addEventListener('mouseleave', this.mouseleaveHandler);
-        }
+        // if (!this.isMobile) {
+        //     this.element.addEventListener('mouseenter', this.mouseenterHandler);
+        //     this.element.addEventListener('mouseleave', this.mouseleaveHandler);
+        // }
     }
 
     /**
@@ -428,10 +428,10 @@ class AnnotationDialog extends EventEmitter {
             annotationTextEl.removeEventListener('focus', this.validateTextArea);
         }
 
-        if (!this.isMobile) {
-            this.element.removeEventListener('mouseenter', this.mouseenterHandler);
-            this.element.removeEventListener('mouseleave', this.mouseleaveHandler);
-        }
+        // if (!this.isMobile) {
+        //     this.element.removeEventListener('mouseenter', this.mouseenterHandler);
+        //     this.element.removeEventListener('mouseleave', this.mouseleaveHandler);
+        // }
     }
 
     /**
@@ -571,9 +571,9 @@ class AnnotationDialog extends EventEmitter {
                 break;
             // Clicking 'Cancel' button to cancel the annotation
             case constants.DATA_TYPE_CANCEL:
-                if (this.isMobile) {
-                    this.hide();
-                } else {
+                this.hide();
+
+                if (!this.isMobile) {
                     // Cancels + destroys the annotation thread
                     this.cancelAnnotation();
                 }
@@ -584,7 +584,8 @@ class AnnotationDialog extends EventEmitter {
                 break;
             // Canceling a reply
             case constants.DATA_TYPE_CANCEL_REPLY:
-                this.deactivateReply(true);
+                // this.deactivateReply(true);
+                this.hide();
                 break;
             // Clicking 'Post' button to create a reply annotation
             case constants.DATA_TYPE_POST_REPLY:

--- a/src/AnnotationThread.js
+++ b/src/AnnotationThread.js
@@ -357,11 +357,11 @@ class AnnotationThread extends EventEmitter {
         }
 
         this.element.addEventListener('click', this.showDialog);
-        this.element.addEventListener('mouseenter', this.showDialog);
+        // this.element.addEventListener('mouseenter', this.showDialog);
 
-        if (!this.isMobile) {
-            this.element.addEventListener('mouseleave', this.mouseoutHandler);
-        }
+        // if (!this.isMobile) {
+        //     this.element.addEventListener('mouseleave', this.mouseoutHandler);
+        // }
     }
 
     /**
@@ -376,11 +376,11 @@ class AnnotationThread extends EventEmitter {
         }
 
         this.element.removeEventListener('click', this.showDialog);
-        this.element.removeEventListener('mouseenter', this.showDialog);
+        // this.element.removeEventListener('mouseenter', this.showDialog);
 
-        if (!this.isMobile) {
-            this.element.removeEventListener('mouseleave', this.mouseoutHandler);
-        }
+        // if (!this.isMobile) {
+        //     this.element.removeEventListener('mouseleave', this.mouseoutHandler);
+        // }
     }
 
     /**

--- a/src/Annotator.scss
+++ b/src/Annotator.scss
@@ -183,15 +183,11 @@
         line-height: 13px;
         margin: 0;
         max-width: 250px;
-        min-height: 34px;
+        min-height: 68px;
         padding: 7px;
         resize: vertical;
-        transition: border-color linear .15s, box-shadow linear .1s, min-height .1s;
+        transition: border-color linear .15s, box-shadow linear .1s;
         width: 100%;
-
-        &.bp-is-active {
-            min-height: 68px;
-        }
 
         &.ba-invalid-input {
             border-color: fade-out($great-balls-of-fire, .5);

--- a/src/BoxAnnotations.js
+++ b/src/BoxAnnotations.js
@@ -19,7 +19,7 @@ const ANNOTATORS = [
         CONSTRUCTOR: DocAnnotator,
         VIEWER: ['Document', 'Presentation'],
         TYPE: [TYPES.point, TYPES.highlight, TYPES.highlight_comment, TYPES.draw],
-        DEFAULT_TYPES: [TYPES.point, TYPES.highlight, TYPES.highlight_comment]
+        DEFAULT_TYPES: [TYPES.point, TYPES.highlight, TYPES.highlight_comment, TYPES.draw]
     },
     {
         NAME: 'Image',

--- a/src/doc/DocAnnotator.js
+++ b/src/doc/DocAnnotator.js
@@ -415,10 +415,29 @@ class DocAnnotator extends Annotator {
             }
 
             // Desktop-only highlight listeners
-            if (!this.isMobile && (this.plainHighlightEnabled || this.commentHighlightEnabled)) {
-                this.annotatedElement.addEventListener('mousemove', this.getHighlightMouseMoveHandler());
-            }
+            // if (!this.isMobile && (this.plainHighlightEnabled || this.commentHighlightEnabled)) {
+            //     this.annotatedElement.addEventListener('mousemove', this.getHighlightMouseMoveHandler());
+            // }
         }
+
+        // Hide open threads when clicking on document
+        this.annotatedElement.addEventListener(
+            'mouseup',
+            (event) => {
+                if (util.isInDialog(event)) {
+                    return;
+                }
+
+                Object.keys(this.modeControllers).forEach((mode) => {
+                    this.modeControllers[mode].applyActionToThreads((thread) => {
+                        if (!util.isPending(thread.state)) {
+                            thread.hideDialog();
+                        }
+                    });
+                });
+            },
+            true /* Use Capture so this executes first */
+        );
 
         // Prevent highlight creation if annotating (or plain AND comment highlights) is disabled
         if (!this.permissions.canAnnotate || !(this.plainHighlightEnabled || this.commentHighlightEnabled)) {

--- a/src/doc/DocHighlightDialog.js
+++ b/src/doc/DocHighlightDialog.js
@@ -336,10 +336,10 @@ class DocHighlightDialog extends AnnotationDialog {
         this.element.addEventListener('mouseup', this.stopPropagation);
         this.element.addEventListener('wheel', this.stopPropagation);
 
-        if (!this.isMobile) {
-            this.element.addEventListener('mouseenter', this.mouseenterHandler);
-            this.element.addEventListener('mouseleave', this.mouseleaveHandler);
-        }
+        // if (!this.isMobile) {
+        //     this.element.addEventListener('mouseenter', this.mouseenterHandler);
+        //     this.element.addEventListener('mouseleave', this.mouseleaveHandler);
+        // }
     }
 
     /**
@@ -355,10 +355,10 @@ class DocHighlightDialog extends AnnotationDialog {
         this.element.removeEventListener('mouseup', this.stopPropagation);
         this.element.removeEventListener('wheel', this.stopPropagation);
 
-        if (!this.isMobile) {
-            this.element.removeEventListener('mouseenter', this.mouseenterHandler);
-            this.element.removeEventListener('mouseleave', this.mouseleaveHandler);
-        }
+        // if (!this.isMobile) {
+        //     this.element.removeEventListener('mouseenter', this.mouseenterHandler);
+        //     this.element.removeEventListener('mouseleave', this.mouseleaveHandler);
+        // }
     }
 
     /**

--- a/src/doc/DocHighlightThread.js
+++ b/src/doc/DocHighlightThread.js
@@ -172,6 +172,7 @@ class DocHighlightThread extends AnnotationThread {
         // so we can skip the is in highlight calculation
         if (!consumed && this.isOnHighlight(event)) {
             this.state = STATES.hover;
+            this.show();
             return true;
         }
 


### PR DESCRIPTION
- Remove min-height animation when opening dialog
- Remove hover to open/close dialogs, dialogs open when indicator is clicked and close when you click outside

TODO:
- Bug with drawing - once you create a drawing you cannot select it by clicking until page refresh
- Keep hover indicator for highlights, but require click to open dialog?
- Lots of cleanup