### PR TITLE
Fix: Ensure point annotations aren't scrolled out of view on focus

### DIFF
--- a/src/AnnotationThread.js
+++ b/src/AnnotationThread.js
@@ -470,11 +470,12 @@ class AnnotationThread extends EventEmitter {
     /**
      * Scroll annotation into the center of the viewport, if possible
      *
+     * @param {number|null} dialogYPos - Y coordinate of the annotation popover
      * @return {void}
      */
-    scrollIntoView() {
+    scrollIntoView(dialogYPos: ?number) {
         // $FlowFixMe
-        const yPos = parseInt(this.location.y, 10);
+        const yPos = dialogYPos || parseInt(this.location.y, 10);
         this.scrollToPage();
         this.centerAnnotation(this.annotatedElement.scrollTop + yPos);
     }
@@ -505,7 +506,7 @@ class AnnotationThread extends EventEmitter {
      */
     centerAnnotation(scrollVal: number) {
         if (scrollVal < this.annotatedElement.scrollHeight) {
-            this.annotatedElement.scrollTop = scrollVal;
+            this.annotatedElement.scrollTop = scrollVal - this.annotatedElement.clientHeight / 2;
         } else {
             // $FlowFixMe
             this.annotatedElement.scrollTop = this.annotatedElement.scrollBottom;

--- a/src/__tests__/AnnotationThread-test.js
+++ b/src/__tests__/AnnotationThread-test.js
@@ -453,12 +453,27 @@ describe('AnnotationThread', () => {
     });
 
     describe('scrollIntoView()', () => {
+        beforeEach(() => {
+            thread.annotatedElement = {
+                scrollTop: 0
+            };
+        });
+
+        it('should scroll to annotation page and center annotation in viewport according to dialog y position', () => {
+            thread.scrollToPage = jest.fn();
+            thread.centerAnnotation = jest.fn();
+            thread.scrollIntoView(50);
+            expect(thread.scrollToPage);
+            expect(thread.centerAnnotation).not.toBeCalledWith(thread.location.y);
+        });
+
         it('should scroll to annotation page and center annotation in viewport', () => {
+            thread.location.y = 10;
             thread.scrollToPage = jest.fn();
             thread.centerAnnotation = jest.fn();
             thread.scrollIntoView();
             expect(thread.scrollToPage);
-            expect(thread.centerAnnotation).toBeCalledWith(expect.any(Number));
+            expect(thread.centerAnnotation).toBeCalledWith(thread.location.y);
         });
     });
 
@@ -494,13 +509,14 @@ describe('AnnotationThread', () => {
             thread.annotatedElement = {
                 scrollHeight: 100,
                 scrollTop: 0,
-                scrollBottom: 200
+                scrollBottom: 200,
+                clientHeight: 50
             };
         });
 
         it('should scroll so annotation is vertically centered in viewport', () => {
             thread.centerAnnotation(50);
-            expect(thread.annotatedElement.scrollTop).toEqual(50);
+            expect(thread.annotatedElement.scrollTop).toEqual(25);
         });
 
         it('should scroll so annotation is vertically centered in viewport', () => {

--- a/src/doc/DocPointThread.js
+++ b/src/doc/DocPointThread.js
@@ -101,6 +101,7 @@ class DocPointThread extends AnnotationThread {
         // Position the dialog
         popoverEl.style.left = `${dialogLeftX}px`;
         popoverEl.style.top = `${dialogTopY}px`;
+        this.scrollIntoView(dialogTopY);
     };
 }
 

--- a/src/doc/__tests__/DocPointThread-test.js
+++ b/src/doc/__tests__/DocPointThread-test.js
@@ -76,6 +76,7 @@ describe('doc/DocPointThread', () => {
             util.findElement = jest.fn().mockReturnValue(rootElement);
             thread.getPopoverParent = jest.fn().mockReturnValue(rootElement);
             util.repositionCaret = jest.fn().mockReturnValue(0);
+            thread.scrollIntoView = jest.fn();
         });
 
         it('should not re-position the popover on mobile devices', () => {
@@ -89,6 +90,7 @@ describe('doc/DocPointThread', () => {
             thread.position();
             expect(util.findElement).toBeCalled();
             expect(rootElement.classList).not.toContain(CLASS_FLIPPED_POPOVER);
+            expect(thread.scrollIntoView).toBeCalled();
         });
 
         it('should flip popovers in the lower half of the viewport', () => {
@@ -96,6 +98,7 @@ describe('doc/DocPointThread', () => {
             thread.position();
             expect(util.findElement).toBeCalled();
             expect(rootElement.classList).toContain(CLASS_FLIPPED_POPOVER);
+            expect(thread.scrollIntoView).toBeCalled();
         });
     });
 });

--- a/src/image/ImagePointThread.js
+++ b/src/image/ImagePointThread.js
@@ -86,6 +86,7 @@ class ImagePointThread extends AnnotationThread {
         // Position the dialog
         popoverEl.style.left = `${dialogLeftX}px`;
         popoverEl.style.top = `${dialogTopY}px`;
+        this.scrollIntoView(dialogTopY);
     };
 }
 

--- a/src/image/__tests__/ImagePointThread-test.js
+++ b/src/image/__tests__/ImagePointThread-test.js
@@ -88,6 +88,7 @@ describe('image/ImagePointThread', () => {
             util.findElement = jest.fn().mockReturnValue(rootElement);
             thread.getPopoverParent = jest.fn().mockReturnValue(rootElement);
             util.repositionCaret = jest.fn().mockReturnValue(0);
+            thread.scrollIntoView = jest.fn();
         });
 
         it('should not re-position the popover on mobile devices', () => {
@@ -101,6 +102,7 @@ describe('image/ImagePointThread', () => {
             thread.position();
             expect(util.findElement).toBeCalled();
             expect(rootElement.classList).not.toContain(CLASS_FLIPPED_POPOVER);
+            expect(thread.scrollIntoView).toBeCalled();
         });
 
         it('should flip popovers in the lower half of the viewport', () => {
@@ -108,6 +110,7 @@ describe('image/ImagePointThread', () => {
             thread.position();
             expect(util.findElement).toBeCalled();
             expect(rootElement.classList).toContain(CLASS_FLIPPED_POPOVER);
+            expect(thread.scrollIntoView).toBeCalled();
         });
     });
 


### PR DESCRIPTION
Fixes this issue 
![Mar-13-2019 15-18-58](https://user-images.githubusercontent.com/3299001/54318526-d8280d00-45a3-11e9-9fe3-2b3bb5e85dcf.gif)

- [x] Tests