### PR TITLE
Fix: Unable to select drawing annotation after saving

### DIFF
--- a/src/AnnotationThread.js
+++ b/src/AnnotationThread.js
@@ -246,7 +246,7 @@ class AnnotationThread extends EventEmitter {
         });
 
         this.state = STATES.inactive;
-        this.unmountPopover();
+        this.renderAnnotationPopover();
 
         // Save annotation on server
         return (

--- a/src/AnnotationThread.js
+++ b/src/AnnotationThread.js
@@ -246,7 +246,7 @@ class AnnotationThread extends EventEmitter {
         });
 
         this.state = STATES.inactive;
-        this.renderAnnotationPopover();
+        this.unmountPopover();
 
         // Save annotation on server
         return (
@@ -535,7 +535,6 @@ class AnnotationThread extends EventEmitter {
         }
 
         this.show();
-        this.renderAnnotationPopover();
         this.emit(THREAD_EVENT.save);
     }
 

--- a/src/__tests__/AnnotationThread-test.js
+++ b/src/__tests__/AnnotationThread-test.js
@@ -177,7 +177,7 @@ describe('AnnotationThread', () => {
             thread.getThreadEventData = jest.fn().mockReturnValue({});
             thread.handleThreadSaveError = jest.fn();
             thread.updateTemporaryAnnotation = jest.fn();
-            thread.renderAnnotationPopover = jest.fn();
+            thread.unmountPopover = jest.fn();
         });
 
         it('should save an annotation with the specified type and text', (done) => {
@@ -268,7 +268,6 @@ describe('AnnotationThread', () => {
         beforeEach(() => {
             thread.api.create = jest.fn();
             thread.getThreadEventData = jest.fn().mockReturnValue({});
-            thread.renderAnnotationPopover = jest.fn();
             thread.comments = [tempAnnotation];
         });
 
@@ -291,7 +290,6 @@ describe('AnnotationThread', () => {
 
         it('should only render popover on desktop', () => {
             thread.updateTemporaryAnnotation(tempAnnotation.id, serverAnnotation);
-            expect(thread.renderAnnotationPopover).toBeCalled();
             expect(thread.state).toEqual(STATES.inactive);
         });
 
@@ -299,7 +297,6 @@ describe('AnnotationThread', () => {
             util.shouldDisplayMobileUI = jest.fn().mockReturnValue(true);
             thread.updateTemporaryAnnotation(tempAnnotation.id, serverAnnotation);
             expect(thread.state).toEqual(STATES.active);
-            expect(thread.renderAnnotationPopover).toBeCalled();
         });
     });
 

--- a/src/__tests__/AnnotationThread-test.js
+++ b/src/__tests__/AnnotationThread-test.js
@@ -177,7 +177,7 @@ describe('AnnotationThread', () => {
             thread.getThreadEventData = jest.fn().mockReturnValue({});
             thread.handleThreadSaveError = jest.fn();
             thread.updateTemporaryAnnotation = jest.fn();
-            thread.unmountPopover = jest.fn();
+            thread.renderAnnotationPopover = jest.fn();
         });
 
         it('should save an annotation with the specified type and text', (done) => {

--- a/src/controllers/DrawingModeController.js
+++ b/src/controllers/DrawingModeController.js
@@ -203,7 +203,7 @@ class DrawingModeController extends AnnotationModeController {
         location.maxY = location.y;
 
         // Create new thread with no annotations, show indicator, and show dialog
-        const thread = this.registerThread({
+        const threadParams = this.getThreadParams({
             id: AnnotationAPI.generateID(),
             type: this.mode,
             location,
@@ -214,6 +214,12 @@ class DrawingModeController extends AnnotationModeController {
             isPending: true,
             comments: []
         });
+
+        if (!threadParams) {
+            return;
+        }
+
+        const thread = this.instantiateThread(threadParams);
 
         if (!thread) {
             return;
@@ -267,6 +273,8 @@ class DrawingModeController extends AnnotationModeController {
 
                 this.resetCurrentThread(thread);
                 this.unbindListeners();
+
+                this.registerThread(thread);
 
                 // Clear existing canvases
                 // eslint-disable-next-line

--- a/src/controllers/__tests__/DrawingModeController-test.js
+++ b/src/controllers/__tests__/DrawingModeController-test.js
@@ -192,7 +192,8 @@ describe('controllers/DrawingModeController', () => {
             controller.getLocation = jest.fn();
             controller.currentThread = undefined;
             controller.locationFunction = jest.fn();
-            controller.registerThread = jest.fn().mockReturnValue(thread);
+            controller.getThreadParams = jest.fn().mockReturnValue({});
+            controller.instantiateThread = jest.fn().mockReturnValue(thread);
         });
 
         afterEach(() => {
@@ -203,7 +204,7 @@ describe('controllers/DrawingModeController', () => {
         it('should do nothing if drawing start is invalid', () => {
             controller.drawingStartHandler(event);
             expect(controller.getLocation).toBeCalled();
-            expect(controller.registerThread).not.toBeCalled();
+            expect(controller.instantiateThread).not.toBeCalled();
         });
 
         it('should continue drawing if in the middle of creating a new drawing', () => {
@@ -212,13 +213,12 @@ describe('controllers/DrawingModeController', () => {
             thread.getThreadEventData = jest.fn().mockReturnValue({});
 
             controller.drawingStartHandler(event);
-            expect(controller.registerThread).not.toBeCalled();
+            expect(controller.instantiateThread).not.toBeCalled();
             expect(thread.handleStart).toBeCalledWith(location);
         });
 
         it('should begin a new drawing thread if none exist already', () => {
             controller.getLocation = jest.fn().mockReturnValue(location);
-            controller.registerThread = jest.fn().mockReturnValue(thread);
             thread.getThreadEventData = jest.fn().mockReturnValue({});
 
             controller.drawingStartHandler(event);

--- a/src/doc/DocDrawingThread.js
+++ b/src/doc/DocDrawingThread.js
@@ -376,6 +376,17 @@ class DocDrawingThread extends DrawingThread {
         popoverEl.style.left = `${popoverX}px`;
         popoverEl.style.top = `${popoverY}px`;
     };
+
+    /**
+     * Update annotation after successfully saved.
+     * @override
+     */
+    updateTemporaryAnnotation(tempAnnotationID: string, savedAnnotation: Annotation) {
+        super.updateTemporaryAnnotation(tempAnnotationID, savedAnnotation);
+
+        // Unmount the drawing annotation popover after successful save
+        this.unmountPopover();
+    }
 }
 
 export default DocDrawingThread;


### PR DESCRIPTION
Issue was that when starting a drawing annotation, in `DrawingModeController.drawingStartHandler` we would register the thread, which would make an entry into the rbush instance for that page, however the location would be of the mouse event point, not the finished drawing boundary. Upon refresh the whole boundary would be available and registered into rbush so clicking at that point wouldn't be a problem.

The solution here is to defer `registerThread` until we have successfully saved.

A change in experience is also that after the drawing annotation is saved, we unmount the popover