### PR TITLE
feat(image): Add support for region annotations on image files

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "react-tether": "1.0.5",
         "react-textarea-autosize": "^7.1.2",
         "redux": "^4.0.5",
+        "regenerator-runtime": "^0.13.5",
         "scroll-into-view-if-needed": "^2.2.24"
     },
     "devDependencies": {
@@ -100,7 +101,6 @@
         "postcss-loader": "^3.0.0",
         "prettier": "^1.19.1",
         "raw-loader": "^4.0.1",
-        "regenerator-runtime": "^0.13.5",
         "sass-loader": "^8.0.2",
         "style-loader": "^1.1.4",
         "stylelint": "^12.0.0",

--- a/src/BoxAnnotations.ts
+++ b/src/BoxAnnotations.ts
@@ -1,9 +1,12 @@
+import 'regenerator-runtime/runtime';
 import getProp from 'lodash/get';
+import BaseAnnotator from './common/BaseAnnotator';
+import ImageAnnotator from './image/ImageAnnotator';
 import DocumentAnnotator from './document/DocumentAnnotator';
 import { IntlOptions, Permissions, PERMISSIONS, Type } from './@types';
 
 type Annotator = {
-    CONSTRUCTOR: typeof DocumentAnnotator;
+    CONSTRUCTOR: typeof BaseAnnotator;
     NAME: string;
     TYPES: string[];
     VIEWERS: string[];
@@ -45,6 +48,12 @@ const ANNOTATORS: Annotator[] = [
         NAME: 'Document',
         TYPES: [Type.region],
         VIEWERS: ['AutoCAD', 'Document', 'Presentation'],
+    },
+    {
+        CONSTRUCTOR: ImageAnnotator,
+        NAME: 'Image',
+        TYPES: [Type.region],
+        VIEWERS: ['Image'],
     },
 ];
 

--- a/src/common/BaseManager.ts
+++ b/src/common/BaseManager.ts
@@ -2,8 +2,7 @@ import { IntlShape } from 'react-intl';
 import { Store } from 'redux';
 
 export type Options = {
-    page: number;
-    pageEl: HTMLElement;
+    location?: number;
     referenceEl: HTMLElement;
 };
 
@@ -14,6 +13,7 @@ export type Props = {
 
 export default interface BaseManager {
     destroy(): void;
-    exists(pageEl: HTMLElement): boolean;
+    exists(parentEl: HTMLElement): boolean;
     render(props: Props): void;
+    style(styles: Partial<CSSStyleDeclaration>): CSSStyleDeclaration;
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,15 +1,6 @@
-// Annotation CSS constants
-export const CLASS_ANNOTATIONS_LOADED = 'ba-annotations-loaded';
-
 export const ANNOTATOR_EVENT = {
     fetch: 'annotationsfetched',
     error: 'annotationerror',
     scale: 'scaleannotations',
     setVisibility: 'annotationsetvisibility',
-};
-
-export const PLACEHOLDER_USER = {
-    type: 'user',
-    id: '0',
-    email: '',
 };

--- a/src/image/ImageAnnotator.scss
+++ b/src/image/ImageAnnotator.scss
@@ -1,0 +1,11 @@
+.bp-image {
+    .ba-Layer {
+        position: absolute;
+        pointer-events: none;
+    }
+
+    // Applied to img element, which is managed by Preview SDK
+    .ba-is-drawing {
+        user-select: none; // Prevent visible selection highlight
+    }
+}

--- a/src/image/ImageAnnotator.ts
+++ b/src/image/ImageAnnotator.ts
@@ -1,0 +1,112 @@
+import { Unsubscribe } from 'redux';
+import BaseAnnotator, { Options } from '../common/BaseAnnotator';
+import BaseManager from '../common/BaseManager';
+import { getAnnotation } from '../store/annotations';
+import { centerRegion, isRegion, RegionManager } from '../region';
+import { CreatorStatus, getCreatorStatus } from '../store/creator';
+import { scrollToLocation } from '../utils/scroll';
+import './ImageAnnotator.scss';
+
+export const CSS_IS_DRAWING_CLASS = 'ba-is-drawing';
+
+export default class ImageAnnotator extends BaseAnnotator {
+    annotatedEl?: HTMLElement;
+
+    managers: Set<BaseManager> = new Set();
+
+    storeHandler?: Unsubscribe;
+
+    constructor(options: Options) {
+        super(options);
+
+        this.storeHandler = this.store.subscribe(this.handleStore);
+    }
+
+    destroy(): void {
+        if (this.storeHandler) {
+            this.storeHandler();
+        }
+
+        super.destroy();
+    }
+
+    getAnnotatedElement(): HTMLElement | null | undefined {
+        return this.containerEl?.querySelector('.bp-image');
+    }
+
+    getManagers(parentEl: HTMLElement, referenceEl: HTMLElement): Set<BaseManager> {
+        this.managers.forEach(manager => {
+            if (!manager.exists(parentEl)) {
+                manager.destroy();
+                this.managers.delete(manager);
+            }
+        });
+
+        if (this.managers.size === 0) {
+            this.managers.add(new RegionManager({ referenceEl }));
+        }
+
+        return this.managers;
+    }
+
+    getReference(): HTMLElement | null | undefined {
+        return this.annotatedEl?.querySelector('img');
+    }
+
+    handleStore = (): void => {
+        const referenceEl = this.getReference();
+
+        if (!referenceEl) {
+            return;
+        }
+
+        if (getCreatorStatus(this.store.getState()) === CreatorStatus.started) {
+            referenceEl.classList.add(CSS_IS_DRAWING_CLASS);
+        } else {
+            referenceEl.classList.remove(CSS_IS_DRAWING_CLASS);
+        }
+    };
+
+    render(): void {
+        const referenceEl = this.getReference();
+
+        if (!this.annotatedEl || !referenceEl) {
+            return;
+        }
+
+        this.getManagers(this.annotatedEl, referenceEl).forEach(manager => {
+            manager.style({
+                height: `${referenceEl.offsetHeight}px`,
+                left: `${referenceEl.offsetLeft}px`,
+                top: `${referenceEl.offsetTop}px`,
+                width: `${referenceEl.offsetWidth}px`,
+            });
+
+            manager.render({
+                intl: this.intl,
+                store: this.store,
+            });
+        });
+    }
+
+    scrollToAnnotation(annotationId: string | null): void {
+        if (!annotationId) {
+            return;
+        }
+
+        const annotation = getAnnotation(this.store.getState(), annotationId);
+        const annotationLocation = annotation?.target.location.value ?? 1;
+        const referenceEl = this.getReference();
+
+        if (!annotation || !annotationLocation || !referenceEl || !this.annotatedEl) {
+            return;
+        }
+
+        if (isRegion(annotation)) {
+            // TODO: Add support for scroll when image is rotated
+            scrollToLocation(this.annotatedEl, referenceEl, {
+                offsets: centerRegion(annotation.target.shape),
+            });
+        }
+    }
+}

--- a/src/image/__tests__/ImageAnnotator-test.ts
+++ b/src/image/__tests__/ImageAnnotator-test.ts
@@ -1,0 +1,222 @@
+import ImageAnnotator, { CSS_IS_DRAWING_CLASS } from '../ImageAnnotator';
+import RegionManager from '../../region/RegionManager';
+import { Annotation } from '../../@types';
+import { CreatorStatus, fetchAnnotationsAction, setStatusAction } from '../../store';
+import { annotations as regions } from '../../region/__mocks__/data';
+import { scrollToLocation } from '../../utils/scroll';
+
+jest.mock('../../region/RegionManager');
+jest.mock('../../utils/scroll');
+
+describe('ImageAnnotator', () => {
+    const container = document.createElement('div');
+    const defaults = {
+        apiHost: 'https://api.box.com',
+        container,
+        file: {
+            id: '12345',
+            file_version: { id: '98765' },
+            permissions: {
+                can_create_annotations: true,
+                can_view_annotations: true,
+            },
+        },
+        intl: {
+            messages: {},
+        },
+        locale: 'en-US',
+        token: '1234567890',
+    };
+    const getAnnotator = (options = {}): ImageAnnotator => new ImageAnnotator({ ...defaults, ...options });
+    const getImage = (): HTMLElement => {
+        const image = container.querySelector('.image') as HTMLElement;
+
+        Object.defineProperty(image, 'offsetHeight', { configurable: true, value: 100 });
+        Object.defineProperty(image, 'offsetLeft', { configurable: true, value: 50 });
+        Object.defineProperty(image, 'offsetTop', { configurable: true, value: 50 });
+        Object.defineProperty(image, 'offsetWidth', { configurable: true, value: 100 });
+
+        return image;
+    };
+    const getParent = (): HTMLElement => container.querySelector('.bp-image') as HTMLElement;
+    const mockManager = {
+        destroy: jest.fn(),
+        exists: jest.fn(),
+        render: jest.fn(),
+        style: jest.fn(),
+    };
+
+    let annotator = getAnnotator();
+
+    beforeEach(() => {
+        container.classList.add('bp');
+        container.innerHTML = `
+            <div class="bp-image">
+                <img alt="test" class="image" src="data:image/png;base64, test" />
+            </div>
+        `;
+
+        annotator = getAnnotator();
+    });
+
+    afterEach(() => {
+        if (annotator) {
+            annotator.destroy();
+        }
+    });
+
+    describe('destroy', () => {
+        test('should unsubscribe from the store', () => {
+            jest.spyOn(annotator, 'storeHandler');
+
+            annotator.destroy();
+
+            expect(annotator.storeHandler).toHaveBeenCalled();
+        });
+    });
+
+    describe('getManagers()', () => {
+        test('should create new managers if they are not present in the annotated element', () => {
+            const managers = annotator.getManagers(getParent(), getImage());
+
+            expect(managers.size).toBe(1);
+            expect(managers.values().next().value).toBeInstanceOf(RegionManager);
+        });
+
+        test('should destroy any existing managers if they are not present in the annotated element', () => {
+            mockManager.exists.mockReturnValue(false);
+            annotator.managers = new Set([mockManager]);
+
+            const managers = annotator.getManagers(getParent(), getImage());
+
+            expect(mockManager.exists).toHaveBeenCalled();
+            expect(mockManager.destroy).toHaveBeenCalled();
+            expect(managers.values().next().value).not.toEqual(mockManager);
+        });
+
+        test('should return the existing managers if they already exist in the annotated element', () => {
+            mockManager.exists.mockReturnValue(true);
+            annotator.managers = new Set([mockManager]);
+
+            const managers = annotator.getManagers(getParent(), getImage());
+
+            expect(mockManager.exists).toHaveBeenCalled();
+            expect(mockManager.destroy).not.toHaveBeenCalled();
+            expect(managers.values().next().value).toEqual(mockManager);
+        });
+    });
+
+    describe('getReference()', () => {
+        test('should return the underlying image element', () => {
+            annotator.init(1);
+
+            expect(annotator.getReference()).toBe(container.querySelector('.image'));
+        });
+    });
+
+    describe('handleStore', () => {
+        test('should update the reference element with the correct class', () => {
+            jest.spyOn(annotator, 'getReference').mockImplementation(getImage);
+
+            annotator.store.dispatch(setStatusAction(CreatorStatus.init));
+            expect(getImage().classList).not.toContain(CSS_IS_DRAWING_CLASS);
+
+            annotator.store.dispatch(setStatusAction(CreatorStatus.started));
+            expect(getImage().classList).toContain(CSS_IS_DRAWING_CLASS);
+
+            annotator.store.dispatch(setStatusAction(CreatorStatus.pending));
+            expect(getImage().classList).not.toContain(CSS_IS_DRAWING_CLASS);
+        });
+    });
+
+    describe('init()', () => {
+        beforeEach(() => {
+            jest.spyOn(annotator, 'render');
+        });
+
+        test('should do nothing if the root element is not defined', () => {
+            annotator.container = '#nonsense';
+            annotator.init(2);
+
+            expect(annotator.render).not.toHaveBeenCalled();
+        });
+
+        test('should set the root and annotated element based on class name', () => {
+            annotator.init(2);
+
+            expect(annotator.containerEl).toBe(container);
+            expect(annotator.annotatedEl).toBe(getParent());
+            expect(annotator.render).toHaveBeenCalled();
+        });
+    });
+
+    describe('render()', () => {
+        beforeEach(() => {
+            jest.spyOn(annotator, 'getManagers').mockImplementation(() => new Set([mockManager]));
+            jest.spyOn(annotator, 'getReference').mockImplementation(getImage);
+        });
+
+        test('should initialize a manager for a new page', () => {
+            annotator.init(1);
+            annotator.render();
+
+            expect(annotator.getManagers).toHaveBeenCalled();
+            expect(mockManager.render).toHaveBeenCalledWith({
+                intl: annotator.intl,
+                store: expect.any(Object),
+            });
+            expect(mockManager.style).toHaveBeenCalledWith({
+                height: '100px',
+                left: '50px',
+                top: '50px',
+                width: '100px',
+            });
+        });
+
+        test('should do nothing if the annotated element is not defined', () => {
+            annotator.annotatedEl = undefined;
+            annotator.render();
+
+            expect(annotator.getManagers).not.toHaveBeenCalled();
+            expect(mockManager.render).not.toHaveBeenCalled();
+            expect(mockManager.style).not.toHaveBeenCalled();
+        });
+
+        test('should do nothing if the reference image element is not defined', () => {
+            annotator.getReference = jest.fn();
+            annotator.init(1);
+            annotator.render();
+
+            expect(annotator.getManagers).not.toHaveBeenCalled();
+            expect(mockManager.render).not.toHaveBeenCalled();
+            expect(mockManager.style).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('scrollToAnnotation()', () => {
+        beforeEach(() => {
+            const payload = {
+                entries: regions as Annotation[],
+                limit: 1000,
+                next_marker: null,
+                previous_marker: null,
+            };
+
+            annotator.annotatedEl = getParent();
+            annotator.store.dispatch(fetchAnnotationsAction.fulfilled(payload, 'test', undefined));
+        });
+
+        test('should call scrollToLocation for region annotations', () => {
+            annotator.scrollToAnnotation('anno_1');
+            expect(scrollToLocation).toHaveBeenCalledWith(getParent(), getImage(), { offsets: { x: 15, y: 15 } });
+        });
+
+        test('should do nothing if the annotation id is undefined or not available in the store', () => {
+            annotator.scrollToAnnotation('nonsense');
+            expect(scrollToLocation).not.toHaveBeenCalled();
+
+            annotator.scrollToAnnotation(null);
+            expect(scrollToLocation).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/region/RegionAnnotations.scss
+++ b/src/region/RegionAnnotations.scss
@@ -26,3 +26,7 @@
 .ba-RegionAnnotations-popup {
     pointer-events: auto; // Swallow all pointer events that occur within the popup
 }
+
+.ba-RegionAnnotations-target {
+    pointer-events: none;
+}

--- a/src/region/RegionAnnotations.tsx
+++ b/src/region/RegionAnnotations.tsx
@@ -13,8 +13,8 @@ type Props = {
     annotations: AnnotationRegion[];
     createRegion: (arg: CreateArg) => void;
     isCreating: boolean;
+    location: number;
     message: string;
-    page: number;
     setActiveAnnotationId: (annotationId: string | null) => void;
     setMessage: (message: string) => void;
     setStaged: (staged: CreatorItem | null) => void;
@@ -56,12 +56,12 @@ export default class RegionAnnotations extends React.PureComponent<Props, State>
     handleStart = (): void => {
         const { setStaged, setStatus } = this.props;
         setStaged(null);
-        setStatus(CreatorStatus.init);
+        setStatus(CreatorStatus.started);
     };
 
     handleStop = (shape: Rect): void => {
-        const { page, setStaged, setStatus } = this.props;
-        setStaged({ location: page, shape });
+        const { location, setStaged, setStatus } = this.props;
+        setStaged({ location, shape });
         setStatus(CreatorStatus.staged);
     };
 
@@ -82,7 +82,7 @@ export default class RegionAnnotations extends React.PureComponent<Props, State>
     render(): JSX.Element {
         const { activeAnnotationId, annotations, isCreating, message, staged, status } = this.props;
         const { rectRef } = this.state;
-        const canReply = status !== CreatorStatus.init;
+        const canReply = status !== CreatorStatus.started && status !== CreatorStatus.init;
         const isPending = status === CreatorStatus.pending;
 
         return (

--- a/src/region/RegionContainer.tsx
+++ b/src/region/RegionContainer.tsx
@@ -29,12 +29,12 @@ export type Props = {
     status: CreatorStatus;
 };
 
-export const mapStateToProps = (state: AppState, { page }: { page: number }): Props => ({
+export const mapStateToProps = (state: AppState, { location }: { location: number }): Props => ({
     activeAnnotationId: getActiveAnnotationId(state),
-    annotations: getAnnotationsForLocation(state, page).filter(isRegion),
+    annotations: getAnnotationsForLocation(state, location).filter(isRegion),
     isCreating: getAnnotationMode(state) === 'region',
     message: getCreatorMessage(state),
-    staged: getCreatorStagedForLocation(state, page),
+    staged: getCreatorStagedForLocation(state, location),
     status: getCreatorStatus(state),
 });
 

--- a/src/region/RegionList.tsx
+++ b/src/region/RegionList.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import * as Redux from 'react-redux';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
 import RegionAnnotation from './RegionAnnotation';
 import useOutsideEvent from '../common/useOutsideEvent';
 import { AnnotationRegion } from '../@types';
+import { getRotation } from '../store/options';
 
 export type Props = {
     activeId?: string | null;
@@ -34,6 +36,7 @@ export function sortRegion({ target: targetA }: AnnotationRegion, { target: targ
 export function RegionList({ activeId, annotations, className, onSelect = noop }: Props): JSX.Element {
     const [isListening, setIsListening] = React.useState(true);
     const rootElRef = React.createRef<HTMLDivElement>();
+    const rotation = Redux.useSelector(getRotation);
 
     // Document-level event handlers for focus and pointer control
     useOutsideEvent('mousedown', rootElRef, (): void => {
@@ -43,7 +46,11 @@ export function RegionList({ activeId, annotations, className, onSelect = noop }
     useOutsideEvent('mouseup', rootElRef, (): void => setIsListening(true));
 
     return (
-        <div ref={rootElRef} className={classNames(className, { 'is-listening': isListening })}>
+        <div
+            ref={rootElRef}
+            className={classNames(className, { 'is-listening': isListening })}
+            style={{ transform: `rotate(${rotation}deg)` }}
+        >
             {annotations
                 .filter(filterRegion)
                 .sort(sortRegion)

--- a/src/region/RegionManager.tsx
+++ b/src/region/RegionManager.tsx
@@ -4,31 +4,28 @@ import BaseManager, { Options, Props } from '../common/BaseManager';
 import RegionContainer from './RegionContainer';
 
 export default class RegionManager implements BaseManager {
-    page: number;
+    location: number;
 
-    pageEl: HTMLElement;
+    reactEl: HTMLElement;
 
-    rootEl: HTMLElement;
-
-    constructor({ page, pageEl, referenceEl }: Options) {
-        this.page = page;
-        this.pageEl = pageEl;
-        this.rootEl = this.insert(referenceEl);
+    constructor({ location = 1, referenceEl }: Options) {
+        this.location = location;
+        this.reactEl = this.insert(referenceEl);
     }
 
     destroy(): void {
-        ReactDOM.unmountComponentAtNode(this.rootEl);
+        ReactDOM.unmountComponentAtNode(this.reactEl);
 
-        this.rootEl.remove();
+        this.reactEl.remove();
     }
 
-    exists(pageEl: HTMLElement): boolean {
-        return pageEl.contains(this.rootEl);
+    exists(parentEl: HTMLElement): boolean {
+        return parentEl.contains(this.reactEl);
     }
 
     insert(referenceEl: HTMLElement): HTMLElement {
         // Find the nearest applicable reference and document elements
-        const documentEl = this.pageEl.ownerDocument || document;
+        const documentEl = referenceEl.ownerDocument || document;
         const parentEl = referenceEl.parentNode || documentEl;
 
         // Construct a layer element where we can inject a root React component
@@ -42,6 +39,10 @@ export default class RegionManager implements BaseManager {
     }
 
     render(props: Props): void {
-        ReactDOM.render(<RegionContainer page={this.page} {...props} />, this.rootEl);
+        ReactDOM.render(<RegionContainer location={this.location} {...props} />, this.reactEl);
+    }
+
+    style(styles: Partial<CSSStyleDeclaration>): CSSStyleDeclaration {
+        return Object.assign(this.reactEl.style, styles);
     }
 }

--- a/src/region/__tests__/RegionAnnotations-test.tsx
+++ b/src/region/__tests__/RegionAnnotations-test.tsx
@@ -18,8 +18,8 @@ describe('components/region/RegionAnnotations', () => {
     const defaults = {
         activeAnnotationId: null,
         createRegion: jest.fn(),
+        location: 1,
         message: 'test',
-        page: 1,
         setActiveAnnotationId: jest.fn(),
         setMessage: jest.fn(),
         setStaged: jest.fn(),
@@ -75,7 +75,7 @@ describe('components/region/RegionAnnotations', () => {
                 instance.handleStart();
 
                 expect(defaults.setStaged).toHaveBeenCalledWith(null);
-                expect(defaults.setStatus).toHaveBeenCalledWith(CreatorStatus.init);
+                expect(defaults.setStatus).toHaveBeenCalledWith(CreatorStatus.started);
             });
         });
 
@@ -92,7 +92,7 @@ describe('components/region/RegionAnnotations', () => {
                 instance.handleStop(shape);
 
                 expect(defaults.setStaged).toHaveBeenCalledWith({
-                    location: defaults.page,
+                    location: defaults.location,
                     shape,
                 });
                 expect(defaults.setStatus).toHaveBeenCalledWith(CreatorStatus.staged);

--- a/src/region/__tests__/RegionContainer-test.tsx
+++ b/src/region/__tests__/RegionContainer-test.tsx
@@ -11,7 +11,7 @@ jest.mock('../RegionAnnotations');
 describe('RegionContainer', () => {
     const defaults = {
         intl: {} as IntlShape,
-        page: 1,
+        location: 1,
         store: createStore(),
     };
     const getWrapper = (props = {}): ReactWrapper<Props> => mount(<RegionContainer {...defaults} {...props} />);
@@ -26,8 +26,8 @@ describe('RegionContainer', () => {
                 annotations: [],
                 createRegion: expect.any(Function),
                 isCreating: false,
+                location: 1,
                 message: '',
-                page: defaults.page,
                 staged: null,
                 status: CreatorStatus.init,
                 setActiveAnnotationId: expect.any(Function),

--- a/src/region/__tests__/RegionList-test.tsx
+++ b/src/region/__tests__/RegionList-test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as ReactRedux from 'react-redux';
 import { shallow, ShallowWrapper } from 'enzyme';
 import RegionAnnotation from '../RegionAnnotation';
 import RegionList from '../RegionList';
@@ -27,6 +28,7 @@ describe('RegionList', () => {
         setIsListeningValue.current = null; // Reset the mocked state
 
         jest.spyOn(React, 'useState').mockImplementation(() => [setIsListeningValue.current, setIsListening]);
+        jest.spyOn(ReactRedux, 'useSelector').mockImplementation(() => 0);
     });
 
     describe('event handlers', () => {

--- a/src/region/__tests__/RegionManager-test.ts
+++ b/src/region/__tests__/RegionManager-test.ts
@@ -1,8 +1,8 @@
 import ReactDOM from 'react-dom';
 import { createIntl } from 'react-intl';
+import RegionManager from '../RegionManager';
 import { createStore } from '../../store';
 import { Options } from '../../common/BaseManager';
-import RegionManager from '../RegionManager';
 
 jest.mock('react-dom', () => ({
     render: jest.fn(),
@@ -11,48 +11,65 @@ jest.mock('react-dom', () => ({
 
 describe('RegionManager', () => {
     const intl = createIntl({ locale: 'en' });
-    const pageEl = document.createElement('div');
-    const getWrapper = (options: Options): RegionManager => new RegionManager(options);
-    let wrapper: RegionManager;
+    const rootEl = document.createElement('div');
+    const getOptions = (options: Partial<Options> = {}): Options => ({
+        referenceEl: rootEl.querySelector('.reference') as HTMLElement,
+        ...options,
+    });
+    const getLayer = (): HTMLElement => rootEl.querySelector('[data-testid="ba-Layer--region"]') as HTMLElement;
+    const getWrapper = (options?: Partial<Options>): RegionManager => new RegionManager(getOptions(options));
 
     beforeEach(() => {
-        pageEl.innerHTML = `<div class="reference" />`;
-
-        wrapper = getWrapper({
-            page: 1,
-            pageEl,
-            referenceEl: pageEl.querySelector('.reference') as HTMLElement,
-        });
+        rootEl.classList.add('root');
+        rootEl.innerHTML = '<div class="reference" />'; // referenceEl
     });
 
     describe('constructor', () => {
         test('should set all necessary properties', () => {
-            expect(wrapper.page).toEqual(1);
-            expect(wrapper.pageEl).toEqual(pageEl);
-            expect(wrapper.rootEl).toEqual(pageEl.querySelector('[data-testid="ba-Layer--region"]'));
+            const wrapper = getWrapper();
+
+            expect(wrapper.location).toEqual(1);
+            expect(wrapper.reactEl).toEqual(getLayer());
         });
     });
 
     describe('destroy()', () => {
         test('should unmount the React node and remove the root element', () => {
+            const wrapper = getWrapper();
+
             wrapper.destroy();
 
-            expect(ReactDOM.unmountComponentAtNode).toHaveBeenCalledWith(wrapper.rootEl);
+            expect(ReactDOM.unmountComponentAtNode).toHaveBeenCalledWith(wrapper.reactEl);
         });
     });
 
     describe('exists()', () => {
         test('should return a boolean based on its presence in the page element', () => {
-            expect(wrapper.exists(pageEl)).toBe(true);
+            const wrapper = getWrapper();
+
+            expect(wrapper.exists(rootEl)).toBe(true);
             expect(wrapper.exists(document.createElement('div'))).toBe(false);
         });
     });
 
     describe('render()', () => {
         test('should format the props and pass them to the underlying components', () => {
+            const wrapper = getWrapper();
+
             wrapper.render({ intl, store: createStore() });
 
             expect(ReactDOM.render).toHaveBeenCalled();
+        });
+    });
+
+    describe('style', () => {
+        test('should assign the style object to the root element', () => {
+            const wrapper = getWrapper();
+
+            wrapper.style({ left: '5px', top: '10px' });
+
+            expect(getLayer().style.left).toEqual('5px');
+            expect(getLayer().style.top).toEqual('10px');
         });
     });
 });

--- a/src/store/__mocks__/createStore.ts
+++ b/src/store/__mocks__/createStore.ts
@@ -1,0 +1,5 @@
+export default jest.fn(() => ({
+    dispatch: jest.fn(),
+    getState: jest.fn(),
+    subscribe: jest.fn(() => jest.fn()),
+}));

--- a/src/store/creator/types.ts
+++ b/src/store/creator/types.ts
@@ -5,6 +5,7 @@ export enum CreatorStatus {
     pending = 'pending',
     rejected = 'rejected',
     staged = 'staged',
+    started = 'started',
 }
 
 export type CreatorItem = {

--- a/src/store/eventing/__tests__/init-test.ts
+++ b/src/store/eventing/__tests__/init-test.ts
@@ -6,11 +6,32 @@ import { handleAnnotationsInitialized } from '../init';
 jest.mock('../../../common/EventManager');
 
 describe('store/eventing/init', () => {
-    test('should emit annotations_initialized event with annotations', () => {
-        handleAnnotationsInitialized({} as AppState, { annotations: annotationState } as AppState);
+    test('should emit annotations_initialized event with annotations if isInitialized changes to true', () => {
+        handleAnnotationsInitialized(
+            { annotations: { ...annotationState, isInitialized: false } } as AppState,
+            { annotations: { ...annotationState, isInitialized: true } } as AppState,
+        );
 
         expect(eventManager.emit).toBeCalledWith('annotations_initialized', {
             annotations: [annotationState.byId.test1, annotationState.byId.test2, annotationState.byId.test3],
         });
+    });
+
+    test('should do nothing if isInitialized changes to false', () => {
+        handleAnnotationsInitialized(
+            { annotations: { ...annotationState, isInitialized: true } } as AppState,
+            { annotations: { ...annotationState, isInitialized: false } } as AppState,
+        );
+
+        expect(eventManager.emit).not.toBeCalled();
+    });
+
+    test('should do nothing if isInitialized does not change', () => {
+        handleAnnotationsInitialized(
+            { annotations: { ...annotationState, isInitialized: true } } as AppState,
+            { annotations: { ...annotationState, isInitialized: true } } as AppState,
+        );
+
+        expect(eventManager.emit).not.toBeCalled();
     });
 });

--- a/src/store/eventing/init.ts
+++ b/src/store/eventing/init.ts
@@ -1,8 +1,14 @@
 import eventManager from '../../common/EventManager';
 import { AppState } from '../types';
 import { Event } from '../../@types';
-import { getAnnotations } from '../annotations';
+import { getAnnotations, getIsInitialized } from '../annotations';
 
 export const handleAnnotationsInitialized = (prevState: AppState, nextState: AppState): void => {
-    eventManager.emit(Event.ANNOTATIONS_INITIALIZED, { annotations: getAnnotations(nextState) });
+    const prevIsInitialized = getIsInitialized(prevState);
+    const nextIsInitialized = getIsInitialized(nextState);
+
+    // Only emit an event the first time the library is initialized/rendered
+    if (prevIsInitialized !== nextIsInitialized && nextIsInitialized) {
+        eventManager.emit(Event.ANNOTATIONS_INITIALIZED, { annotations: getAnnotations(nextState) });
+    }
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -4,5 +4,6 @@ export { default as createStore } from './createStore';
 export * from './annotations';
 export * from './common';
 export * from './creator';
+export * from './options';
 export * from './types';
 export * from './users';

--- a/src/store/options/__tests__/selectors-test.ts
+++ b/src/store/options/__tests__/selectors-test.ts
@@ -1,4 +1,4 @@
-import { getFileId, getFileVersionId, getPermissions } from '../selectors';
+import { getFileId, getFileVersionId, getPermissions, getRotation, getScale } from '../selectors';
 
 describe('store/options/selectors', () => {
     const optionsState = {
@@ -8,6 +8,8 @@ describe('store/options/selectors', () => {
             can_create_annotations: true,
             can_view_annotations: true,
         },
+        rotation: 0,
+        scale: 1,
     };
 
     describe('getFileVersionId', () => {
@@ -28,6 +30,18 @@ describe('store/options/selectors', () => {
                 can_create_annotations: true,
                 can_view_annotations: true,
             });
+        });
+    });
+
+    describe('getRotation', () => {
+        test('should return the current rotation', () => {
+            expect(getRotation({ options: optionsState })).toBe(0);
+        });
+    });
+
+    describe('getScale', () => {
+        test('should return the current scale', () => {
+            expect(getScale({ options: optionsState })).toBe(1);
         });
     });
 });

--- a/src/store/options/actions.ts
+++ b/src/store/options/actions.ts
@@ -4,3 +4,5 @@ import { Permissions } from '../../@types';
 export const setFileIdAction = createAction<string | null>('SET_FIlE_ID');
 export const setFileVersionIdAction = createAction<string | null>('SET_FILE_VERSION_ID');
 export const setPermissionsAction = createAction<Permissions>('SET_PERMISSIONS');
+export const setRotationAction = createAction<number>('SET_ROTATION');
+export const setScaleAction = createAction<number>('SET_SCALE');

--- a/src/store/options/reducer.ts
+++ b/src/store/options/reducer.ts
@@ -1,11 +1,19 @@
 import { createReducer } from '@reduxjs/toolkit';
 import { OptionsState } from './types';
-import { setFileIdAction, setFileVersionIdAction, setPermissionsAction } from './actions';
+import {
+    setFileIdAction,
+    setFileVersionIdAction,
+    setPermissionsAction,
+    setRotationAction,
+    setScaleAction,
+} from './actions';
 
 export const initialState = {
     fileId: null,
     fileVersionId: null,
     permissions: {},
+    rotation: 0,
+    scale: 1,
 };
 
 export default createReducer<OptionsState>(initialState, builder =>
@@ -18,5 +26,11 @@ export default createReducer<OptionsState>(initialState, builder =>
         })
         .addCase(setPermissionsAction, (state, { payload }) => {
             state.permissions = payload;
+        })
+        .addCase(setRotationAction, (state, { payload }) => {
+            state.rotation = payload;
+        })
+        .addCase(setScaleAction, (state, { payload }) => {
+            state.scale = payload;
         }),
 );

--- a/src/store/options/selectors.ts
+++ b/src/store/options/selectors.ts
@@ -6,3 +6,5 @@ type State = Pick<AppState, 'options'>;
 export const getFileId = (state: State): string | null => state.options.fileId;
 export const getFileVersionId = (state: State): string | null => state.options.fileVersionId;
 export const getPermissions = (state: State): Permissions => state.options.permissions;
+export const getRotation = (state: State): number => state.options.rotation;
+export const getScale = (state: State): number => state.options.scale;

--- a/src/store/options/types.ts
+++ b/src/store/options/types.ts
@@ -4,4 +4,6 @@ export type OptionsState = {
     fileId: string | null;
     fileVersionId: string | null;
     permissions: Permissions;
+    rotation: number;
+    scale: number;
 };

--- a/src/utils/__tests__/scroll-test.ts
+++ b/src/utils/__tests__/scroll-test.ts
@@ -1,0 +1,65 @@
+import { scrollToLocation } from '../scroll';
+
+describe('scrollToLocation', () => {
+    const container = document.createElement('div');
+    const getReference = (offsetTop = 0): HTMLElement => {
+        const page = document.createElement('div');
+
+        Object.defineProperty(page, 'clientHeight', { configurable: true, value: 100 });
+        Object.defineProperty(page, 'clientWidth', { configurable: true, value: 100 });
+        Object.defineProperty(page, 'offsetLeft', { configurable: true, value: 0 });
+        Object.defineProperty(page, 'offsetTop', { configurable: true, value: offsetTop });
+
+        return page;
+    };
+
+    beforeEach(() => {
+        jest.spyOn(container, 'scrollHeight', 'get').mockReturnValue(2000);
+        jest.spyOn(container, 'scrollWidth', 'get').mockReturnValue(2000);
+        jest.spyOn(container, 'scrollLeft', 'set');
+        jest.spyOn(container, 'scrollTop', 'set');
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
+        container.scrollTo = jest.fn((options?: ScrollToOptions) => {
+            const { left, top } = options || {};
+
+            container.scrollLeft = left || 0;
+            container.scrollTop = top || 0;
+        });
+    });
+
+    test.each`
+        parentTop | scrollTop
+        ${-200}   | ${0}
+        ${0}      | ${0}
+        ${200}    | ${200}
+        ${2000}   | ${2000}
+        ${3000}   | ${2000}
+    `('should scroll to $scrollTop with a reference parentTop of $parentTop', ({ parentTop, scrollTop }) => {
+        const reference = getReference(parentTop);
+
+        scrollToLocation(container, reference);
+
+        expect(container.scrollTop).toEqual(scrollTop);
+    });
+
+    test.each`
+        parentTop | scrollLeft | scrollTop
+        ${-200}   | ${50}      | ${0}
+        ${0}      | ${50}      | ${50}
+        ${200}    | ${50}      | ${250}
+        ${2000}   | ${50}      | ${2000}
+        ${3000}   | ${50}      | ${2000}
+    `(
+        'should scroll to $scrollLeft/$scrollTop with a reference parentTop of $parentTop with offsets',
+        ({ parentTop, scrollLeft, scrollTop }) => {
+            const reference = getReference(parentTop);
+
+            scrollToLocation(container, reference, { offsets: { x: 50, y: 50 } });
+
+            expect(container.scrollLeft).toEqual(scrollLeft);
+            expect(container.scrollTop).toEqual(scrollTop);
+        },
+    );
+});

--- a/src/utils/scroll.ts
+++ b/src/utils/scroll.ts
@@ -1,0 +1,35 @@
+import { Position } from '../@types';
+
+export type ScrollOptions = {
+    offsets?: Position;
+    threshold?: number;
+};
+
+const DEFAULT_OFFSETS = { x: 0, y: 0 };
+const DEFAULT_THRESHOLD = 1000; // pixels
+
+export function scrollToLocation(parentEl: HTMLElement, referenceEl: HTMLElement, options: ScrollOptions = {}): void {
+    const { offsets = DEFAULT_OFFSETS, threshold = DEFAULT_THRESHOLD } = options;
+    const { x: offsetX, y: offsetY } = offsets;
+
+    const canSmoothScroll = 'scrollBehavior' in parentEl.style;
+    const parentCenterX = Math.round(parentEl.clientWidth / 2);
+    const parentCenterY = Math.round(parentEl.clientHeight / 2);
+    const offsetCenterX = Math.round(referenceEl.clientWidth * (offsetX / 100));
+    const offsetCenterY = Math.round(referenceEl.clientHeight * (offsetY / 100));
+    const offsetScrollLeft = referenceEl.offsetLeft - parentCenterX + offsetCenterX;
+    const offsetScrollTop = referenceEl.offsetTop - parentCenterY + offsetCenterY;
+    const scrollLeft = Math.max(0, Math.min(offsetScrollLeft, parentEl.scrollWidth));
+    const scrollTop = Math.max(0, Math.min(offsetScrollTop, parentEl.scrollHeight));
+
+    if (canSmoothScroll && Math.abs(parentEl.scrollTop - scrollTop) < threshold) {
+        parentEl.scrollTo({
+            behavior: 'smooth',
+            left: scrollLeft,
+            top: scrollTop,
+        });
+    } else {
+        parentEl.scrollLeft = scrollLeft;
+        parentEl.scrollTop = scrollTop;
+    }
+}


### PR DESCRIPTION
This solution will correctly display rotated annotations when the underlying image is rotated. However, creating annotations when the image is rotated will lead to them being mispositioned. Supporting that case is more complex, so I'll tackle it in a follow-up patchset.

Todo
- [x] Cross-browser testing
- [x] Unit tests for ImageAnnotator