### PR TITLE
Fix: Increase action control button padding

### DIFF
--- a/src/components/ActionControls/ActionControls.scss
+++ b/src/components/ActionControls/ActionControls.scss
@@ -25,9 +25,7 @@
         margin: 0;
     }
 
-    .ba-annotator-label ~ .ba-action-controls .ba-action-controls-draw,
-    .ba-annotator-label ~ .ba-action-controls .ba-action-controls-highlight {
-        border-left: 1px solid $see-see;
+    .ba-annotator-label ~ .ba-action-controls .ba-action-controls-draw {
         margin-left: 5px;
     }
 

--- a/src/components/ActionControls/DrawingControls.scss
+++ b/src/components/ActionControls/DrawingControls.scss
@@ -5,21 +5,28 @@
         $button-spacing: 5px;
 
         display: flex;
-        margin-left: -#{$button-spacing};
-        margin-right: -#{$button-spacing};
 
         .btn-plain {
             flex-grow: 1;
-            padding-left: $button-spacing;
-            padding-right: $button-spacing;
+            padding: 10px;
 
             .fill-color {
                 fill: $sevens;
             }
+
+            &:hover .fill-color {
+                fill: $better-black;
+            }
         }
 
-        .btn-plain:hover .fill-color {
-            fill: $better-black;
+        .ba-drawing-save-btn,
+        .ba-drawing-save-btn:hover {
+            padding-right: $button-spacing;
+        }
+
+        .ba-drawing-delete-btn,
+        .ba-drawing-delete-btn:hover {
+            padding-left: $button-spacing;
         }
     }
 

--- a/src/components/ActionControls/HighlightControls.scss
+++ b/src/components/ActionControls/HighlightControls.scss
@@ -5,13 +5,10 @@
         $button-spacing: 5px;
 
         display: flex;
-        margin-left: -#{$button-spacing};
-        margin-right: -#{$button-spacing};
 
         .btn-plain {
             flex-grow: 1;
-            padding-left: $button-spacing;
-            padding-right: $button-spacing;
+            padding: 10px;
 
             .icon-annotation-highlight,
             .icon-annotation-highlight-comment .icon {
@@ -21,17 +18,27 @@
             .icon-annotation-highlight.ba-saved-highlight {
                 fill: $highlight-yellow;
             }
+
+            &:hover {
+                .icon-annotation-highlight,
+                .icon-annotation-highlight-comment .icon {
+                    fill: $better-black;
+                }
+
+                .icon-annotation-highlight.ba-saved-highlight {
+                    fill: $highlight-yellow-hover;
+                }
+            }
         }
 
-        .btn-plain:hover {
-            .icon-annotation-highlight,
-            .icon-annotation-highlight-comment .icon {
-                fill: $better-black;
-            }
+        .ba-highlight-btn,
+        .ba-highlight-btn:hover {
+            padding-right: $button-spacing;
+        }
 
-            .icon-annotation-highlight.ba-saved-highlight {
-                fill: $highlight-yellow-hover;
-            }
+        .ba-highlight-comment-btn,
+        .ba-highlight-comment-btn:hover {
+            padding-left: $button-spacing;
         }
     }
 

--- a/src/components/AnnotationPopover/AnnotationPopover.scss
+++ b/src/components/AnnotationPopover/AnnotationPopover.scss
@@ -54,6 +54,7 @@
     .ba-inline-popover .ba-popover-overlay {
         align-items: center;
         display: inline-flex;
+        padding: 0;
     }
 
     .bcs-comment-input-form-container {

--- a/src/components/AnnotationPopover/AnnotatorLabel.scss
+++ b/src/components/AnnotationPopover/AnnotatorLabel.scss
@@ -1,6 +1,12 @@
 @import '../../variables';
 
 .ba {
+    .ba-annotator-label {
+        border-right: 1px solid $see-see;
+        margin: 10px 0 10px 10px;
+        padding-right: 10px;
+    }
+
     // MOBILE & TABLET CSS
     @media #{$mobile}, #{$tablet} {
         .ba-annotator-label {


### PR DESCRIPTION
Visually this will look the same, however this will make the action control buttons cover more space, making it easier to click the actual button

![image](https://user-images.githubusercontent.com/3299001/52249803-cdde6900-28a9-11e9-9c91-4dacc3228675.png)
 
Tested on all types of devices/dialogs that can appear (mobile/tablet/desktop)