### PR TITLE
Fix: Binding of controller.unregisterThread on destroy

### DIFF
--- a/src/controllers/AnnotationModeController.js
+++ b/src/controllers/AnnotationModeController.js
@@ -133,7 +133,7 @@ class AnnotationModeController extends EventEmitter {
     destroy(): void {
         Object.keys(this.annotations).forEach((pageNum) => {
             const pageThreads = this.annotations[pageNum].all() || [];
-            pageThreads.forEach(this.unregisterThread);
+            pageThreads.forEach(this.unregisterThread.bind(this));
         });
 
         if (this.buttonEl) {

--- a/src/controllers/AnnotationModeController.js
+++ b/src/controllers/AnnotationModeController.js
@@ -123,6 +123,8 @@ class AnnotationModeController extends EventEmitter {
             this.modeButton = data.modeButton;
             this.showButton();
         }
+
+        this.unregisterThread = this.unregisterThread.bind(this);
     }
 
     /**
@@ -133,7 +135,7 @@ class AnnotationModeController extends EventEmitter {
     destroy(): void {
         Object.keys(this.annotations).forEach((pageNum) => {
             const pageThreads = this.annotations[pageNum].all() || [];
-            pageThreads.forEach(this.unregisterThread.bind(this));
+            pageThreads.forEach(this.unregisterThread);
         });
 
         if (this.buttonEl) {


### PR DESCRIPTION
Properly unregisters threads when the user previews multiple files consecutively