### PR TITLE
Fix: Reset current annotation thread immediately on save

### DIFF
--- a/src/AnnotationThread.js
+++ b/src/AnnotationThread.js
@@ -56,16 +56,8 @@ class AnnotationThread extends EventEmitter {
         this.annotatedElement = data.annotatedElement;
         this.api = data.api;
         this.container = data.container;
-        this.fileVersionId = data.fileVersionId;
-        this.location = data.location;
-        this.threadID = data.threadID || AnnotationAPI.generateID();
-        this.threadNumber = data.threadNumber || '';
-        this.type = data.type;
         this.locale = data.locale;
         this.hasTouch = data.hasTouch || false;
-        this.permissions = data.permissions;
-        this.state = STATES.inactive;
-        this.canComment = true;
         this.headerHeight = data.headerHeight;
 
         this.id = data.id;
@@ -77,6 +69,8 @@ class AnnotationThread extends EventEmitter {
         this.modifiedAt = data.modifiedAt;
         this.fileVersionId = data.fileVersionId;
         this.threadID = data.threadID || AnnotationAPI.generateID();
+        this.state = STATES.inactive;
+        this.permissions = data.permissions;
         this.canDelete = data.canDelete;
         this.canAnnotate = data.canAnnotate;
         this.canComment = true;
@@ -236,6 +230,8 @@ class AnnotationThread extends EventEmitter {
      * @return {Promise} - Annotation create promise
      */
     save(type: AnnotationType, message: string): Promise<any> {
+        this.emit(THREAD_EVENT.create);
+
         const annotationData = this.createAnnotationData(type, message);
 
         // Save annotation on client

--- a/src/__tests__/AnnotationThread-test.js
+++ b/src/__tests__/AnnotationThread-test.js
@@ -156,6 +156,7 @@ describe('AnnotationThread', () => {
                 done();
             });
             expect(thread.api.create).toBeCalled();
+            expect(thread.emit).toBeCalledWith(THREAD_EVENT.create);
         });
 
         it('should delete the temporary annotation and broadcast an error if there was an error saving', (done) => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -146,6 +146,7 @@ export const ANNOTATOR_EVENT = {
 };
 
 export const THREAD_EVENT = {
+    create: 'annotationcreate',
     pending: 'annotationpending',
     render: 'annotationrender',
     save: 'annotationsaved',

--- a/src/controllers/AnnotationModeController.js
+++ b/src/controllers/AnnotationModeController.js
@@ -493,6 +493,19 @@ class AnnotationModeController extends EventEmitter {
     setupHandlers(): void {}
 
     /**
+     * Resets current thread when annotation is no longer pending
+     *
+     * @param {AnnotationThread} thread  - Annotation thread being saved
+     * @return {void}
+     */
+    resetCurrentThread(thread: AnnotationThread): void {
+        this.selectedThread = thread;
+        this.currentThread = undefined;
+        this.hadPendingThreads = false;
+        this.pendingThreadID = null;
+    }
+
+    /**
      * Handles annotation thread events and emits them to the viewer
      *
      * @param {AnnotationThread} thread - The thread that emitted the event
@@ -505,6 +518,9 @@ class AnnotationModeController extends EventEmitter {
         const { event, data: threadData, eventData } = data;
 
         switch (event) {
+            case THREAD_EVENT.create:
+                this.resetCurrentThread(thread);
+                break;
             case THREAD_EVENT.save:
             case THREAD_EVENT.cancel:
                 this.hadPendingThreads = false;

--- a/src/controllers/DrawingModeController.js
+++ b/src/controllers/DrawingModeController.js
@@ -267,8 +267,7 @@ class DrawingModeController extends AnnotationModeController {
                 thread.removeListener('threadevent', this.handleThreadEvents);
                 thread.unbindDrawingListeners();
 
-                this.currentThread = undefined;
-                this.selectedThread = thread;
+                this.resetCurrentThread(thread);
                 this.unbindListeners();
 
                 // Clear existing canvases

--- a/src/controllers/__tests__/AnnotationModeController-test.js
+++ b/src/controllers/__tests__/AnnotationModeController-test.js
@@ -438,6 +438,15 @@ describe('controllers/AnnotationModeController', () => {
             });
         });
 
+        describe('resetCurrentThread()', () => {
+            it('should reset the current thread when an annotaiton is no longer pending', () => {
+                controller.currentThread = thread;
+                controller.resetCurrentThread(thread);
+                expect(controller.currentThread).toBeUndefined();
+                expect(controller.selectedThread).toEqual(thread);
+            });
+        });
+
         describe('handleThreadEvents()', () => {
             beforeEach(() => {
                 controller.emit = jest.fn();
@@ -445,10 +454,16 @@ describe('controllers/AnnotationModeController', () => {
                 controller.render = jest.fn();
                 controller.registerThread = jest.fn();
                 controller.unregisterThread = jest.fn();
+                controller.resetCurrentThread = jest.fn();
                 controller.localized = {
                     deleteError: 'delete error',
                     createError: 'create error'
                 };
+            });
+
+            it('should reset the current thread when a new annotation is created', () => {
+                controller.handleThreadEvents(thread, { event: THREAD_EVENT.create });
+                expect(controller.resetCurrentThread).toBeCalledWith(thread);
             });
 
             it('should mark hadPendingThreads as false and emit event on thread save or cancel', () => {

--- a/src/controllers/__tests__/DrawingModeController-test.js
+++ b/src/controllers/__tests__/DrawingModeController-test.js
@@ -246,6 +246,15 @@ describe('controllers/DrawingModeController', () => {
         });
     });
 
+    describe('resetCurrentThread()', () => {
+        it('should reset the current annotation thread', () => {
+            controller.selectedThread = null;
+            controller.resetCurrentThread(thread);
+            expect(controller.selectedThread).not.toBeNull();
+            expect(controller.currentThread).toBeUndefined();
+        });
+    });
+
     describe('handleThreadEvents()', () => {
         beforeEach(() => {
             controller.unbindListeners = jest.fn();

--- a/src/controllers/__tests__/DrawingModeController-test.js
+++ b/src/controllers/__tests__/DrawingModeController-test.js
@@ -246,15 +246,6 @@ describe('controllers/DrawingModeController', () => {
         });
     });
 
-    describe('resetCurrentThread()', () => {
-        it('should reset the current annotation thread', () => {
-            controller.selectedThread = null;
-            controller.resetCurrentThread(thread);
-            expect(controller.selectedThread).not.toBeNull();
-            expect(controller.currentThread).toBeUndefined();
-        });
-    });
-
     describe('handleThreadEvents()', () => {
         beforeEach(() => {
             controller.unbindListeners = jest.fn();


### PR DESCRIPTION
- Prevents new annotations (drawings) that are created before the create API call has successfully returned from being appended onto previous annotations (drawings)