### PR TITLE
Reduce size of dirty drawing canvas

### DIFF
--- a/src/doc/DocDrawingThread.js
+++ b/src/doc/DocDrawingThread.js
@@ -259,7 +259,7 @@ class DocDrawingThread extends DrawingThread {
         // Set the scale and in-memory context for the pending thread
         this.lastScaleFactor = scale;
         this.pageEl = getPageEl(this.annotatedElement, this.location.page);
-        this.drawingContext = getContext(this.pageEl, CLASS_ANNOTATION_LAYER_DRAW_IN_PROGRESS);
+        this.drawingContext = getContext(this.pageEl, CLASS_ANNOTATION_LAYER_DRAW_IN_PROGRESS, 1);
 
         const config = { scale };
         this.setContextStyles(config);

--- a/src/doc/DocDrawingThread.js
+++ b/src/doc/DocDrawingThread.js
@@ -10,6 +10,8 @@ import {
 import { getBrowserCoordinatesFromLocation, getContext, getPageEl } from './docUtil';
 import { createLocation, getScale } from '../util';
 
+const IN_PROGRESS_CANVAS_SCALE = 1;
+
 class DocDrawingThread extends DrawingThread {
     /** @property {HTMLElement} - Page element being observed */
     pageEl;
@@ -259,7 +261,11 @@ class DocDrawingThread extends DrawingThread {
         // Set the scale and in-memory context for the pending thread
         this.lastScaleFactor = scale;
         this.pageEl = getPageEl(this.annotatedElement, this.location.page);
-        this.drawingContext = getContext(this.pageEl, CLASS_ANNOTATION_LAYER_DRAW_IN_PROGRESS, 1);
+        this.drawingContext = getContext(
+            this.pageEl,
+            CLASS_ANNOTATION_LAYER_DRAW_IN_PROGRESS,
+            IN_PROGRESS_CANVAS_SCALE
+        );
 
         const config = { scale };
         this.setContextStyles(config);

--- a/src/doc/docUtil.js
+++ b/src/doc/docUtil.js
@@ -70,7 +70,7 @@ export function isPointInPolyOpt(poly, x, y) {
     /* eslint-disable */
     for (var c = false, i = -1, l = poly.length, j = l - 1; ++i < l; j = i)
         ((poly[i][1] <= y && y < poly[j][1]) || (poly[j][1] <= y && y < poly[i][1])) &&
-            x < (poly[j][0] - poly[i][0]) * (y - poly[i][1]) / (poly[j][1] - poly[i][1]) + poly[i][0] &&
+            x < ((poly[j][0] - poly[i][0]) * (y - poly[i][1])) / (poly[j][1] - poly[i][1]) + poly[i][0] &&
             (c = !c);
     return c;
     /* eslint-enable */
@@ -176,7 +176,7 @@ export function convertDOMSpaceToPDFSpace(coordinates, pageHeight, scale) {
         pdfCoordinates = [x1, pageHeight - y1, x2, pageHeight - y2, x3, pageHeight - y3, x4, pageHeight - y4];
     }
 
-    return pdfCoordinates.map((val) => (val * CSS_PIXEL_TO_PDF_UNIT / scale).toFixed(4));
+    return pdfCoordinates.map((val) => ((val * CSS_PIXEL_TO_PDF_UNIT) / scale).toFixed(4));
 }
 
 /**
@@ -316,9 +316,8 @@ export function isValidSelection(selection) {
  * @param {HTMLElement} annotationLayerEl - The annotation canvas layer
  * @return {HTMLElement} The scaled annotation canvas layer
  */
-export function scaleCanvas(pageEl, annotationLayerEl) {
+export function scaleCanvas(pageEl, annotationLayerEl, pxRatio = window.devicePixelRatio || 1) {
     const pageDimensions = pageEl.getBoundingClientRect();
-    const pxRatio = window.devicePixelRatio || 1;
     const { width } = pageDimensions;
     const height = pageDimensions.height - constants.PAGE_PADDING_TOP - constants.PAGE_PADDING_BOTTOM;
 
@@ -342,11 +341,10 @@ export function scaleCanvas(pageEl, annotationLayerEl) {
  *
  * @param {HTMLElement} pageEl - The DOM element for the current page
  * @param {string} annotationLayerClass - The class name for the annotation layer
- * @param {number} [paddingTop] - The top padding of each page element
- * @param {number} [paddingBottom] - The bottom padding of each page element
+ * @param {number} [pixelRatio] - The pixel ratio to scale the canvas to. By default, uses devicePixelRatio
  * @return {RenderingContext|null} Context or null if no page element was given
  */
-export function getContext(pageEl, annotationLayerClass) {
+export function getContext(pageEl, annotationLayerClass, pixelRatio) {
     if (!pageEl) {
         return null;
     }
@@ -360,7 +358,7 @@ export function getContext(pageEl, annotationLayerClass) {
     // Create annotation layer (e.g. first load or page resize)
     annotationLayerEl = document.createElement('canvas');
     annotationLayerEl.classList.add(annotationLayerClass);
-    annotationLayerEl = scaleCanvas(pageEl, annotationLayerEl);
+    annotationLayerEl = scaleCanvas(pageEl, annotationLayerEl, pixelRatio);
 
     const textLayerEl = pageEl.querySelector('.textLayer');
     const canvasWrapperEl = pageEl.querySelector('.canvasWrapper');

--- a/src/doc/docUtil.js
+++ b/src/doc/docUtil.js
@@ -314,6 +314,7 @@ export function isValidSelection(selection) {
  *
  * @param {HTMLElement} pageEl - The DOM element for the current page
  * @param {HTMLElement} annotationLayerEl - The annotation canvas layer
+ * @param {number} [pxRatio] - Pixel ratio to scale the canvas by. Defaults to DVP or 1
  * @return {HTMLElement} The scaled annotation canvas layer
  */
 export function scaleCanvas(pageEl, annotationLayerEl, pxRatio = window.devicePixelRatio || 1) {


### PR DESCRIPTION
By reducing drawing canvas size to 1, we can reduce fill rate issues by rendering fewer pixels for a device with a DVP > 1 (most, in our case).