### PR TITLE
Fix: Replacing DraftJSMentionSelector with TextArea

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "yarn": ">=1.0.0"
   },
   "peerDependencies": {
-    "box-react-ui": "^26.1.1",
+    "box-react-ui": "^29.0.0",
     "form-serialize": "^0.7.2",
     "immutable": "^3.7.4",
     "lodash": "^4.17.10",
@@ -56,7 +56,7 @@
     "bluebird": "^3.5.2",
     "box-locales": "^0.0.1",
     "box-node-sdk": "^1.22.0",
-    "box-react-ui": "^26.1.1",
+    "box-react-ui": "^29.0.0",
     "chai": "^4.1.2",
     "chai-dom": "^1.8.0",
     "circular-dependency-plugin": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "peerDependencies": {
     "box-react-ui": "^26.1.1",
-    "draft-js": "^0.10.5",
     "form-serialize": "^0.7.2",
     "immutable": "^3.7.4",
     "lodash": "^4.17.10",
@@ -69,7 +68,6 @@
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
     "cssnano-cli": "^1.0.5",
-    "draft-js": "^0.10.5",
     "enzyme": "^3.4.4",
     "enzyme-adapter-react-16": "^1.2.0",
     "enzyme-to-json": "^3.3.4",

--- a/src/components/ActionControls/ActionControls.js
+++ b/src/components/ActionControls/ActionControls.js
@@ -67,7 +67,7 @@ class ActionControls extends React.Component<Props, State> {
     onCreate = ({ text }: { text: string }) => {
         const { onCreate, type } = this.props;
         onCreate(type, text);
-        this.setState({ isInputOpen: false });
+        this.setState({ isInputOpen: true });
     };
 
     onDelete = (event: Event) => {

--- a/third-party/components/ApprovalCommentForm/ApprovalCommentForm.js
+++ b/third-party/components/ApprovalCommentForm/ApprovalCommentForm.js
@@ -11,7 +11,8 @@ import { ContentState, EditorState } from 'draft-js';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
 import Form from 'box-react-ui/lib/components/form-elements/form/Form';
-import DraftJSMentionSelector, {
+import TextArea from 'box-react-ui/lib/components/form-elements/text-area/TextArea';
+import {
     DraftMentionDecorator
 } from 'box-react-ui/lib/components/form-elements/draft-js-mention-selector';
 import commonMessages from 'box-react-ui/lib/common/messages';
@@ -204,21 +205,31 @@ class ApprovalCommentForm extends React.Component<Props, State> {
         approvers.splice(index, 1);
         this.setState({ approvers });
     };
+    
+    validateTextArea = (value: ?string) => {
+        const { intl } = this.props;
+        if (value && value.trim() === '') {
+            return {
+                message: intl.formatMessage(
+                    commonMessages.requiredFieldError
+                )
+            };
+        }
+        return null;
+    }
 
     render(): React.Node {
         const {
             approverSelectorContacts,
             className,
             createTask,
-            getMentionWithQuery,
             intl: { formatMessage },
-            isDisabled,
             isOpen,
-            mentionSelectorContacts = [],
             onCancel,
             onFocus,
             user,
             isEditing,
+            isDisabled,
             tagged_message,
             getAvatarUrl
         } = this.props;
@@ -226,7 +237,6 @@ class ApprovalCommentForm extends React.Component<Props, State> {
             approvalDate,
             approvers,
             approverSelectorError,
-            commentEditorState,
             isAddApprovalVisible
         } = this.state;
         const inputContainerClassNames = classNames(
@@ -249,28 +259,24 @@ class ApprovalCommentForm extends React.Component<Props, State> {
                         onChange={this.onFormChangeHandler}
                         onValidSubmit={this.onFormValidSubmitHandler}
                     >
-                        <DraftJSMentionSelector
+                        {/* TODO: Replace Draft.js in box-react-ui implementation of ApprovalCommentForm */}
+                        <TextArea
                             className='bcs-comment-input'
-                            contacts={isOpen ? mentionSelectorContacts : []}
-                            editorState={commentEditorState}
-                            hideLabel
-                            isDisabled={isDisabled}
                             isRequired={isOpen}
+                            isDisabled={isDisabled}
                             name='commentText'
-                            label='Comment'
                             onChange={this.onMentionSelectorChangeHandler}
                             onFocus={onFocus}
-                            onMention={getMentionWithQuery}
                             placeholder={
                                 tagged_message
                                     ? null
                                     : formatMessage(messages.commentWrite)
                             }
-                            validateOnBlur={false}
+                            validation={this.validateTextArea}
                         />
                         <aside
                             className={classNames('bcs-at-mention-tip', {
-                                'accessibility-hidden': isOpen,
+                                'accessibility-hidden': isOpen
                             })}
                         >
                             <FormattedMessage {...messages.atMentionTip} />

--- a/third-party/components/ApprovalCommentForm/ApprovalCommentForm.js
+++ b/third-party/components/ApprovalCommentForm/ApprovalCommentForm.js
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
 import Form from 'box-react-ui/lib/components/form-elements/form/Form';
-import TextArea from 'box-react-ui/lib/components/form-elements/text-area/TextArea';
+import TextArea from 'box-react-ui/lib/components/text-area/TextArea';
 import commonMessages from 'box-react-ui/lib/common/messages';
 
 import AddApproval from './AddApproval';
@@ -209,6 +209,7 @@ class ApprovalCommentForm extends React.Component<Props, State> {
                             isDisabled={isDisabled}
                             name='commentText'
                             label='Annotation Comment'
+                            hideLabel={true}
                             onFocus={onFocus}
                             value={commentText}
                             placeholder={

--- a/third-party/components/ApprovalCommentForm/ApprovalCommentForm.scss
+++ b/third-party/components/ApprovalCommentForm/ApprovalCommentForm.scss
@@ -9,10 +9,6 @@
             width: 100%;
         }
 
-        .label {
-            display: none;
-        }
-
         box-shadow: none;
         margin-bottom: 15px;
         margin-top: 5px;

--- a/third-party/components/ApprovalCommentForm/ApprovalCommentForm.scss
+++ b/third-party/components/ApprovalCommentForm/ApprovalCommentForm.scss
@@ -9,6 +9,10 @@
             width: 100%;
         }
 
+        .label {
+            display: none;
+        }
+
         box-shadow: none;
         margin-bottom: 15px;
         margin-top: 5px;

--- a/third-party/components/ApprovalCommentForm/ApprovalCommentForm.scss
+++ b/third-party/components/ApprovalCommentForm/ApprovalCommentForm.scss
@@ -5,13 +5,13 @@
     display: flex;
 
     .bcs-comment-input {
-        div[contentEditable="true"].public-DraftEditor-content {
-            width: auto;
+        textarea {
+            width: 100%;
         }
 
         box-shadow: none;
         margin-bottom: 15px;
-        margin-top: 20px;
+        margin-top: 5px;
         max-height: 140px;
         width: auto;
 

--- a/third-party/components/ApprovalCommentForm/__tests__/ApprovalCommentForm-test.js
+++ b/third-party/components/ApprovalCommentForm/__tests__/ApprovalCommentForm-test.js
@@ -1,0 +1,48 @@
+/* eslint-disable no-unused-expressions */
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import noop from 'lodash/noop';
+
+import ApprovalCommentForm from '../ApprovalCommentForm';
+
+const fn = jest.fn();
+
+describe('third-party/components/ApprovalCommentForm', () => {
+    const render = (props = {}) =>
+        shallow(
+            <ApprovalCommentForm
+                user={null}
+                isOpen={false}
+                isEditing={true}
+                createComment={fn}
+                onCancel={fn}
+                onSubmit={noop}
+                onFocus={fn}
+                getAvatarUrl={noop}
+                {...props}
+            />
+        );
+
+    test('should correctly render empty form', () => {
+        const wrapper = render();
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should render commentText value in textarea', () => {
+        const wrapper = render().dive();
+
+        wrapper.instance().onFormChangeHandler({ commentText: 'something' });
+        wrapper.update();
+
+        expect(wrapper.find('.bcs-comment-input').props().value).toEqual('something');
+    });
+
+    test('should return translated error message on invalid textarea message', () => {
+        const intl = { formatMessage: jest.fn() };
+        const wrapper = render({ intl }).dive();
+        const instance = wrapper.instance();
+
+        expect(instance.validateTextArea('peanuts')).toBeNull();
+        expect(instance.validateTextArea('    ')).not.toBeNull();
+    });
+});

--- a/third-party/components/ApprovalCommentForm/__tests__/__snapshots__/ApprovalCommentForm-test.js.snap
+++ b/third-party/components/ApprovalCommentForm/__tests__/__snapshots__/ApprovalCommentForm-test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`third-party/components/ApprovalCommentForm should correctly render empty form 1`] = `
+<ApprovalCommentForm
+  createComment={[MockFunction]}
+  getAvatarUrl={[Function]}
+  intl={
+    Object {
+      "formatDate": [Function],
+      "formatMessage": [Function],
+    }
+  }
+  isEditing={true}
+  isOpen={false}
+  onCancel={[MockFunction]}
+  onFocus={[MockFunction]}
+  onSubmit={[Function]}
+  user={null}
+/>
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2203,10 +2203,10 @@ box-node-sdk@^1.22.0:
     url-template "^2.0.8"
     uuid "^3.0.0"
 
-box-react-ui@^26.1.1:
-  version "26.11.0"
-  resolved "https://registry.yarnpkg.com/box-react-ui/-/box-react-ui-26.11.0.tgz#1e66a3bc19413a6d58628ddc0bcdeb4ba4e79513"
-  integrity sha512-MlbdZxnpMemwuuSXFJZlRGvHcGW/z+LcuEsztWBl0O/mEHqV1mIUwFLEIsU0Dk/aYuKgS36+z61K+tDx+b3DEA==
+box-react-ui@^29.0.0:
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/box-react-ui/-/box-react-ui-29.0.0.tgz#f4a080de5ca8f049b741a4f53e1f357b7518a8b2"
+  integrity sha512-1fC8dK7ujoKr9kq+qgA/5IAOktMV6UXVqL2NtQ1fMtA24O2D38EQd/YllyKfHyZvoj5xPGGc8KStikbG22hhfg==
 
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3491,11 +3491,6 @@ copy-webpack-plugin@^4.5.2:
     p-limit "^1.0.0"
     serialize-javascript "^1.4.0"
 
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
-
 core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
@@ -4238,15 +4233,6 @@ dot-prop@^4.1.1:
   dependencies:
     is-obj "^1.0.0"
 
-draft-js@^0.10.5:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.10.5.tgz#bfa9beb018fe0533dbb08d6675c371a6b08fa742"
-  integrity sha512-LE6jSCV9nkPhfVX2ggcRLA4FKs6zWq9ceuO/88BpXdNCS7mjRTgs0NsV6piUCJX9YxMsB9An33wnkMmU2sD2Zg==
-  dependencies:
-    fbjs "^0.8.15"
-    immutable "~3.7.4"
-    object-assign "^4.1.0"
-
 duplexer2@~0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
@@ -4346,13 +4332,6 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
-
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
-  dependencies:
-    iconv-lite "~0.4.13"
 
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
@@ -5133,19 +5112,6 @@ fb-watchman@^2.0.0:
   integrity sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=
   dependencies:
     bser "^2.0.0"
-
-fbjs@^0.8.15:
-  version "0.8.17"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
-  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.18"
 
 fetch-mock-forwarder@^1.0.0:
   version "1.0.0"
@@ -6280,7 +6246,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -6330,11 +6296,6 @@ immutable@^3.7.4:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
   integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=
-
-immutable@~3.7.4:
-  version "3.7.6"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
-  integrity sha1-E7TTyxK++hVIKib+Gy665kAHHks=
 
 import-cwd@^2.0.0:
   version "2.1.0"
@@ -6909,7 +6870,7 @@ is-root@1.0.0:
   resolved "https://registry.yarnpkg.com/is-root/-/is-root-1.0.0.tgz#07b6c233bc394cd9d02ba15c966bd6660d6342d5"
   integrity sha1-B7bCM7w5TNnQK6FclmvWZg1jQtU=
 
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -7001,14 +6962,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
-
-isomorphic-fetch@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -8792,14 +8745,6 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
-
 node-fetch@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
@@ -10222,7 +10167,7 @@ promise-retry@^1.1.1:
     err-code "^1.0.0"
     retry "^0.10.0"
 
-promise@^7.0.1, promise@^7.1.1:
+promise@^7.0.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
   integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
@@ -11651,7 +11596,7 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4, setimmediate@^1.0.5, setimmediate@~1.0.4:
+setimmediate@^1.0.4, setimmediate@~1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -12732,11 +12677,6 @@ typescript@^2.5.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
   integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
-ua-parser-js@^0.7.18:
-  version "0.7.18"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
-  integrity sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA==
-
 uglify-es@3.3.4, uglify-es@^3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.4.tgz#2d592678791e5310456bbc95e952139e3b13167a"
@@ -13454,11 +13394,6 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
-
-whatwg-fetch@>=0.10.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 whatwg-fetch@^0.10.1:
   version "0.10.1"


### PR DESCRIPTION
This duplication of ApprovalCommentForm replaces the DraftJSMentionSelector with a simple TextArea due to complications with Android autocomplete interfering with draft.js

See https://github.com/facebook/draft-js/issues/1895

- [x] Update tests
- [x] Test on IE/Edge/Surface
- [x] Test on android w/ autocomplete keyboard