### PR TITLE
Fix: Hide all threads before creating a new point annotation

### DIFF
--- a/src/Annotator.js
+++ b/src/Annotator.js
@@ -253,7 +253,7 @@ class Annotator extends EventEmitter {
         Object.keys(this.modeControllers).forEach((mode) => {
             this.modeControllers[mode].destroyPendingThreads();
             this.modeControllers[mode].applyActionToThreads((thread) => {
-                thread.unmountPopover();
+                thread.hide();
             });
         });
     }

--- a/src/controllers/PointModeController.js
+++ b/src/controllers/PointModeController.js
@@ -105,6 +105,9 @@ class PointModeController extends AnnotationModeController {
         }
 
         this.hadPendingThreads = this.destroyPendingThreads();
+        this.applyActionToThreads((thread) => {
+            thread.hide();
+        });
 
         // Get annotation location from click event, ignore click if location is invalid
         const location = this.getLocation(event, TYPES.point);

--- a/src/controllers/__tests__/PointModeController-test.js
+++ b/src/controllers/__tests__/PointModeController-test.js
@@ -147,6 +147,7 @@ describe('controllers/PointModeController', () => {
 
         beforeEach(() => {
             controller.destroyPendingThreads = jest.fn().mockReturnValue(false);
+            controller.applyActionToThreads = jest.fn();
             util.isInAnnotationOrMarker = jest.fn().mockReturnValue(false);
             controller.modeButton = {
                 title: 'Point Annotation Mode',
@@ -165,6 +166,7 @@ describe('controllers/PointModeController', () => {
             expect(event.stopPropagation).not.toBeCalled();
             expect(event.preventDefault).not.toBeCalled();
             expect(controller.destroyPendingThreads).not.toBeCalled();
+            expect(controller.applyActionToThreads).not.toBeCalled();
         });
 
         it('should not destroy the pending thread if click was in an annotation or marker', () => {
@@ -180,6 +182,8 @@ describe('controllers/PointModeController', () => {
             expect(event.stopPropagation).toBeCalled();
             expect(event.preventDefault).toBeCalled();
             expect(controller.getLocation).toBeCalled();
+            expect(controller.destroyPendingThreads).toBeCalled();
+            expect(controller.applyActionToThreads).toBeCalled();
         });
 
         it('should not create a thread if a location object cannot be inferred from the event', () => {
@@ -193,6 +197,8 @@ describe('controllers/PointModeController', () => {
             expect(event.preventDefault).toBeCalled();
             expect(controller.registerThread).not.toBeCalled();
             expect(controller.getLocation).toBeCalled();
+            expect(controller.destroyPendingThreads).toBeCalled();
+            expect(controller.applyActionToThreads).toBeCalled();
         });
 
         it('should create, show, and bind listeners to a thread', () => {
@@ -208,6 +214,8 @@ describe('controllers/PointModeController', () => {
             expect(event.stopPropagation).toBeCalled();
             expect(event.preventDefault).toBeCalled();
             expect(controller.getLocation).toBeCalled();
+            expect(controller.destroyPendingThreads).toBeCalled();
+            expect(controller.applyActionToThreads).toBeCalled();
         });
     });
 });


### PR DESCRIPTION
Fixes this issue: 
![Mar-15-2019 11-19-20](https://user-images.githubusercontent.com/3299001/54453282-4095fc00-4714-11e9-9e04-bc7e01bb371a.gif)
