### PR TITLE
Chore: break all text to fit into dialog

### DIFF
--- a/src/Annotator.scss
+++ b/src/Annotator.scss
@@ -210,6 +210,7 @@
 
         .ba-annotation-comment-text {
             margin-bottom: 0;
+            word-break: break-all;
 
             & p {
                 margin: 0;

--- a/src/Annotator.scss
+++ b/src/Annotator.scss
@@ -210,7 +210,7 @@
 
         .ba-annotation-comment-text {
             margin-bottom: 0;
-            word-break: break-all;
+            word-break: break-word;
 
             & p {
                 margin: 0;


### PR DESCRIPTION
From this:
<img width="291" alt="screen shot 2018-09-21 at 1 35 41 pm" src="https://user-images.githubusercontent.com/763560/45902383-83010080-bda3-11e8-9fea-16bd2eb15a7a.png">



To this:
<img width="291" alt="screen shot 2018-09-21 at 1 35 50 pm" src="https://user-images.githubusercontent.com/763560/45902384-85635a80-bda3-11e8-85b7-df6658e9eb82.png">

