### PR TITLE
fix(baseannotator): remove argument form removeAllListeners

### DIFF
--- a/src/common/BaseAnnotator.ts
+++ b/src/common/BaseAnnotator.ts
@@ -116,8 +116,8 @@ export default class BaseAnnotator {
         eventManager.addListener(event, listener);
     }
 
-    removeAllListeners(event?: string | symbol): void {
-        eventManager.removeAllListeners(event);
+    removeAllListeners(): void {
+        eventManager.removeAllListeners();
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Was causing a memory leak of listeners added by client libraries (preview SDK) because `undefined` was being proxied to `EventEmitter.removeAllListeners`