### PR TITLE
feat(eventing): add removeAllListeners

### DIFF
--- a/src/common/BaseAnnotator.ts
+++ b/src/common/BaseAnnotator.ts
@@ -116,6 +116,10 @@ export default class BaseAnnotator {
         eventManager.addListener(event, listener);
     }
 
+    removeAllListeners(event?: string | symbol): void {
+        eventManager.removeAllListeners(event);
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     removeListener(event: string | symbol, listener: (...args: any[]) => void): void {
         eventManager.removeListener(event, listener);

--- a/src/common/__mocks__/EventManager.ts
+++ b/src/common/__mocks__/EventManager.ts
@@ -2,4 +2,5 @@ module.exports = {
     addListener: jest.fn(),
     emit: jest.fn(),
     removeListener: jest.fn(),
+    removeAllListeners: jest.fn(),
 };

--- a/src/common/__tests__/BaseAnnotator-test.ts
+++ b/src/common/__tests__/BaseAnnotator-test.ts
@@ -130,6 +130,13 @@ describe('BaseAnnotator', () => {
             });
         });
 
+        describe('removeAllListeners()', () => {
+            test('should proxy removeAllListeners to eventManager', () => {
+                annotator.removeAllListeners();
+                expect(eventManager.removeAllListeners).toHaveBeenCalled();
+            });
+        });
+
         describe('removeListener()', () => {
             test('should proxy removeListener to eventManager', () => {
                 annotator.removeListener('foo', noop);


### PR DESCRIPTION
Looks like Preview SDK makes a call to `annotator.removeAllListeners()`