### PR TITLE
fix(docs): Revert annotation asset paths used by example site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,10 +4,10 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <link rel="stylesheet" href="./styles.css" />
         <link rel="stylesheet" href="https://cdn01.boxcdn.net/platform/preview/2.32.1/en-US/preview.css" />
-        <link rel="stylesheet" href="https://unpkg.com/box-annotations/dist/annotations.css" />
+        <link rel="stylesheet" href="https://unpkg.com/box-annotations/lib/annotations.css" />
         <script src="https://cdn01.boxcdn.net/polyfills/core-js/2.5.3/core.min.js"></script>
         <script src="https://cdn01.boxcdn.net/platform/preview/2.32.1/en-US/preview.js"></script>
-        <script src="https://unpkg.com/box-annotations/dist/annotations.js"></script>
+        <script src="https://unpkg.com/box-annotations/lib/annotations.js"></script>
     </head>
 
     <body>


### PR DESCRIPTION
It looks like this page gets deployed to https://opensource.box.com/box-annotations automatically, but the latest release of Annotations was still published under `lib` rather than `dist`. We'll need to change this back once we do another release from master.