### PR TITLE
Fix: Get mode button from header element rather than container

### DIFF
--- a/src/controllers/AnnotationModeController.js
+++ b/src/controllers/AnnotationModeController.js
@@ -151,7 +151,7 @@ class AnnotationModeController extends EventEmitter {
      */
     getButton(annotatorSelector: string): HTMLElement {
         // $FlowFixMe
-        return this.container.querySelector(annotatorSelector);
+        return this.headerElement.querySelector(annotatorSelector);
     }
 
     /**

--- a/src/controllers/__tests__/AnnotationModeController-test.js
+++ b/src/controllers/__tests__/AnnotationModeController-test.js
@@ -123,14 +123,10 @@ describe('controllers/AnnotationModeController', () => {
             it('should return the annotation mode button', () => {
                 const buttonEl = document.createElement('button');
                 buttonEl.classList.add('class');
-                controller.container = document.createElement('div');
-                controller.container.appendChild(buttonEl);
+                controller.headerElement = document.createElement('div');
+                controller.headerElement.appendChild(buttonEl);
 
                 expect(controller.getButton('.class')).not.toBeNull();
-            });
-
-            it('should return null if no headerElement', () => {
-                expect(controller.getButton('.class')).toBeNull();
             });
         });
 


### PR DESCRIPTION
- This is a fix specifically for Annotations in the ContentPreview element or other cases when the header element is not contained inside box-content-preview