### PR TITLE
Fix: Mobile point annotation behavior

### DIFF
--- a/src/controllers/PointModeController.js
+++ b/src/controllers/PointModeController.js
@@ -176,12 +176,14 @@ class PointModeController extends AnnotationModeController {
         // Get annotation location from click event, ignore click if location is invalid
         const location = this.annotator.getLocationFromEvent(event, TYPES.point);
         if (!location) {
+            this.hideSharedDialog();
             return;
         }
 
         // Create new thread with no annotations, show indicator, and show dialog
         const thread = this.annotator.createAnnotationThread([], location, TYPES.point);
         if (!thread) {
+            this.hideSharedDialog();
             return;
         }
 

--- a/src/controllers/__tests__/PointModeController-test.js
+++ b/src/controllers/__tests__/PointModeController-test.js
@@ -221,6 +221,7 @@ describe('controllers/PointModeController', () => {
         beforeEach(() => {
             stubs.destroy = sandbox.stub(controller, 'destroyPendingThreads');
             sandbox.stub(controller, 'registerThread');
+            sandbox.stub(controller, 'hideSharedDialog');
             controller.modeButton = {
                 title: 'Point Annotation Mode',
                 selector: '.bp-btn-annotate'
@@ -235,12 +236,6 @@ describe('controllers/PointModeController', () => {
         afterEach(() => {
             controller.modeButton = {};
             controller.container = document;
-        });
-
-        it('should not destroy the pending thread if click was in the dialog', () => {
-            stubs.isInDialog.returns(true);
-            controller.pointClickHandler(event);
-            expect(stubs.destroy).to.not.be.called;
         });
 
         it('should not destroy the pending thread if click was in the dialog', () => {
@@ -266,6 +261,7 @@ describe('controllers/PointModeController', () => {
 
             controller.pointClickHandler(event);
             expect(controller.registerThread).to.not.be.called;
+            expect(controller.hideSharedDialog).to.be.called;
         });
 
         it('should not create a thread if a location object cannot be inferred from the event', () => {
@@ -276,6 +272,7 @@ describe('controllers/PointModeController', () => {
 
             controller.pointClickHandler(event);
             expect(controller.registerThread).to.not.be.called;
+            expect(controller.hideSharedDialog).to.be.called;
         });
 
         it('should create, show, and bind listeners to a thread', () => {
@@ -289,6 +286,7 @@ describe('controllers/PointModeController', () => {
             expect(controller.registerThread).to.be.called;
             expect(controller.emit).to.be.calledWith(THREAD_EVENT.pending, 'data');
             expect(controller.registerThread).to.be.calledWith(stubs.thread);
+            expect(controller.hideSharedDialog).to.not.be.called;
         });
 
         it('should show the create dialog', () => {
@@ -310,6 +308,7 @@ describe('controllers/PointModeController', () => {
             createMock.expects('showCommentBox');
 
             controller.pointClickHandler(event);
+            expect(controller.hideSharedDialog).to.not.be.called;
         });
     });
 });


### PR DESCRIPTION
- Attempting to create a point annotation on top of an existing point annotation will close the dialog.
- Initially only the point annotation icon would be removed but the dialog would remain with no way of closing it