### PR TITLE
Fix: Don't save empty drawing threads

### DIFF
--- a/src/__tests__/util-test.js
+++ b/src/__tests__/util-test.js
@@ -825,5 +825,9 @@ describe('util', () => {
                 maxY: 1
             })).to.be.true;
         });
+
+        it('should return true for highlight annotations', () => {
+            expect(hasValidBoundaryCoordinates({ type: TYPES.highlight })).to.be.true;
+        })
     });
 });

--- a/src/__tests__/util-test.js
+++ b/src/__tests__/util-test.js
@@ -39,7 +39,8 @@ import {
     clearCanvas,
     replaceHeader,
     isInDialog,
-    focusTextArea
+    focusTextArea,
+    hasValidBoundaryCoordinates
 } from '../util';
 import {
     STATES,
@@ -805,6 +806,24 @@ describe('util', () => {
         it('should activate the textarea', () => {
             const el = document.createElement('div');
             expect(focusTextArea(el)).to.have.class(CLASS_ACTIVE);
+        });
+    });
+
+    describe('hasValidBoundaryCoordinates()', () => {
+        it('return true only if boundary coordinates are valid', () => {
+            expect(hasValidBoundaryCoordinates({})).to.be.false;
+            expect(hasValidBoundaryCoordinates({
+                minX: NaN,
+                minY: 1,
+                maxX: 1,
+                maxY: 1
+            })).to.be.false;
+            expect(hasValidBoundaryCoordinates({
+                minX: 1,
+                minY: 1,
+                maxX: 1,
+                maxY: 1
+            })).to.be.true;
         });
     });
 });

--- a/src/controllers/AnnotationModeController.js
+++ b/src/controllers/AnnotationModeController.js
@@ -1,6 +1,6 @@
 import rbush from 'rbush';
 import EventEmitter from 'events';
-import { insertTemplate, isPending, replaceHeader } from '../util';
+import { insertTemplate, isPending, replaceHeader, hasValidBoundaryCoordinates } from '../util';
 import {
     CLASS_HIDDEN,
     CLASS_ACTIVE,
@@ -207,7 +207,7 @@ class AnnotationModeController extends EventEmitter {
      * @return {void}
      */
     registerThread(thread) {
-        if (!thread || !thread.location) {
+        if (!thread || !thread.location || !hasValidBoundaryCoordinates(thread)) {
             return;
         }
 

--- a/src/controllers/DrawingModeController.js
+++ b/src/controllers/DrawingModeController.js
@@ -1,7 +1,14 @@
 import AnnotationModeController from './AnnotationModeController';
 import shell from './drawingShell.html';
 import DocDrawingThread from '../doc/DocDrawingThread';
-import { replaceHeader, enableElement, disableElement, eventToLocationHandler, clearCanvas } from '../util';
+import {
+    replaceHeader,
+    enableElement,
+    disableElement,
+    eventToLocationHandler,
+    clearCanvas,
+    hasValidBoundaryCoordinates
+} from '../util';
 import {
     TYPES,
     STATES,
@@ -306,7 +313,7 @@ class DrawingModeController extends AnnotationModeController {
      * @return {void}
      */
     saveThread(thread) {
-        if (!thread) {
+        if (!thread || !hasValidBoundaryCoordinates(thread)) {
             return;
         }
 

--- a/src/controllers/DrawingModeController.js
+++ b/src/controllers/DrawingModeController.js
@@ -17,7 +17,8 @@ import {
     SELECTOR_ANNOTATION_BUTTON_DRAW_UNDO,
     SELECTOR_ANNOTATION_BUTTON_DRAW_REDO,
     SELECTOR_DRAW_MODE_HEADER,
-    CLASS_ANNOTATION_LAYER_DRAW
+    CLASS_ANNOTATION_LAYER_DRAW,
+    THREAD_EVENT
 } from '../constants';
 
 class DrawingModeController extends AnnotationModeController {
@@ -107,6 +108,7 @@ class DrawingModeController extends AnnotationModeController {
         /* eslint-enable require-jsdoc */
 
         // Setup
+        this.hasPendingDrawing = false;
         const threadParams = this.annotator.getThreadParams([], {}, TYPES.draw);
         this.currentThread = new DocDrawingThread(threadParams);
         this.currentThread.addListener('threadevent', (data) => {
@@ -141,7 +143,10 @@ class DrawingModeController extends AnnotationModeController {
         });
 
         this.pushElementHandler(this.postButtonEl, 'click', () => {
-            this.saveThread(this.currentThread);
+            if (this.hasPendingDrawing) {
+                this.saveThread(this.currentThread);
+            }
+
             this.toggleMode();
         });
 
@@ -163,8 +168,12 @@ class DrawingModeController extends AnnotationModeController {
     handleThreadEvents(thread, data = {}) {
         const { eventData } = data;
         switch (data.event) {
+            case THREAD_EVENT.pending:
+                this.hasPendingDrawing = true;
+                break;
             case 'softcommit':
                 this.currentThread = undefined;
+                this.hasPendingDrawing = false;
                 this.saveThread(thread);
                 this.unbindListeners();
                 this.bindListeners();
@@ -183,6 +192,7 @@ class DrawingModeController extends AnnotationModeController {
                 if (thread.state === STATES.pending) {
                     // Soft delete, in-progress thread doesn't require a redraw or a delete on the server
                     // Clear in-progress thread and restart drawing
+                    this.hasPendingDrawing = false;
                     thread.destroy();
                     this.unbindListeners();
                     this.bindListeners();

--- a/src/controllers/DrawingModeController.js
+++ b/src/controllers/DrawingModeController.js
@@ -17,8 +17,7 @@ import {
     SELECTOR_ANNOTATION_BUTTON_DRAW_UNDO,
     SELECTOR_ANNOTATION_BUTTON_DRAW_REDO,
     SELECTOR_DRAW_MODE_HEADER,
-    CLASS_ANNOTATION_LAYER_DRAW,
-    THREAD_EVENT
+    CLASS_ANNOTATION_LAYER_DRAW
 } from '../constants';
 
 class DrawingModeController extends AnnotationModeController {
@@ -108,7 +107,6 @@ class DrawingModeController extends AnnotationModeController {
         /* eslint-enable require-jsdoc */
 
         // Setup
-        this.hasPendingDrawing = false;
         const threadParams = this.annotator.getThreadParams([], {}, TYPES.draw);
         this.currentThread = new DocDrawingThread(threadParams);
         this.currentThread.addListener('threadevent', (data) => {
@@ -143,7 +141,7 @@ class DrawingModeController extends AnnotationModeController {
         });
 
         this.pushElementHandler(this.postButtonEl, 'click', () => {
-            if (this.hasPendingDrawing) {
+            if (this.currentThread && this.currentThread.state === STATES.pending) {
                 this.saveThread(this.currentThread);
             }
 
@@ -168,12 +166,8 @@ class DrawingModeController extends AnnotationModeController {
     handleThreadEvents(thread, data = {}) {
         const { eventData } = data;
         switch (data.event) {
-            case THREAD_EVENT.pending:
-                this.hasPendingDrawing = true;
-                break;
             case 'softcommit':
                 this.currentThread = undefined;
-                this.hasPendingDrawing = false;
                 this.saveThread(thread);
                 this.unbindListeners();
                 this.bindListeners();
@@ -192,7 +186,6 @@ class DrawingModeController extends AnnotationModeController {
                 if (thread.state === STATES.pending) {
                     // Soft delete, in-progress thread doesn't require a redraw or a delete on the server
                     // Clear in-progress thread and restart drawing
-                    this.hasPendingDrawing = false;
                     thread.destroy();
                     this.unbindListeners();
                     this.bindListeners();

--- a/src/controllers/__tests__/AnnotationModeController-test.js
+++ b/src/controllers/__tests__/AnnotationModeController-test.js
@@ -272,6 +272,12 @@ describe('controllers/AnnotationModeController', () => {
             expect(controller.emit).to.not.be.called;
         });
 
+        it('should do nothing if thread has invalid boundary', () => {
+            controller.registerThread({ minX: NaN, minY: 1, maxX: 1, maxY: 1 });
+            controller.registerThread({ type: 'someType' });
+            expect(controller.emit).to.not.be.called;
+        });
+
         it('should create a new rbush for the thread\'s page location', () => {
             stubs.threadMock.expects('addListener').withArgs('threadevent', sinon.match.func);
 
@@ -550,7 +556,7 @@ describe('controllers/AnnotationModeController', () => {
                 removeAllListeners: () => {}
             };
             stubs.pendingMock = sandbox.mock(pendingThread);
-            controller.registerThread(pendingThread);
+            controller.threads[1].insert(pendingThread);
 
             stubs.threadMock.expects('destroy').never();
             stubs.pendingMock.expects('destroy');

--- a/src/controllers/__tests__/DrawingModeController-test.js
+++ b/src/controllers/__tests__/DrawingModeController-test.js
@@ -212,13 +212,6 @@ describe('controllers/DrawingModeController', () => {
             sandbox.stub(controller, 'updateUndoRedoButtonEls');
         });
 
-        it('should set hasPendingDrawing to true when the user begins drawing', () => {
-            controller.handleThreadEvents(stubs.thread, {
-                event: THREAD_EVENT.pending
-            });
-            expect(controller.hasPendingDrawing).to.be.true;
-        });
-
         it('should save thread on softcommit', () => {
             stubs.threadMock.expects('handleStart').never();
             controller.handleThreadEvents(stubs.thread, {
@@ -227,7 +220,6 @@ describe('controllers/DrawingModeController', () => {
             expect(controller.unbindListeners).to.be.called;
             expect(controller.bindListeners).to.be.called;
             expect(controller.saveThread).to.be.called;
-            expect(controller.hasPendingDrawing).to.be.false;
         });
 
         it('should start a new thread on pagechanged', () => {
@@ -267,7 +259,6 @@ describe('controllers/DrawingModeController', () => {
             expect(controller.saveThread).to.be.called;
             expect(controller.unbindListeners).to.be.called;
             expect(controller.bindListeners).to.be.called;
-            expect(controller.hasPendingDrawing).to.be.false;
             expect(thread2.handleStart).to.be.calledWith(data.eventData.location);
         });
 

--- a/src/controllers/__tests__/DrawingModeController-test.js
+++ b/src/controllers/__tests__/DrawingModeController-test.js
@@ -212,6 +212,13 @@ describe('controllers/DrawingModeController', () => {
             sandbox.stub(controller, 'updateUndoRedoButtonEls');
         });
 
+        it('should set hasPendingDrawing to true when the user begins drawing', () => {
+            controller.handleThreadEvents(stubs.thread, {
+                event: THREAD_EVENT.pending
+            });
+            expect(controller.hasPendingDrawing).to.be.true;
+        });
+
         it('should save thread on softcommit', () => {
             stubs.threadMock.expects('handleStart').never();
             controller.handleThreadEvents(stubs.thread, {
@@ -220,6 +227,7 @@ describe('controllers/DrawingModeController', () => {
             expect(controller.unbindListeners).to.be.called;
             expect(controller.bindListeners).to.be.called;
             expect(controller.saveThread).to.be.called;
+            expect(controller.hasPendingDrawing).to.be.false;
         });
 
         it('should start a new thread on pagechanged', () => {
@@ -259,6 +267,7 @@ describe('controllers/DrawingModeController', () => {
             expect(controller.saveThread).to.be.called;
             expect(controller.unbindListeners).to.be.called;
             expect(controller.bindListeners).to.be.called;
+            expect(controller.hasPendingDrawing).to.be.false;
             expect(thread2.handleStart).to.be.calledWith(data.eventData.location);
         });
 

--- a/src/controllers/__tests__/HighlightModeController-test.js
+++ b/src/controllers/__tests__/HighlightModeController-test.js
@@ -7,6 +7,7 @@ import {
     CLASS_ANNOTATION_MODE,
     THREAD_EVENT,
     STATES,
+    TYPES,
     CONTROLLER_EVENT,
     CLASS_ANNOTATION_LAYER_HIGHLIGHT
 } from '../../constants';
@@ -22,6 +23,7 @@ describe('controllers/HighlightModeController', () => {
         stubs.thread = {
             annotations: {},
             location: { page: 1 },
+            type: TYPES.highlight,
             show: () => {},
             addListener: () => {}
         };
@@ -115,7 +117,6 @@ describe('controllers/HighlightModeController', () => {
         beforeEach(() => {
             controller.annotatedElement = document.createElement('div');
             controller.annotatedElement.setAttribute('data-page-number', 1);
-
             sandbox.stub(util, 'clearCanvas');
         });
 
@@ -127,7 +128,7 @@ describe('controllers/HighlightModeController', () => {
 
         it('should render the annotations on the specified page', () => {
             controller.registerThread(stubs.thread);
-            stubs.threadMock.expects('show').once();
+            stubs.threadMock.expects('show');
             controller.renderPage(1);
             expect(util.clearCanvas).to.be.called;
         });

--- a/src/doc/DocDrawingThread.js
+++ b/src/doc/DocDrawingThread.js
@@ -5,7 +5,8 @@ import {
     STATES,
     DRAW_STATES,
     CLASS_ANNOTATION_LAYER_DRAW,
-    CLASS_ANNOTATION_LAYER_DRAW_IN_PROGRESS
+    CLASS_ANNOTATION_LAYER_DRAW_IN_PROGRESS,
+    THREAD_EVENT
 } from '../constants';
 import { getBrowserCoordinatesFromLocation, getContext, getPageEl } from './docUtil';
 import { createLocation, getScale } from '../util';
@@ -92,6 +93,7 @@ class DocDrawingThread extends DrawingThread {
 
         // Start drawing rendering
         this.lastAnimationRequestId = window.requestAnimationFrame(this.render);
+        this.emit(THREAD_EVENT.pending);
     }
 
     /**

--- a/src/doc/DocDrawingThread.js
+++ b/src/doc/DocDrawingThread.js
@@ -5,8 +5,7 @@ import {
     STATES,
     DRAW_STATES,
     CLASS_ANNOTATION_LAYER_DRAW,
-    CLASS_ANNOTATION_LAYER_DRAW_IN_PROGRESS,
-    THREAD_EVENT
+    CLASS_ANNOTATION_LAYER_DRAW_IN_PROGRESS
 } from '../constants';
 import { getBrowserCoordinatesFromLocation, getContext, getPageEl } from './docUtil';
 import { createLocation, getScale } from '../util';
@@ -93,7 +92,7 @@ class DocDrawingThread extends DrawingThread {
 
         // Start drawing rendering
         this.lastAnimationRequestId = window.requestAnimationFrame(this.render);
-        this.emit(THREAD_EVENT.pending);
+        this.state = STATES.pending;
     }
 
     /**

--- a/src/doc/__tests__/DocDrawingThread-test.js
+++ b/src/doc/__tests__/DocDrawingThread-test.js
@@ -97,26 +97,26 @@ describe('doc/DocDrawingThread', () => {
             sandbox.stub(thread, 'onPageChange');
             sandbox.stub(docUtil, 'getPageEl').returns(context);
             stubs.pageChange = sandbox.stub(thread, 'hasPageChanged');
-            sandbox.stub(thread, 'emit');
         });
 
         it('should do nothing if no location is provided', () => {
             thread.handleStart();
             expect(stubs.pageChange).to.not.be.called;
-            expect(thread.emit).to.not.be.calledWith(THREAD_EVENT.pending);
+            expect(thread.state).to.equal(STATES.inactive);
         });
 
         it('should set the drawingFlag, pendingPath, and context if they do not exist', () => {
             stubs.pageChange.returns(false);
             thread.drawingFlag = DRAW_STATES.idle;
             thread.pendingPath = undefined;
+            expect(thread.state).to.equal(STATES.inactive);
             thread.handleStart(thread.location);
 
             expect(window.requestAnimationFrame).to.be.called;
             expect(thread.drawingFlag).to.equal(DRAW_STATES.drawing);
             expect(thread.hasPageChanged).to.be.called;
             expect(thread.pendingPath).to.be.an.instanceof(DrawingPath);
-            expect(thread.emit).to.be.calledWith(THREAD_EVENT.pending);
+            expect(thread.state).to.equal(STATES.pending);
         });
 
         it('should commit the thread when the page changes', () => {
@@ -129,7 +129,7 @@ describe('doc/DocDrawingThread', () => {
             expect(thread.hasPageChanged).to.be.called;
             expect(thread.onPageChange).to.be.called;
             expect(thread.checkAndHandleScaleUpdate).to.not.be.called;
-            expect(thread.emit).to.not.be.calledWith(THREAD_EVENT.pending);
+            expect(thread.state).to.equal(STATES.inactive);
         });
 
     });

--- a/src/doc/__tests__/DocDrawingThread-test.js
+++ b/src/doc/__tests__/DocDrawingThread-test.js
@@ -6,6 +6,7 @@ import AnnotationThread from '../../AnnotationThread';
 import DrawingPath from '../../drawing/DrawingPath';
 import {
     DRAW_STATES,
+    THREAD_EVENT,
     STATES
 } from '../../constants';
 
@@ -96,11 +97,13 @@ describe('doc/DocDrawingThread', () => {
             sandbox.stub(thread, 'onPageChange');
             sandbox.stub(docUtil, 'getPageEl').returns(context);
             stubs.pageChange = sandbox.stub(thread, 'hasPageChanged');
+            sandbox.stub(thread, 'emit');
         });
 
         it('should do nothing if no location is provided', () => {
             thread.handleStart();
             expect(stubs.pageChange).to.not.be.called;
+            expect(thread.emit).to.not.be.calledWith(THREAD_EVENT.pending);
         });
 
         it('should set the drawingFlag, pendingPath, and context if they do not exist', () => {
@@ -113,6 +116,7 @@ describe('doc/DocDrawingThread', () => {
             expect(thread.drawingFlag).to.equal(DRAW_STATES.drawing);
             expect(thread.hasPageChanged).to.be.called;
             expect(thread.pendingPath).to.be.an.instanceof(DrawingPath);
+            expect(thread.emit).to.be.calledWith(THREAD_EVENT.pending);
         });
 
         it('should commit the thread when the page changes', () => {
@@ -125,6 +129,7 @@ describe('doc/DocDrawingThread', () => {
             expect(thread.hasPageChanged).to.be.called;
             expect(thread.onPageChange).to.be.called;
             expect(thread.checkAndHandleScaleUpdate).to.not.be.called;
+            expect(thread.emit).to.not.be.calledWith(THREAD_EVENT.pending);
         });
 
     });

--- a/src/drawing/DrawingThread.js
+++ b/src/drawing/DrawingThread.js
@@ -59,6 +59,9 @@ class DrawingThread extends AnnotationThread {
     constructor(data) {
         super(data);
 
+        // Default drawing thread state to inactive until user begins drawing
+        this.state = STATES.inactive;
+
         this.render = this.render.bind(this);
         this.handleStart = this.handleStart.bind(this);
         this.handleMove = this.handleMove.bind(this);

--- a/src/drawing/__tests__/DrawingThread-test.js
+++ b/src/drawing/__tests__/DrawingThread-test.js
@@ -31,6 +31,7 @@ describe('drawing/DrawingThread', () => {
             threadID: 2,
             type: 'draw'
         });
+        expect(thread.state).to.equal(STATES.inactive);
     });
 
     afterEach(() => {

--- a/src/util.js
+++ b/src/util.js
@@ -512,14 +512,15 @@ export function isPending(threadState) {
  */
 export function hasValidBoundaryCoordinates(thread) {
     return !!(
-        thread.minX &&
-        !Number.isNaN(thread.minX) &&
-        thread.minY &&
-        !Number.isNaN(thread.minY) &&
-        thread.maxX &&
-        !Number.isNaN(thread.maxX) &&
-        thread.maxY &&
-        !Number.isNaN(thread.maxY)
+        isHighlightAnnotation(thread.type) ||
+        (thread.minX &&
+            !Number.isNaN(thread.minX) &&
+            thread.minY &&
+            !Number.isNaN(thread.minY) &&
+            thread.maxX &&
+            !Number.isNaN(thread.maxX) &&
+            thread.maxY &&
+            !Number.isNaN(thread.maxY))
     );
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -511,17 +511,7 @@ export function isPending(threadState) {
  * @return {boolean} Whether or not the annotation has valid boundary coordinates
  */
 export function hasValidBoundaryCoordinates(thread) {
-    return !!(
-        isHighlightAnnotation(thread.type) ||
-        (thread.minX &&
-            !Number.isNaN(thread.minX) &&
-            thread.minY &&
-            !Number.isNaN(thread.minY) &&
-            thread.maxX &&
-            !Number.isNaN(thread.maxX) &&
-            thread.maxY &&
-            !Number.isNaN(thread.maxY))
-    );
+    return !!(isHighlightAnnotation(thread.type) || (thread.minX && thread.minY && thread.maxX && thread.maxY));
 }
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -505,6 +505,25 @@ export function isPending(threadState) {
 }
 
 /**
+ * Checks whether an annotation thread has valid min/max boundary coordinates
+ *
+ * @param {AnnotationThread} thread Annotation thread location object
+ * @return {boolean} Whether or not the annotation has valid boundary coordinates
+ */
+export function hasValidBoundaryCoordinates(thread) {
+    return !!(
+        thread.minX &&
+        !Number.isNaN(thread.minX) &&
+        thread.minY &&
+        !Number.isNaN(thread.minY) &&
+        thread.maxX &&
+        !Number.isNaN(thread.maxX) &&
+        thread.maxY &&
+        !Number.isNaN(thread.maxY)
+    );
+}
+
+/**
  * Checks whether a point annotation thread has the correct location params
  *
  * @param {Object} location Point annotation thread location object


### PR DESCRIPTION
- Fixes issue where users couldn't select drawings after pressing the "Done" button
- Drawing handlers require a blank temporary thread in order to actually start/stop drawing. This thread is not yet saved into the API and will not have valid location information until the user actually begins drawing. This prevents the controller from saving that empty thread until it contains valid location information.
- Validates min/max boundary coordinates for annotation threads