### PR TITLE
Fix: Allow dialog to process events when in point mode

### DIFF
--- a/src/controllers/PointModeController.js
+++ b/src/controllers/PointModeController.js
@@ -115,7 +115,7 @@ class PointModeController extends AnnotationModeController {
         this.pointClickHandler = this.pointClickHandler.bind(this);
 
         // Get handlers
-        this.pushElementHandler(this.annotatedElement, ['mousedown', 'touchstart'], this.pointClickHandler);
+        this.pushElementHandler(this.annotatedElement, ['click', 'touchstart'], this.pointClickHandler);
 
         this.pushElementHandler(this.exitButtonEl, 'click', this.toggleMode);
     }


### PR DESCRIPTION
When clicking in the dialog while in point mode, we no longer stop the event from propagating. This allows the dialog to process events as normal.

Fixes the bug where cancelling a deletion would leave the focus in a stuck state. 