### PR TITLE
fix(style): Reset image annotator layer styles inherited from parent

### DIFF
--- a/src/image/ImageAnnotator.scss
+++ b/src/image/ImageAnnotator.scss
@@ -1,6 +1,8 @@
 .bp-image {
     .ba-Layer {
         position: absolute;
+        white-space: initial; // Overrides white-space: no-wrap inherited .bp-image
+        text-align: initial; // Overrides text-align: center inherited .bp-image
         pointer-events: none;
     }
 


### PR DESCRIPTION
Fixes center-aligned collaborator names/email entries for image annotations.