### PR TITLE
Fix: Cursor type in annotation dialog

### DIFF
--- a/src/Annotator.scss
+++ b/src/Annotator.scss
@@ -156,7 +156,7 @@
 .ba-annotation-dialog,
 .ba-create-annotation-dialog {
     border-top: 20px solid transparent; // Transparent border for hover detection
-    cursor: default; // Overrides cursor: none from annotation mode
+    cursor: auto; // Overrides cursor: none from annotation mode
     font-family: Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
     position: absolute;
     text-align: left;


### PR DESCRIPTION
Cursor should be overridden with `auto` instead of `default` since `default` just uses an arrow for everything.