### PR TITLE
feat(highlights): render interactive element as button

### DIFF
--- a/src/highlight/HighlightCanvas.tsx
+++ b/src/highlight/HighlightCanvas.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { bdlYellorange, black, white } from 'box-ui-elements/es/styles/variables';
+import { bdlYellorange, white } from 'box-ui-elements/es/styles/variables';
 import { Rect } from '../@types';
 import './HighlightCanvas.scss';
 
-export type CanvasShape = Rect & { isActive?: boolean };
+export type CanvasShape = Rect & { annotationId?: string; isActive?: boolean };
 
 export type Props = {
     shapes: CanvasShape[] | CanvasShape;
@@ -117,19 +117,6 @@ export default class HighlightCanvas extends React.PureComponent<Props> {
             context.strokeStyle = white;
             context.lineWidth = 1;
             this.roundRect(context, x1, y1, rectWidth, rectHeight, 5, false, true);
-
-            // If annotation is active, apply a shadow
-            if (isActive) {
-                const imgData = context.getImageData(x1 - 1, y1 - 1, rectWidth + 2, rectHeight + 2);
-
-                context.save();
-                context.shadowColor = black;
-                context.shadowBlur = 10;
-
-                this.roundRect(context, x1, y1, rectWidth, rectHeight, 5, false, true);
-                context.putImageData(imgData, x1 - 1, y1 - 1);
-                context.restore();
-            }
 
             context.restore();
         });

--- a/src/highlight/HighlightList.scss
+++ b/src/highlight/HighlightList.scss
@@ -5,6 +5,12 @@
     width: 100%;
     height: 100%;
 
+    &.is-listening {
+        .ba-HighlightRect {
+            pointer-events: all;
+        }
+    }
+
     .ba-HighlightSvg.is-listening {
         .ba-HighlightTarget-rect {
             pointer-events: all;

--- a/src/highlight/HighlightRect.scss
+++ b/src/highlight/HighlightRect.scss
@@ -1,0 +1,53 @@
+@import '~box-ui-elements/es/styles/variables';
+
+.ba-HighlightRect {
+    $ba-HighlightRect-color: $bdl-yellorange;
+    $ba-HighlightRect-bgColor--default: rgba($ba-HighlightRect-color, 0); // Default color uses zero alpha value for transition
+    $ba-HighlightRect-bgColor--hover: rgba($ba-HighlightRect-color, .1);
+    $ba-HighlightRect-bgColor--active: rgba($ba-HighlightRect-color, 0);
+    $ba-HighlightRect-transitionDelay: 25ms;
+    $ba-HighlightRect-transitionDuration: 200ms;
+
+    $border-radius: 6px;
+    $border-size-inner: 1px;
+    $border-size-outer: 4px;
+
+    position: absolute;
+    // stylelint-disable-next-line declaration-no-important
+    box-sizing: content-box !important; // Padding needs to increase the hit area of the button to include the borders
+    margin: 0;
+    padding: 0;
+    background: none;
+    border: none;
+    box-shadow: none;
+
+    &:hover {
+        cursor: pointer;
+    }
+
+    &:focus {
+        outline: none;
+    }
+
+    &::after {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        display: block;
+        background-color: $ba-HighlightRect-bgColor--default;
+        border-radius: $border-radius;
+        box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
+        transition: background-color $ba-HighlightRect-transitionDuration ease, box-shadow $ba-HighlightRect-transitionDuration ease;
+        content: '';
+    }
+
+    &.is-active {
+        &::after {
+            background-color: $ba-HighlightRect-bgColor--active;
+            box-shadow: 0 2px 8px 0 rgba(0, 0, 0, .2);
+            transition-delay: $ba-HighlightRect-transitionDelay;
+        }
+    }
+}

--- a/src/highlight/HighlightRect.tsx
+++ b/src/highlight/HighlightRect.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import classNames from 'classnames';
+import noop from 'lodash/noop';
+import { CanvasShape } from './HighlightCanvas';
+import './HighlightRect.scss';
+
+type Props = {
+    canvasShape: CanvasShape;
+    onSelect?: (annotationId: string | null) => void;
+};
+
+const HighlightRect = ({ canvasShape, onSelect = noop }: Props, ref: React.Ref<HTMLButtonElement>): JSX.Element => {
+    const { annotationId, height, isActive, width, x, y } = canvasShape;
+
+    const handleFocus = (): void => {
+        if (annotationId) {
+            onSelect(annotationId);
+        }
+    };
+
+    return (
+        <button
+            ref={ref}
+            className={classNames('ba-HighlightRect', { 'is-active': isActive })}
+            onFocus={handleFocus}
+            style={{ top: `${y}%`, left: `${x}%`, height: `${height}%`, width: `${width}%` }}
+            tabIndex={-1}
+            type="button"
+        />
+    );
+};
+
+export default React.forwardRef(HighlightRect);


### PR DESCRIPTION
Changed the interactive highlight element from `svg` anchors and rects, to `button` elements. 

The main tradeoff appears to be multiple click handlers per highlight annotation (depending on how many rects the highlight is composed of) vs flexibility in styling.

The main drawback of the `svg` approach is that in the screenshot below you'll see the corners of the selected highlight are not clean due to the way the rounded corners + drop shadow is implemented.

**Canvas drop shadow:**
![Screen Shot 2020-08-21 at 2 16 40 PM](https://user-images.githubusercontent.com/17791289/90935969-2f492880-e3b9-11ea-817b-a0d32f2ed945.png)

**HTML button drop shadow:**
![Screen Shot 2020-08-21 at 2 12 26 PM](https://user-images.githubusercontent.com/17791289/90935951-26f0ed80-e3b9-11ea-807c-89d070ecd4c3.png)

TODO:
- [ ] Refine types
- [ ] Unit tests