### PR TITLE
Chore: Don't allow selection of saved thread in draw mode

### DIFF
--- a/src/controllers/DrawingModeController.js
+++ b/src/controllers/DrawingModeController.js
@@ -217,7 +217,8 @@ class DrawingModeController extends AnnotationModeController {
      */
     handleSelection(event) {
         // NOTE: @jpress This is a workaround when buttons are not given precedence in the event chain
-        if (!event || (event.target && event.target.nodeName === 'BUTTON')) {
+        const hasPendingDrawing = this.currentThread && this.currentThread.state === STATES.pending;
+        if (!event || (event.target && event.target.nodeName === 'BUTTON') || hasPendingDrawing) {
             return;
         }
 

--- a/src/controllers/__tests__/DrawingModeController-test.js
+++ b/src/controllers/__tests__/DrawingModeController-test.js
@@ -4,6 +4,7 @@ import DrawingModeController from '../DrawingModeController';
 import * as util from '../../util';
 import {
     TYPES,
+    STATES,
     THREAD_EVENT,
     SELECTOR_ANNOTATION_BUTTON_DRAW_CANCEL,
     SELECTOR_ANNOTATION_BUTTON_DRAW_POST,
@@ -334,6 +335,12 @@ describe('controllers/DrawingModeController', () => {
             expect(stubs.select).to.not.be.called;
             expect(stubs.event.stopPropagation).to.be.called;
         });
+
+        it('should do nothing with while drawing a new annotation event', () => {
+            controller.currentThread = { state: STATES.pending };
+            controller.handleSelection(stubs.event);
+            expect(stubs.intersecting).to.not.be.called;
+        })
 
         it('should call select on an thread found in the data store', () => {
             controller.handleSelection(stubs.event);


### PR DESCRIPTION
Currently users are able to select existing drawings while in the process of drawing a new annotation. This can cause an additional annotation dialog to stay open in the background in addition to the dialog for the new unsaved drawing. This commit does not trigger any saved annotation dialogs while drawing.