### PR TITLE
Fix: Cleanup thread when API requests fail

### DIFF
--- a/src/AnnotationThread.js
+++ b/src/AnnotationThread.js
@@ -307,6 +307,7 @@ class AnnotationThread extends EventEmitter {
             /* eslint-disable no-console */
             console.error(THREAD_EVENT.deleteError, `Annotation with ID ${annotationIDToRemove} could not be found.`);
             /* eslint-enable no-console */
+            this.deleteSuccessHandler();
             return Promise.reject();
         }
 
@@ -331,6 +332,7 @@ class AnnotationThread extends EventEmitter {
                 `Annotation with ID ${annotation.threadNumber} not deleted from server`
             );
             /* eslint-enable no-console */
+            this.deleteSuccessHandler();
             return Promise.resolve();
         }
 

--- a/src/__tests__/AnnotationThread-test.js
+++ b/src/__tests__/AnnotationThread-test.js
@@ -347,6 +347,7 @@ describe('AnnotationThread', () => {
             thread.delete({ id: 'someID' }).catch(() => {
                 expect(api.delete).not.toBeCalled();
                 expect(console.error).toBeCalled(); // eslint-disable-line
+                expect(thread.deleteSuccessHandler).toBeCalled();
             });
         });
 
@@ -355,6 +356,7 @@ describe('AnnotationThread', () => {
             thread.delete({ id: 'someID' }).catch(() => {
                 expect(api.delete).not.toBeCalled();
                 expect(console.error).toBeCalled(); // eslint-disable-line
+                expect(thread.deleteSuccessHandler).toBeCalled();
             });
         });
 
@@ -362,6 +364,7 @@ describe('AnnotationThread', () => {
             thread.delete({ id: 'someID' }, false).then(() => {
                 expect(api.delete).not.toBeCalled();
                 expect(console.error).toBeCalled(); // eslint-disable-line
+                expect(thread.deleteSuccessHandler).toBeCalled();
             });
         });
 


### PR DESCRIPTION
Ensures newly created annotations are deleted appropriately when the create API request fails. 