### PR TITLE
Fix: firefox dialog collapse on mouseout

### DIFF
--- a/src/AnnotationDialog.js
+++ b/src/AnnotationDialog.js
@@ -459,7 +459,7 @@ class AnnotationDialog extends EventEmitter {
      * @return {void}
      */
     mouseleaveHandler(event) {
-        const isStillInDialog = util.isInDialog(event, event.toElement);
+        const isStillInDialog = util.isInDialog(event, event.relatedTarget);
         if (!isStillInDialog && this.hasAnnotations) {
             this.hide();
         }


### PR DESCRIPTION
This issue was caused because toElement is not supported in firefox, thus was returning undefined and was being replaced with event.target in a later method, which is the dialog itself. Replaced with relatedTarget which is cross browser