### PR TITLE
feat(i18n): add options field

### DIFF
--- a/src/BoxAnnotations.ts
+++ b/src/BoxAnnotations.ts
@@ -9,6 +9,10 @@ type Annotator = {
     VIEWERS: string[];
 };
 
+type AnnotationsOptions = {
+    intl: IntlOptions;
+};
+
 type PreviewOptions = {
     file?: {
         permissions?: Permissions;
@@ -47,7 +51,7 @@ const ANNOTATORS: Annotator[] = [
 class BoxAnnotations {
     annotators: Annotator[];
 
-    annotationsOptions?: IntlOptions;
+    annotationsOptions?: AnnotationsOptions;
 
     viewerOptions?: ViewerOptions | null;
 
@@ -58,7 +62,7 @@ class BoxAnnotations {
      * @param {AnnotationsOptions } options - options passed to the annotations instance
      * @return {BoxAnnotations} BoxAnnotations instance
      */
-    constructor(viewerOptions?: ViewerOptions, options?: IntlOptions) {
+    constructor(viewerOptions?: ViewerOptions, options?: AnnotationsOptions) {
         this.annotators = ANNOTATORS;
         this.annotationsOptions = options;
         this.viewerOptions = viewerOptions;
@@ -118,7 +122,7 @@ class BoxAnnotations {
         return { ...annotator, TYPES: enabledTypes };
     }
 
-    getOptions(): IntlOptions | undefined {
+    getOptions(): AnnotationsOptions | undefined {
         return this.annotationsOptions;
     }
 }

--- a/src/BoxAnnotations.ts
+++ b/src/BoxAnnotations.ts
@@ -2,6 +2,11 @@ import getProp from 'lodash/get';
 import DocumentAnnotator from './document/DocumentAnnotator';
 import { Permissions, PERMISSIONS, Type } from './@types';
 
+type AnnotationsOptions = {
+    messages?: Record<string, string>;
+    locale?: string;
+};
+
 type Annotator = {
     CONSTRUCTOR: typeof DocumentAnnotator;
     NAME: string;
@@ -37,15 +42,17 @@ type ViewerOptions = Record<string, ViewerOption>;
  */
 const ANNOTATORS: Annotator[] = [
     {
-        NAME: 'Document',
         CONSTRUCTOR: DocumentAnnotator,
-        VIEWERS: ['Document', 'Presentation'],
+        NAME: 'Document',
         TYPES: [Type.region],
+        VIEWERS: ['Document', 'Presentation'],
     },
 ];
 
 class BoxAnnotations {
     annotators: Annotator[];
+
+    annotationsOptions?: AnnotationsOptions;
 
     viewerOptions?: ViewerOptions | null;
 
@@ -53,10 +60,12 @@ class BoxAnnotations {
      * [constructor]
      *
      * @param {Object} viewerOptions - Viewer-specific annotator options
+     * @param {AnnotationsOptions } options - options passed to the annotations instance
      * @return {BoxAnnotations} BoxAnnotations instance
      */
-    constructor(viewerOptions?: ViewerOptions) {
+    constructor(viewerOptions?: ViewerOptions, options?: AnnotationsOptions) {
         this.annotators = ANNOTATORS;
+        this.annotationsOptions = options;
         this.viewerOptions = viewerOptions;
     }
 
@@ -112,6 +121,10 @@ class BoxAnnotations {
         const enabledTypes = enabledTypesBase.filter((type: string) => annotator.TYPES.some(t => t === type));
 
         return { ...annotator, TYPES: enabledTypes };
+    }
+
+    getAnnotationsOptions(): AnnotationsOptions | undefined {
+        return this.annotationsOptions;
     }
 }
 

--- a/src/BoxAnnotations.ts
+++ b/src/BoxAnnotations.ts
@@ -3,8 +3,9 @@ import DocumentAnnotator from './document/DocumentAnnotator';
 import { Permissions, PERMISSIONS, Type } from './@types';
 
 type AnnotationsOptions = {
-    messages?: Record<string, string>;
+    language?: string;
     locale?: string;
+    messages?: Record<string, string>;
 };
 
 type Annotator = {
@@ -123,7 +124,7 @@ class BoxAnnotations {
         return { ...annotator, TYPES: enabledTypes };
     }
 
-    getAnnotationsOptions(): AnnotationsOptions | undefined {
+    getOptions(): AnnotationsOptions | undefined {
         return this.annotationsOptions;
     }
 }

--- a/src/BoxAnnotations.ts
+++ b/src/BoxAnnotations.ts
@@ -1,12 +1,6 @@
 import getProp from 'lodash/get';
 import DocumentAnnotator from './document/DocumentAnnotator';
-import { Permissions, PERMISSIONS, Type } from './@types';
-
-type AnnotationsOptions = {
-    language?: string;
-    locale?: string;
-    messages?: Record<string, string>;
-};
+import { IntlOptions, Permissions, PERMISSIONS, Type } from './@types';
 
 type Annotator = {
     CONSTRUCTOR: typeof DocumentAnnotator;
@@ -53,7 +47,7 @@ const ANNOTATORS: Annotator[] = [
 class BoxAnnotations {
     annotators: Annotator[];
 
-    annotationsOptions?: AnnotationsOptions;
+    annotationsOptions?: IntlOptions;
 
     viewerOptions?: ViewerOptions | null;
 
@@ -64,7 +58,7 @@ class BoxAnnotations {
      * @param {AnnotationsOptions } options - options passed to the annotations instance
      * @return {BoxAnnotations} BoxAnnotations instance
      */
-    constructor(viewerOptions?: ViewerOptions, options?: AnnotationsOptions) {
+    constructor(viewerOptions?: ViewerOptions, options?: IntlOptions) {
         this.annotators = ANNOTATORS;
         this.annotationsOptions = options;
         this.viewerOptions = viewerOptions;
@@ -124,7 +118,7 @@ class BoxAnnotations {
         return { ...annotator, TYPES: enabledTypes };
     }
 
-    getOptions(): AnnotationsOptions | undefined {
+    getOptions(): IntlOptions | undefined {
         return this.annotationsOptions;
     }
 }

--- a/src/__tests__/BoxAnnotations-test.js
+++ b/src/__tests__/BoxAnnotations-test.js
@@ -159,7 +159,7 @@ describe('BoxAnnotations', () => {
     });
 
     describe('getOptions', () => {
-        it.each([undefined, { messages: { test: 'Hello' } }])(
+        it.each([undefined, { intl: { messages: { test: 'Hello' } } }])(
             'should return the passed in options when they are %o',
             mockOptions => {
                 loader = new BoxAnnotations(null, mockOptions);

--- a/src/__tests__/BoxAnnotations-test.js
+++ b/src/__tests__/BoxAnnotations-test.js
@@ -157,4 +157,17 @@ describe('BoxAnnotations', () => {
             expect(loader.determineAnnotator(options, config)).toBeNull();
         });
     });
+
+    describe('getAnnotationsOptions', () => {
+        it.each([undefined, { messages: { test: 'Hello' } }])(
+            'should return the passed in options when they are %o',
+            mockOptions => {
+                loader = new BoxAnnotations(null, mockOptions);
+
+                const options = loader.getAnnotationsOptions();
+
+                expect(options).toEqual(mockOptions);
+            },
+        );
+    });
 });

--- a/src/__tests__/BoxAnnotations-test.js
+++ b/src/__tests__/BoxAnnotations-test.js
@@ -158,13 +158,13 @@ describe('BoxAnnotations', () => {
         });
     });
 
-    describe('getAnnotationsOptions', () => {
+    describe('getOptions', () => {
         it.each([undefined, { messages: { test: 'Hello' } }])(
             'should return the passed in options when they are %o',
             mockOptions => {
                 loader = new BoxAnnotations(null, mockOptions);
 
-                const options = loader.getAnnotationsOptions();
+                const options = loader.getOptions();
 
                 expect(options).toEqual(mockOptions);
             },


### PR DESCRIPTION
* Add options field that can be passed into the instance. These options then will be passed to the annotator in Preview SDK. In this case, we will want to pass intl to the instance and then that should get passed to content preview, or which ever consumer calls `determineAnnotator`. These options will then be passed to the annotator configs in Preview SDK and use the current `intl` framework

- [x] Unit tests