### PR TITLE
Fix: Highlight selection on Surface

### DIFF
--- a/src/doc/DocAnnotator.js
+++ b/src/doc/DocAnnotator.js
@@ -462,12 +462,8 @@ class DocAnnotator extends Annotator {
     resetHighlightSelection(event: ?Event) {
         this.hideCreateDialog(event);
 
-        const selection = window.getSelection();
-        if (selection.rangeCount > 0) {
-            // $FlowFixMe
-            selection.removeAllRanges();
-        }
-
+        // $FlowFixMe
+        window.getSelection().removeAllRanges();
         if (this.highlighter) {
             this.highlighter.removeAllHighlights();
         }

--- a/src/doc/DocAnnotator.js
+++ b/src/doc/DocAnnotator.js
@@ -416,6 +416,7 @@ class DocAnnotator extends Annotator {
         if (
             // $FlowFixMe
             this.hasMouseMoved(this.lastHighlightEvent, event) &&
+            !this.isCreatingHighlight &&
             this.createHighlightDialog &&
             this.createHighlightDialog.isVisible &&
             !this.createHighlightDialog.isInHighlight(mouseEvent)

--- a/src/doc/DocAnnotator.js
+++ b/src/doc/DocAnnotator.js
@@ -597,7 +597,7 @@ class DocAnnotator extends Annotator {
             this.modeControllers[TYPES.highlight_comment].applyActionToThreads((thread) => thread.reset(), page);
         }
 
-        this.lastHighlightEvent = this.hasTouch ? get(event, 'targetTouches[0]', event) : event;
+        this.lastHighlightEvent = get(event, 'targetTouches[0]', event);
         this.lastSelection = selection;
     }
 

--- a/src/doc/DocAnnotator.js
+++ b/src/doc/DocAnnotator.js
@@ -1,5 +1,6 @@
 // @flow
 import rangy from 'rangy';
+import get from 'lodash/get';
 /* eslint-disable no-unused-vars */
 // Workaround for rangy npm issue: https://github.com/timdown/rangy/lib/issues/342
 import rangyClassApplier from 'rangy/lib/rangy-classapplier';
@@ -596,8 +597,7 @@ class DocAnnotator extends Annotator {
             this.modeControllers[TYPES.highlight_comment].applyActionToThreads((thread) => thread.reset(), page);
         }
 
-        // $FlowFixMe
-        this.lastHighlightEvent = this.hasTouch && event.targetTouches ? event.targetTouches[0] : event;
+        this.lastHighlightEvent = this.hasTouch ? get(event, 'targetTouches[0]', event) : event;
         this.lastSelection = selection;
     }
 
@@ -772,17 +772,15 @@ class DocAnnotator extends Annotator {
      * Bail if mid highlight and click is outside highlight/selection
      *
      * @param {Event} event - Mouse event
-     * @return {boolean} - Whether or not event was consumed
+     * @return {void}
      */
-    resetHighlightOnOutsideClick(event: Event): boolean {
+    resetHighlightOnOutsideClick(event: Event) {
         const selection = window.getSelection();
         const isClickOutsideCreateDialog = this.isCreatingHighlight && !util.isInDialog(event);
         if (!docUtil.isValidSelection(selection) && isClickOutsideCreateDialog) {
             this.lastHighlightEvent = null;
             this.resetHighlightSelection(event);
-            return true;
         }
-        return false;
     }
 
     /**

--- a/src/doc/__tests__/DocAnnotator-test.js
+++ b/src/doc/__tests__/DocAnnotator-test.js
@@ -846,11 +846,12 @@ describe('doc/DocAnnotator', () => {
             expect(annotator.selectionEndTimeout).not.toEqual(123);
         });
 
-        it('should clear selection if the user is currently creating a highlight annotation', () => {
-            annotator.isCreatingHighlight = true;
+        it('should clear selection if the user is NOT currently creating a highlight annotation', () => {
+            annotator.isCreatingHighlight = false;
             util.isInDialog = jest.fn().mockReturnValue(true);
             annotator.onSelectionChange(event);
             expect(annotator.resetHighlightOnOutsideClick).toBeCalled();
+            expect(util.findClosestElWithClass).toBeCalled();
         });
 
         it('should clear out highlights and exit "annotation creation" mode if an invalid selection', () => {
@@ -893,6 +894,25 @@ describe('doc/DocAnnotator', () => {
             docUtil.hasSelectionChanged = jest.fn().mockReturnValue(true);
             annotator.lastHighlightEvent = event;
             annotator.createHighlightDialog.isVisible = false;
+
+            annotator.onSelectionChange(event);
+            expect(annotator.selectionEndTimeout).not.toBeNull();
+            expect(annotator.isCreatingHighlight).toBeTruthy();
+        });
+
+        it('should reposition the existing createHighlightDialog', () => {
+            const selection = {
+                rangeCount: 10,
+                isCollapsed: false,
+                anchorNode: {
+                    parentNode: 'Node'
+                },
+                toString: () => 'asdf'
+            };
+            window.getSelection = jest.fn().mockReturnValue(selection);
+            docUtil.hasSelectionChanged = jest.fn().mockReturnValue(true);
+            annotator.lastHighlightEvent = event;
+            annotator.createHighlightDialog.isVisible = true;
 
             annotator.onSelectionChange(event);
             expect(annotator.selectionEndTimeout).not.toBeNull();


### PR DESCRIPTION
- Only reset highlight selection on `selectionchange` event on touch enabled devices when the user is NOT creating a highlight annotation

- [x] tests