### PR TITLE
Fix: Cleanup hiding/closing of the mobile dialog

### DIFF
--- a/src/AnnotationDialog.js
+++ b/src/AnnotationDialog.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 import * as util from './util';
 import * as constants from './constants';
-import { ICON_CLOSE, ICON_DELETE } from './icons/icons';
+import { ICON_DELETE } from './icons/icons';
 
 const POINT_ANNOTATION_ICON_HEIGHT = 31;
 const POINT_ANNOTATION_ICON_DOT_HEIGHT = 8;
@@ -63,8 +63,6 @@ class AnnotationDialog extends EventEmitter {
         if (!this.isMobile) {
             this.mouseenterHandler = this.mouseenterHandler.bind(this);
             this.mouseleaveHandler = this.mouseleaveHandler.bind(this);
-        } else {
-            this.hideMobileDialog = this.hideMobileDialog.bind(this);
         }
     }
 
@@ -193,15 +191,7 @@ class AnnotationDialog extends EventEmitter {
             this.dialogEl.parentNode.removeChild(this.dialogEl);
         }
 
-        this.element.classList.remove(constants.CLASS_ANIMATE_DIALOG);
-
         // Clear annotations from dialog
-        this.element.innerHTML = `
-            <div class="${constants.CLASS_MOBILE_DIALOG_HEADER}">
-                <button class="${constants.CLASS_DIALOG_CLOSE}">${ICON_CLOSE}</button>
-            </div>`.trim();
-        this.element.classList.remove(constants.CLASS_ANNOTATION_PLAIN_HIGHLIGHT);
-
         util.hideElement(this.element);
         this.unbindDOMListeners();
 
@@ -387,14 +377,6 @@ class AnnotationDialog extends EventEmitter {
             this.element.addEventListener('click', this.clickHandler);
             this.element.addEventListener('mouseenter', this.mouseenterHandler);
             this.element.addEventListener('mouseleave', this.mouseleaveHandler);
-            return;
-        }
-
-        const dialogCloseButtonEl = this.element.querySelector(constants.SELECTOR_DIALOG_CLOSE);
-        dialogCloseButtonEl.addEventListener('click', this.hideMobileDialog);
-
-        if (this.hasTouch) {
-            dialogCloseButtonEl.addEventListener('touchstart', this.hideMobileDialog);
         }
     }
 
@@ -444,14 +426,6 @@ class AnnotationDialog extends EventEmitter {
             this.element.removeEventListener('click', this.clickHandler);
             this.element.removeEventListener('mouseenter', this.mouseenterHandler);
             this.element.removeEventListener('mouseleave', this.mouseleaveHandler);
-            return;
-        }
-
-        const dialogCloseButtonEl = this.element.querySelector(constants.SELECTOR_DIALOG_CLOSE);
-        dialogCloseButtonEl.removeEventListener('click', this.hideMobileDialog);
-
-        if (this.hasTouch) {
-            dialogCloseButtonEl.removeEventListener('touchstart', this.hideMobileDialog);
         }
     }
 
@@ -590,14 +564,11 @@ class AnnotationDialog extends EventEmitter {
             case constants.DATA_TYPE_POST:
                 this.postAnnotation();
                 break;
-            // Clicking 'Cancel' button to cancel the annotation
+            // Clicking 'Cancel' button to cancel the annotation OR
+            // Clicking 'X' button on mobile dialog to close
             case constants.DATA_TYPE_CANCEL:
-                if (this.isMobile) {
-                    this.hide();
-                } else {
-                    // Cancels + destroys the annotation thread
-                    this.cancelAnnotation();
-                }
+            case constants.DATA_TYPE_MOBILE_CLOSE:
+                this.cancelAnnotation();
                 break;
             // Clicking inside reply text area
             case constants.DATA_TYPE_REPLY_TEXTAREA:
@@ -620,10 +591,9 @@ class AnnotationDialog extends EventEmitter {
                 this.hideDeleteConfirmation(annotationID);
                 break;
             // Clicking 'Delete' button to confirm deletion
-            case constants.DATA_TYPE_CONFIRM_DELETE: {
+            case constants.DATA_TYPE_CONFIRM_DELETE:
                 this.deleteAnnotation(annotationID);
                 break;
-            }
 
             default:
                 break;

--- a/src/AnnotationDialog.js
+++ b/src/AnnotationDialog.js
@@ -193,6 +193,7 @@ class AnnotationDialog extends EventEmitter {
 
         // Clear annotations from dialog
         util.hideElement(this.element);
+        this.element = util.regenerateMobileDialog();
         this.unbindDOMListeners();
 
         // Cancel any unsaved annotations

--- a/src/AnnotationDialog.js
+++ b/src/AnnotationDialog.js
@@ -193,7 +193,7 @@ class AnnotationDialog extends EventEmitter {
 
         // Clear annotations from dialog
         util.hideElement(this.element);
-        this.element = util.regenerateMobileDialog();
+        this.element = util.generateMobileDialogEl();
         this.unbindDOMListeners();
 
         // Cancel any unsaved annotations

--- a/src/AnnotationDialog.js
+++ b/src/AnnotationDialog.js
@@ -178,7 +178,7 @@ class AnnotationDialog extends EventEmitter {
     }
 
     /**
-     * Hides and resets the shared mobile dialog.
+     * Hides the shared mobile dialog.
      *
      * @return {void}
      */

--- a/src/AnnotationThread.js
+++ b/src/AnnotationThread.js
@@ -438,6 +438,7 @@ class AnnotationThread extends EventEmitter {
      */
     cancelUnsavedAnnotation() {
         if (!util.isPending(this.state)) {
+            this.hideDialog();
             return;
         }
 

--- a/src/Annotator.js
+++ b/src/Annotator.js
@@ -269,7 +269,7 @@ class Annotator extends EventEmitter {
      * @return {void}
      */
     setupMobileDialog() {
-        this.mobileDialogEl = util.regenerateMobileDialog();
+        this.mobileDialogEl = util.generateMobileDialogEl();
         this.mobileDialogEl.setAttribute('data-type', DATA_TYPE_ANNOTATION_DIALOG);
         this.mobileDialogEl.classList.add(CLASS_MOBILE_ANNOTATION_DIALOG);
         this.mobileDialogEl.classList.add(CLASS_ANNOTATION_DIALOG);
@@ -283,7 +283,7 @@ class Annotator extends EventEmitter {
      *
      * @return {void}
      */
-    resetMobileDialog() {
+    removeThreadFromSharedDialog() {
         if (!this.mobileDialogEl || this.mobileDialogEl.classList.contains(CLASS_HIDDEN)) {
             return;
         }
@@ -658,7 +658,7 @@ class Annotator extends EventEmitter {
     handleControllerEvents(data) {
         switch (data.event) {
             case CONTROLLER_EVENT.resetMobileDialog:
-                this.resetMobileDialog();
+                this.removeThreadFromSharedDialog();
                 break;
             case CONTROLLER_EVENT.toggleMode:
                 this.toggleAnnotationMode(data.mode);

--- a/src/Annotator.js
+++ b/src/Annotator.js
@@ -1,7 +1,6 @@
 import EventEmitter from 'events';
 import AnnotationService from './AnnotationService';
 import * as util from './util';
-import { ICON_CLOSE } from './icons/icons';
 import './Annotator.scss';
 import {
     CLASS_HIDDEN,
@@ -9,7 +8,6 @@ import {
     CLASS_MOBILE_ANNOTATION_DIALOG,
     CLASS_ANNOTATION_DIALOG,
     CLASS_MOBILE_DIALOG_HEADER,
-    CLASS_DIALOG_CLOSE,
     ID_MOBILE_ANNOTATION_DIALOG,
     TYPES,
     STATES,
@@ -17,8 +15,6 @@ import {
     ANNOTATOR_EVENT,
     CONTROLLER_EVENT
 } from './constants';
-
-const MOBILE_DIALOG_CLOSE = 'mobile-dialog-close';
 
 class Annotator extends EventEmitter {
     //--------------------------------------------------------------------------
@@ -273,21 +269,13 @@ class Annotator extends EventEmitter {
      * @return {void}
      */
     setupMobileDialog() {
-        // Generate HTML of dialog
-        this.mobileDialogEl = document.createElement('div');
+        this.mobileDialogEl = util.regenerateMobileDialog();
         this.mobileDialogEl.setAttribute('data-type', DATA_TYPE_ANNOTATION_DIALOG);
         this.mobileDialogEl.classList.add(CLASS_MOBILE_ANNOTATION_DIALOG);
         this.mobileDialogEl.classList.add(CLASS_ANNOTATION_DIALOG);
         this.mobileDialogEl.classList.add(CLASS_HIDDEN);
         this.mobileDialogEl.id = ID_MOBILE_ANNOTATION_DIALOG;
         this.container.appendChild(this.mobileDialogEl);
-
-        const mobileHeader = document.createElement('div');
-        mobileHeader.classList.add(CLASS_MOBILE_DIALOG_HEADER);
-        this.mobileDialogEl.appendChild(mobileHeader);
-
-        const closeBtn = util.generateBtn([CLASS_DIALOG_CLOSE], MOBILE_DIALOG_CLOSE, ICON_CLOSE, MOBILE_DIALOG_CLOSE);
-        mobileHeader.appendChild(closeBtn);
     }
 
     /**

--- a/src/__tests__/AnnotationDialog-test.js
+++ b/src/__tests__/AnnotationDialog-test.js
@@ -208,7 +208,7 @@ describe('AnnotationDialog', () => {
             expect(stubs.hide).to.not.be.called;
         });
 
-        it('should hide and reset the mobile annotations dialog', () => {
+        it('should hide the mobile annotations dialog', () => {
             dialog.element = document.querySelector(constants.SELECTOR_MOBILE_ANNOTATION_DIALOG);
             stubs.hide = sandbox.stub(util, 'hideElement');
             stubs.unbind = sandbox.stub(dialog, 'unbindDOMListeners');
@@ -219,13 +219,6 @@ describe('AnnotationDialog', () => {
             expect(stubs.hide).to.be.called;
             expect(stubs.unbind).to.be.called;
             expect(stubs.cancel).to.be.called;
-            expect(dialog.element.classList.contains(CLASS_ANIMATE_DIALOG)).to.be.false;
-        });
-
-        it('should remove the animation class', () => {
-            dialog.element = document.querySelector(constants.SELECTOR_MOBILE_ANNOTATION_DIALOG);
-            dialog.hideMobileDialog();
-            expect(dialog.element.classList.contains(CLASS_ANIMATE_DIALOG)).to.be.false;
         });
 
         it('should cancel unsaved annotations only if the dialog does not have annotations', () => {
@@ -733,53 +726,47 @@ describe('AnnotationDialog', () => {
         });
 
         it('should post annotation when post annotation button is clicked', () => {
-            stubs.findClosest.returns(constants.CLASS_ANNOTATION_BUTTON_POST);
+            stubs.findClosest.returns(constants.DATA_TYPE_POST);
 
             dialog.clickHandler(stubs.event);
             expect(stubs.post).to.be.called;
         });
 
         it('should cancel annotation when cancel annotation button is clicked', () => {
-            stubs.findClosest.returns(constants.CLASS_ANNOTATION_BUTTON_CANCEL);
-            dialog.isMobile = false;
-
+            stubs.findClosest.returns(constants.DATA_TYPE_CANCEL);
             dialog.clickHandler(stubs.event);
             expect(stubs.cancel).to.be.called;
-            expect(stubs.hideMobile).to.not.be.called;
         });
 
-        it('should only hide the mobile dialog when the cancel annotation button is clicked on mobile', () => {
-            stubs.findClosest.returns(constants.CLASS_ANNOTATION_BUTTON_CANCEL);
-            dialog.isMobile = true;
-
+        it('should cancel annotation when mobile dialog close button is clicked', () => {
+            stubs.findClosest.returns(constants.DATA_TYPE_MOBILE_CLOSE);
             dialog.clickHandler(stubs.event);
-            expect(stubs.cancel).to.not.be.called;
-            expect(stubs.hideMobile).to.be.called;
+            expect(stubs.cancel).to.be.called;
         });
 
         it('should activate reply area when textarea is clicked', () => {
-            stubs.findClosest.returns(CLASS_REPLY_TEXTAREA);
+            stubs.findClosest.returns(constants.DATA_TYPE_REPLY_TEXTAREA);
 
             dialog.clickHandler(stubs.event);
             expect(stubs.activate).to.be.called;
         });
 
         it('should deactivate reply area when cancel reply button is clicked', () => {
-            stubs.findClosest.returns('cancel-reply-btn');
+            stubs.findClosest.returns(constants.DATA_TYPE_CANCEL_REPLY);
 
             dialog.clickHandler(stubs.event);
             expect(stubs.deactivate).to.be.calledWith(true);
         });
 
         it('should post reply when post reply button is clicked', () => {
-            stubs.findClosest.returns('post-reply-btn');
+            stubs.findClosest.returns(constants.DATA_TYPE_POST_REPLY);
 
             dialog.clickHandler(stubs.event);
             expect(stubs.reply).to.be.called;
         });
 
         it('should show delete confirmation when delete button is clicked', () => {
-            stubs.findClosest.onFirstCall().returns('delete-btn');
+            stubs.findClosest.onFirstCall().returns(constants.DATA_TYPE_DELETE);
             stubs.findClosest.onSecondCall().returns('someID');
 
             dialog.clickHandler(stubs.event);
@@ -787,7 +774,7 @@ describe('AnnotationDialog', () => {
         });
 
         it('should cancel deletion when cancel delete button is clicked', () => {
-            stubs.findClosest.onFirstCall().returns(CLASS_CANCEL_DELETE);
+            stubs.findClosest.onFirstCall().returns(constants.DATA_TYPE_CANCEL_DELETE);
             stubs.findClosest.onSecondCall().returns('someID');
 
             dialog.clickHandler(stubs.event);
@@ -795,7 +782,7 @@ describe('AnnotationDialog', () => {
         });
 
         it('should confirm deletion when confirm delete button is clicked', () => {
-            stubs.findClosest.onFirstCall().returns('confirm-delete-btn');
+            stubs.findClosest.onFirstCall().returns(constants.DATA_TYPE_CONFIRM_DELETE);
             stubs.findClosest.onSecondCall().returns('someID');
 
             dialog.clickHandler(stubs.event);

--- a/src/__tests__/AnnotationThread-test.js
+++ b/src/__tests__/AnnotationThread-test.js
@@ -743,27 +743,26 @@ describe('AnnotationThread', () => {
     });
 
     describe('cancelUnsavedAnnotation()', () => {
-        it('should only destroy thread if on a mobile browser or in a pending/pending-active state', () => {
+        it('should destroy thread if in a pending/pending-active state', () => {
             sandbox.stub(thread, 'destroy');
+            sandbox.stub(thread, 'hideDialog');
+            stubs.isPending = sandbox.stub(util, 'isPending').returns(true);
 
-            // mobile
-            thread.isMobile = true;
             thread.cancelUnsavedAnnotation();
             expect(thread.destroy).to.be.called;
             expect(thread.emit).to.be.calledWith(THREAD_EVENT.cancel);
+            expect(thread.hideDialog).to.not.be.called;
+        });
 
-            // 'pending' state
-            thread.isMobile = false;
-            thread.state = STATES.pending;
-            thread.cancelUnsavedAnnotation();
-            expect(thread.destroy).to.be.called;
-            expect(thread.emit).to.be.calledWith(THREAD_EVENT.cancel);
+        it('should not destroy thread if not in a pending/pending-active state', () => {
+            sandbox.stub(thread, 'destroy');
+            sandbox.stub(thread, 'hideDialog');
+            stubs.isPending = sandbox.stub(util, 'isPending').returns(false);
 
-            // 'pending-active' state
-            thread.state = STATES.pending_active;
             thread.cancelUnsavedAnnotation();
-            expect(thread.destroy).to.be.called;
-            expect(thread.emit).to.be.calledWith(THREAD_EVENT.cancel);
+            expect(thread.destroy).to.not.be.called;
+            expect(thread.emit).to.not.be.calledWith(THREAD_EVENT.cancel);
+            expect(thread.hideDialog).to.be.called;
         });
     });
 

--- a/src/__tests__/Annotator-test.js
+++ b/src/__tests__/Annotator-test.js
@@ -164,14 +164,14 @@ describe('Annotator', () => {
         });
     });
 
-    describe('resetMobileDialog()', () => {
+    describe('removeThreadFromSharedDialog()', () => {
         beforeEach(() => {
             sandbox.stub(util, 'hideElement');
             sandbox.stub(util, 'showElement');
         });
 
         it('should do nothing if the mobile dialog does not exist or is hidden', () => {
-            annotator.resetMobileDialog();
+            annotator.removeThreadFromSharedDialog();
             expect(util.hideElement).to.not.be.called;
 
             annotator.mobileDialogEl = {
@@ -181,7 +181,7 @@ describe('Annotator', () => {
                 removeChild: sandbox.stub(),
                 lastChild: {}
             };
-            annotator.resetMobileDialog();
+            annotator.removeThreadFromSharedDialog();
             expect(util.hideElement).to.not.be.called;
         });
 
@@ -189,7 +189,7 @@ describe('Annotator', () => {
             annotator.mobileDialogEl = document.createElement('div');
             annotator.mobileDialogEl.appendChild(document.createElement('div'));
 
-            annotator.resetMobileDialog();
+            annotator.removeThreadFromSharedDialog();
             expect(util.hideElement).to.be.called;
             expect(util.showElement).to.be.called;
             expect(annotator.mobileDialogEl.children.length).to.equal(0);
@@ -526,10 +526,10 @@ describe('Annotator', () => {
             });
 
             it('should reset mobile annotation dialog on resetMobileDialog', () => {
-                sandbox.stub(annotator, 'resetMobileDialog');
+                sandbox.stub(annotator, 'removeThreadFromSharedDialog');
                 data.event = CONTROLLER_EVENT.resetMobileDialog;
                 annotator.handleControllerEvents(data);
-                expect(annotator.resetMobileDialog).to.be.called;
+                expect(annotator.removeThreadFromSharedDialog).to.be.called;
             });
 
             it('should toggle annotation mode on togglemode', () => {

--- a/src/__tests__/util-test.js
+++ b/src/__tests__/util-test.js
@@ -836,9 +836,9 @@ describe('util', () => {
         })
     });
 
-    describe('regenerateMobileDialog()', () => {
+    describe('generateMobileDialogEl()', () => {
         it('should return a blank mobile dialog', () => {
-            const el = regenerateMobileDialog();
+            const el = generateMobileDialogEl();
             expect(el).to.have.descendant(`.${CLASS_MOBILE_DIALOG_HEADER}`);
             expect(el).to.have.descendant(`.${CLASS_DIALOG_CLOSE}`);
             expect(el).to.not.have.class(`.${CLASS_ANNOTATION_PLAIN_HIGHLIGHT}`);

--- a/src/__tests__/util-test.js
+++ b/src/__tests__/util-test.js
@@ -40,7 +40,8 @@ import {
     replaceHeader,
     isInDialog,
     focusTextArea,
-    hasValidBoundaryCoordinates
+    hasValidBoundaryCoordinates,
+    regenerateMobileDialog
 } from '../util';
 import {
     STATES,
@@ -49,7 +50,11 @@ import {
     SELECTOR_ANNOTATION_COMMENT_TEXT,
     SELECTOR_ANNOTATION_DIALOG,
     SELECTOR_ANNOTATION_CARET,
-    CLASS_ACTIVE
+    CLASS_ACTIVE,
+    CLASS_MOBILE_DIALOG_HEADER,
+    CLASS_DIALOG_CLOSE,
+    CLASS_ANNOTATION_PLAIN_HIGHLIGHT,
+    CLASS_ANIMATE_DIALOG
 } from '../constants';
 
 const DIALOG_WIDTH = 81;
@@ -829,5 +834,15 @@ describe('util', () => {
         it('should return true for highlight annotations', () => {
             expect(hasValidBoundaryCoordinates({ type: TYPES.highlight })).to.be.true;
         })
+    });
+
+    describe('regenerateMobileDialog()', () => {
+        it('should return a blank mobile dialog', () => {
+            const el = regenerateMobileDialog();
+            expect(el).to.have.descendant(`.${CLASS_MOBILE_DIALOG_HEADER}`);
+            expect(el).to.have.descendant(`.${CLASS_DIALOG_CLOSE}`);
+            expect(el).to.not.have.class(`.${CLASS_ANNOTATION_PLAIN_HIGHLIGHT}`);
+            expect(el).to.not.have.class(`.${CLASS_ANIMATE_DIALOG}`);
+        });
     });
 });

--- a/src/__tests__/util-test.js
+++ b/src/__tests__/util-test.js
@@ -41,7 +41,7 @@ import {
     isInDialog,
     focusTextArea,
     hasValidBoundaryCoordinates,
-    regenerateMobileDialog
+    generateMobileDialogEl
 } from '../util';
 import {
     STATES,

--- a/src/constants.js
+++ b/src/constants.js
@@ -73,6 +73,7 @@ export const DATA_TYPE_POST_REPLY = 'post-reply-btn';
 export const DATA_TYPE_DELETE = 'delete-btn';
 export const DATA_TYPE_CANCEL_DELETE = 'cancel-delete-btn';
 export const DATA_TYPE_CONFIRM_DELETE = 'confirm-delete-btn';
+export const DATA_TYPE_MOBILE_CLOSE = 'mobile-dialog-close-btn';
 
 export const SECTION_CREATE = '[data-section="create"]';
 export const SECTION_SHOW = '[data-section="show"]';

--- a/src/doc/CreateHighlightDialog.js
+++ b/src/doc/CreateHighlightDialog.js
@@ -280,9 +280,11 @@ class CreateHighlightDialog extends CreateAnnotationDialog {
         this.buttonsEl = highlightDialogEl.querySelector(SELECTOR_HIGHLIGHT_BTNS);
 
         // Stop interacting with this element from triggering outside actions
-        this.containerEl.addEventListener('click', this.stopPropagation);
-        this.containerEl.addEventListener('mouseup', this.stopPropagation);
-        this.containerEl.addEventListener('dblclick', this.stopPropagation);
+        if (!this.isMobile) {
+            this.containerEl.addEventListener('click', this.stopPropagation);
+            this.containerEl.addEventListener('mouseup', this.stopPropagation);
+            this.containerEl.addEventListener('dblclick', this.stopPropagation);
+        }
 
         // Events for highlight button
         if (this.allowHighlight) {

--- a/src/doc/DocAnnotator.js
+++ b/src/doc/DocAnnotator.js
@@ -474,13 +474,13 @@ class DocAnnotator extends Annotator {
      *
      * @return {void}
      */
-    resetMobileDialog() {
+    removeThreadFromSharedDialog() {
         if (!this.mobileDialogEl) {
             return;
         }
 
         this.mobileDialogEl.classList.remove(CLASS_ANNOTATION_PLAIN_HIGHLIGHT);
-        super.resetMobileDialog();
+        super.removeThreadFromSharedDialog();
     }
 
     /**
@@ -937,7 +937,7 @@ class DocAnnotator extends Annotator {
         if (this.activeThread) {
             this.activeThread.show();
         } else if (this.isMobile) {
-            this.resetMobileDialog();
+            this.removeThreadFromSharedDialog();
         }
     }
 

--- a/src/doc/DocHighlightThread.js
+++ b/src/doc/DocHighlightThread.js
@@ -47,21 +47,20 @@ class DocHighlightThread extends AnnotationThread {
      * @return {void}
      */
     cancelFirstComment() {
+        // Reset type from highlight-comment to highlight
         if (util.isPlainHighlight(this.annotations)) {
-            if (this.isMobile) {
-                this.dialog.hideCommentsDialog();
-                this.state = STATES.inactive;
-            } else {
-                this.dialog.toggleHighlightDialogs();
-                this.reset();
-            }
-
-            // Reset type from highlight-comment to highlight
             this.type = TYPES.highlight;
-        } else if (!this.isMobile) {
-            this.destroy();
+        }
+
+        this.reset();
+
+        // Clear and reset mobile annotations dialog
+        if (this.isMobile) {
+            this.hideDialog();
+        } else if (util.isPlainHighlight(this.annotations)) {
+            this.dialog.toggleHighlightDialogs();
         } else {
-            this.reset();
+            this.destroy();
         }
     }
 

--- a/src/doc/__tests__/DocAnnotator-test.js
+++ b/src/doc/__tests__/DocAnnotator-test.js
@@ -799,14 +799,14 @@ describe('doc/DocAnnotator', () => {
         });
     });
 
-    describe('resetMobileDialog()', () => {
+    describe('removeThreadFromSharedDialog()', () => {
         beforeEach(() => {
             sandbox.stub(util, 'hideElement');
             sandbox.stub(util, 'showElement');
         });
 
         it('should do nothing if the mobile dialog does not exist', () => {
-            annotator.resetMobileDialog();
+            annotator.removeThreadFromSharedDialog();
             expect(util.hideElement).to.not.be.called;
         });
 
@@ -819,7 +819,7 @@ describe('doc/DocAnnotator', () => {
                 removeChild: sandbox.stub(),
                 lastChild: {}
             };
-            annotator.resetMobileDialog();
+            annotator.removeThreadFromSharedDialog();
             expect(util.hideElement).to.not.be.called;
             expect(annotator.mobileDialogEl.classList.remove).to.be.calledWith(CLASS_ANNOTATION_PLAIN_HIGHLIGHT);
         });
@@ -1286,7 +1286,7 @@ describe('doc/DocAnnotator', () => {
             stubs.threadMock = sandbox.mock(stubs.thread);
             stubs.getPageInfo = stubs.getPageInfo.returns({ pageEl: {}, page: 1 });
             sandbox.stub(annotator, 'clickThread');
-            sandbox.stub(annotator, 'resetMobileDialog');
+            sandbox.stub(annotator, 'removeThreadFromSharedDialog');
 
             annotator.modeControllers = {
                 'highlight': {
@@ -1332,12 +1332,12 @@ describe('doc/DocAnnotator', () => {
 
             annotator.isMobile = false;
             annotator.highlightClickHandler(stubs.event);
-            expect(annotator.resetMobileDialog).to.not.be.called;
+            expect(annotator.removeThreadFromSharedDialog).to.not.be.called;
 
             annotator.plainHighlightEnabled = false;
             annotator.isMobile = true;
             annotator.highlightClickHandler(stubs.event);
-            expect(annotator.resetMobileDialog).to.be.called;
+            expect(annotator.removeThreadFromSharedDialog).to.be.called;
         });
     });
 

--- a/src/util.js
+++ b/src/util.js
@@ -14,8 +14,6 @@ import {
     CLASS_INVALID_INPUT,
     CLASS_ANNOTATION_DIALOG,
     CLASS_BOX_PREVIEW_HEADER,
-    CLASS_ANNOTATION_PLAIN_HIGHLIGHT,
-    CLASS_ANIMATE_DIALOG,
     CLASS_DIALOG_CLOSE,
     CLASS_MOBILE_DIALOG_HEADER,
     DATA_TYPE_MOBILE_CLOSE
@@ -884,8 +882,6 @@ export function focusTextArea(element) {
  */
 export function generateMobileDialogEl() {
     const el = document.createElement('div');
-    el.classList.remove(CLASS_ANNOTATION_PLAIN_HIGHLIGHT);
-    el.classList.remove(CLASS_ANIMATE_DIALOG);
 
     const headerEl = document.createElement('div');
     headerEl.classList.add(CLASS_MOBILE_DIALOG_HEADER);

--- a/src/util.js
+++ b/src/util.js
@@ -882,7 +882,7 @@ export function focusTextArea(element) {
  *
  * @return {HTMLElement} Blank mobile annotation dialog
  */
-export function regenerateMobileDialog() {
+export function generateMobileDialogEl() {
     const el = document.createElement('div');
     el.classList.remove(CLASS_ANNOTATION_PLAIN_HIGHLIGHT);
     el.classList.remove(CLASS_ANIMATE_DIALOG);

--- a/src/util.js
+++ b/src/util.js
@@ -13,8 +13,15 @@ import {
     CLASS_DISABLED,
     CLASS_INVALID_INPUT,
     CLASS_ANNOTATION_DIALOG,
-    CLASS_BOX_PREVIEW_HEADER
+    CLASS_BOX_PREVIEW_HEADER,
+    CLASS_ANNOTATION_PLAIN_HIGHLIGHT,
+    CLASS_ANIMATE_DIALOG,
+    CLASS_DIALOG_CLOSE,
+    CLASS_MOBILE_DIALOG_HEADER,
+    DATA_TYPE_MOBILE_CLOSE
 } from './constants';
+
+import { ICON_CLOSE } from './icons/icons';
 
 const HEADER_CLIENT_NAME = 'X-Box-Client-Name';
 const HEADER_CLIENT_VERSION = 'X-Box-Client-Version';
@@ -868,4 +875,24 @@ export function focusTextArea(element) {
     }
 
     return textAreaEl;
+}
+
+/**
+ * Generates a blank mobile annotation dialog
+ *
+ * @return {HTMLElement} Blank mobile annotation dialog
+ */
+export function regenerateMobileDialog() {
+    const el = document.createElement('div');
+    el.classList.remove(CLASS_ANNOTATION_PLAIN_HIGHLIGHT);
+    el.classList.remove(CLASS_ANIMATE_DIALOG);
+
+    const headerEl = document.createElement('div');
+    headerEl.classList.add(CLASS_MOBILE_DIALOG_HEADER);
+    el.appendChild(headerEl);
+
+    const closeButtonEl = generateBtn([CLASS_DIALOG_CLOSE], DATA_TYPE_MOBILE_CLOSE, ICON_CLOSE, DATA_TYPE_MOBILE_CLOSE);
+    headerEl.appendChild(closeButtonEl);
+
+    return el;
 }


### PR DESCRIPTION
- Simplified some of the logic triggered by closing either mobile point or highlight dialogs. 
- Fixes issue where the mobile highlight comment dialog didn't close on clicking the 'X' button 