### PR TITLE
fix(region): Batch region drawing and round on create to avoid jank

### DIFF
--- a/src/region/RegionAnnotations.tsx
+++ b/src/region/RegionAnnotations.tsx
@@ -59,8 +59,22 @@ export default class RegionAnnotations extends React.Component<Props, State> {
         this.setStaged({ message: text });
     };
 
-    handleDraw = (shape: Rect): void => {
-        this.setStaged({ shape: this.scaleShape(shape, true) }); // Store at a scale of 1
+    handleDraw = (rawShape: Rect): void => {
+        const { staged } = this.props;
+        const newShape = this.scaleShape(rawShape, true);
+        const prevShape = staged && staged.shape;
+
+        if (
+            prevShape &&
+            prevShape.height === newShape.height &&
+            prevShape.width === newShape.width &&
+            prevShape.x === newShape.x &&
+            prevShape.y === newShape.y
+        ) {
+            return;
+        }
+
+        this.setStaged({ shape: newShape }); // Store at a scale of 1
     };
 
     handleStart = (): void => {
@@ -91,10 +105,10 @@ export default class RegionAnnotations extends React.Component<Props, State> {
 
         return {
             ...rest,
-            height: Math.round(height * ratio),
-            width: Math.round(width * ratio),
-            x: Math.round(x * ratio),
-            y: Math.round(y * ratio),
+            height: height * ratio,
+            width: width * ratio,
+            x: x * ratio,
+            y: y * ratio,
         };
     }
 

--- a/src/region/__tests__/actions-test.ts
+++ b/src/region/__tests__/actions-test.ts
@@ -1,23 +1,53 @@
 import { Rect } from '../../@types';
 import { createRegionAction } from '../actions';
+import { createAnnotationAction } from '../../store/annotations';
+
+jest.mock('../../store/annotations');
 
 describe('region/actions', () => {
     describe('createRegionAction', () => {
-        test('should return a promise that proxies createAnnotationAction', async () => {
-            const arg = {
-                location: 5,
-                message: 'message',
-                shape: {
-                    x: 10,
-                    y: 10,
-                } as Rect,
-            };
-            const dispatch = jest.fn();
-            const getState = jest.fn();
+        const arg = {
+            location: 5,
+            message: 'message',
+            shape: {
+                height: 100.25,
+                width: 100.25,
+                x: 10.75,
+                y: 10.75,
+            } as Rect,
+        };
+        const dispatch = jest.fn();
+        const getState = jest.fn();
+
+        test('should return a promise that proxies the async createAnnotationAction', async () => {
             const result = await createRegionAction(arg)(dispatch, getState, {});
 
-            expect(dispatch).toHaveBeenCalledTimes(3); // pending, saveAnnotations, fulfilled
+            expect(dispatch).toHaveBeenCalledTimes(3); // pending, createAnnotation, fulfilled
             expect(result.meta.arg).toEqual(arg);
+        });
+
+        test('should round the argument target position and size to the nearest whole integer', async () => {
+            await createRegionAction(arg)(dispatch, getState, {});
+
+            expect(createAnnotationAction).toHaveBeenCalledWith({
+                description: {
+                    message: 'message',
+                    type: 'reply',
+                },
+                target: {
+                    location: {
+                        type: 'page',
+                        value: 5,
+                    },
+                    shape: {
+                        height: 100,
+                        width: 100,
+                        x: 11,
+                        y: 11,
+                    },
+                    type: 'region',
+                },
+            });
         });
     });
 });

--- a/src/region/actions.ts
+++ b/src/region/actions.ts
@@ -20,7 +20,13 @@ export const createRegionAction = createAsyncThunk('CREATE_REGION', async (arg: 
                 type: 'page' as const,
                 value: location,
             },
-            shape,
+            shape: {
+                ...shape,
+                height: Math.round(shape.height),
+                width: Math.round(shape.width),
+                x: Math.round(shape.x),
+                y: Math.round(shape.y),
+            },
             type: 'region' as const,
         },
     };


### PR DESCRIPTION
I was seeing some jank at higher scale ratios due to the loss of coordinate resolution during the draw phase.