### PR TITLE
feat(highlight): Improve selection logic

### DIFF
--- a/src/document/DocumentAnnotator.ts
+++ b/src/document/DocumentAnnotator.ts
@@ -1,11 +1,10 @@
 import BaseAnnotator, { Options } from '../common/BaseAnnotator';
 import BaseManager from '../common/BaseManager';
-import HighlightListener from '../highlight/HighlightListener';
 import { centerRegion, isRegion, RegionManager } from '../region';
 import { Event } from '../@types';
 import { getAnnotation } from '../store/annotations';
 import { getSelection } from './docUtil';
-import { HighlightManager } from '../highlight';
+import { HighlightListener, HighlightManager } from '../highlight';
 import { Mode } from '../store';
 import { scrollToLocation } from '../utils/scroll';
 import './DocumentAnnotator.scss';

--- a/src/document/__tests__/docUtil-test.ts
+++ b/src/document/__tests__/docUtil-test.ts
@@ -39,11 +39,12 @@ describe('docUtil', () => {
 
     describe('getRange()', () => {
         test.each`
-            selection                                       | result
-            ${null}                                         | ${null}
-            ${{ isCollapsed: true, type: 'Range' }}         | ${null}
-            ${{ type: 'Caret' }}                            | ${null}
-            ${{ getRangeAt: () => 'range', type: 'Range' }} | ${'range'}
+            selection                                                      | result
+            ${null}                                                        | ${null}
+            ${{ type: 'Caret' }}                                           | ${null}
+            ${{ isCollapsed: true, type: 'Range' }}                        | ${null}
+            ${{ isCollapsed: true, rangeCount: 0, type: 'Range' }}         | ${null}
+            ${{ getRangeAt: () => 'range', rangeCount: 1, type: 'Range' }} | ${'range'}
         `('should return range as $result', ({ selection, result }) => {
             jest.spyOn(window, 'getSelection').mockImplementationOnce(() => selection);
 
@@ -73,6 +74,7 @@ describe('docUtil', () => {
                     range.getClientRects = jest.fn().mockReturnValueOnce([]);
                     return range;
                 },
+                rangeCount: 1,
                 type: 'Range',
             } as unknown) as Selection;
         };

--- a/src/document/docUtil.ts
+++ b/src/document/docUtil.ts
@@ -28,11 +28,13 @@ export function getPageNumber(element: Element | null): number | undefined {
 
 export function getRange(): Range | null {
     const selection = window.getSelection();
-    if (!selection || selection.type !== 'Range' || selection.isCollapsed) {
+    if (!selection || selection.type !== 'Range' || selection.isCollapsed || !selection.rangeCount) {
         return null;
     }
 
-    return selection.getRangeAt(0);
+    // Firefox allows to select multiple ranges in the document by using Ctrl/Cmd+click
+    // We only care about the last range
+    return selection.getRangeAt(selection.rangeCount - 1);
 }
 
 export function getSelection(): Selection | null {

--- a/src/highlight/HighlightListener.ts
+++ b/src/highlight/HighlightListener.ts
@@ -1,0 +1,92 @@
+import debounce from 'lodash/debounce';
+import { AppStore, getIsInitialized, SelectionArg as Selection, setSelectionAction } from '../store';
+import { MOUSE_PRIMARY } from '../constants';
+
+export type Options = {
+    getSelection: () => Selection | null;
+    selectionChangeDelay?: number;
+    store: AppStore;
+};
+
+// Debounce 500ms for keyboard selection
+const SELECTION_CHANGE_DEBOUNCE = 500;
+
+export default class HighlightListener {
+    annotatedEl?: HTMLElement;
+
+    getSelection: () => Selection | null;
+
+    isMouseSelecting = false;
+
+    selectionChangeDelay?: number;
+
+    selectionChangeTimer?: number;
+
+    store: AppStore;
+
+    constructor({ getSelection, selectionChangeDelay = 0, store }: Options) {
+        this.getSelection = getSelection;
+        this.selectionChangeDelay = selectionChangeDelay;
+        this.store = store;
+
+        document.addEventListener('selectionchange', this.debounceHandleSelectionChange);
+    }
+
+    destroy(): void {
+        clearTimeout(this.selectionChangeTimer);
+
+        document.removeEventListener('selectionchange', this.debounceHandleSelectionChange);
+
+        if (this.annotatedEl) {
+            this.annotatedEl.removeEventListener('mousedown', this.handleMouseDown);
+            this.annotatedEl.removeEventListener('mouseup', this.handleMouseUp);
+        }
+    }
+
+    init(annotatedEl: HTMLElement): void {
+        this.annotatedEl = annotatedEl;
+
+        // Clear previous selection
+        this.store.dispatch(setSelectionAction(null));
+
+        if (!getIsInitialized(this.store.getState())) {
+            this.annotatedEl.addEventListener('mousedown', this.handleMouseDown);
+            this.annotatedEl.addEventListener('mouseup', this.handleMouseUp);
+        }
+    }
+
+    setSelection = (): void => {
+        this.store.dispatch(setSelectionAction(this.getSelection()));
+    };
+
+    handleMouseDown = ({ buttons }: MouseEvent): void => {
+        if (buttons !== MOUSE_PRIMARY) {
+            return;
+        }
+
+        this.isMouseSelecting = true;
+
+        clearTimeout(this.selectionChangeTimer);
+        this.store.dispatch(setSelectionAction(null));
+    };
+
+    handleMouseUp = (): void => {
+        if (!this.isMouseSelecting) {
+            return;
+        }
+
+        this.isMouseSelecting = false;
+
+        this.selectionChangeTimer = window.setTimeout(this.setSelection, this.selectionChangeDelay);
+    };
+
+    handleSelectionChange = (): void => {
+        if (this.isMouseSelecting) {
+            return;
+        }
+
+        this.setSelection();
+    };
+
+    debounceHandleSelectionChange = debounce(this.handleSelectionChange, SELECTION_CHANGE_DEBOUNCE);
+}

--- a/src/highlight/__tests__/HighlightListener-test.ts
+++ b/src/highlight/__tests__/HighlightListener-test.ts
@@ -1,0 +1,161 @@
+import HighlightListener from '../HighlightListener';
+import { createStore, getIsInitialized } from '../../store';
+import { mockRange } from '../../store/selection/__mocks__/range';
+
+jest.mock('lodash/debounce', () => (func: Function) => func);
+jest.mock('../../store');
+
+jest.useFakeTimers();
+
+describe('HighlightListener', () => {
+    const defaults = {
+        getSelection: jest.fn(() => ({ location: 1, range: mockRange })),
+        store: createStore(),
+    };
+    const mockAnnotatedEl = document.createElement('div');
+
+    const getListener = (options = {}): HighlightListener => {
+        return new HighlightListener({ ...defaults, ...options });
+    };
+
+    let highlightListener: HighlightListener;
+
+    beforeEach(() => {
+        highlightListener = getListener();
+    });
+
+    afterEach(() => {
+        if (highlightListener) {
+            highlightListener.destroy();
+        }
+    });
+
+    describe('constructor()', () => {
+        test('should add selectionchange event listener', () => {
+            jest.spyOn(document, 'addEventListener');
+
+            highlightListener = getListener();
+
+            expect(document.addEventListener).toHaveBeenCalledWith(
+                'selectionchange',
+                highlightListener.handleSelectionChange,
+            );
+        });
+    });
+
+    describe('destroy()', () => {
+        test('should clear timeout and remove event handlers', () => {
+            highlightListener.annotatedEl = mockAnnotatedEl;
+            highlightListener.selectionChangeTimer = 1;
+            jest.spyOn(document, 'removeEventListener');
+            jest.spyOn(mockAnnotatedEl, 'removeEventListener');
+
+            highlightListener.destroy();
+
+            expect(clearTimeout).toHaveBeenCalledWith(1);
+            expect(document.removeEventListener).toHaveBeenCalledWith(
+                'selectionchange',
+                highlightListener.handleSelectionChange,
+            );
+            expect(mockAnnotatedEl.removeEventListener).toHaveBeenCalledWith(
+                'mousedown',
+                highlightListener.handleMouseDown,
+            );
+            expect(mockAnnotatedEl.removeEventListener).toHaveBeenCalledWith(
+                'mouseup',
+                highlightListener.handleMouseUp,
+            );
+        });
+    });
+
+    describe('init()', () => {
+        test('should clear previous selection and add listeners', () => {
+            jest.spyOn(mockAnnotatedEl, 'addEventListener');
+
+            highlightListener.init(mockAnnotatedEl);
+
+            expect(defaults.store.dispatch).toHaveBeenCalledWith(null);
+            expect(mockAnnotatedEl.addEventListener).toHaveBeenCalledWith(
+                'mousedown',
+                highlightListener.handleMouseDown,
+            );
+            expect(mockAnnotatedEl.addEventListener).toHaveBeenCalledWith('mouseup', highlightListener.handleMouseUp);
+        });
+
+        test('should not add listeners if already initialized', () => {
+            jest.spyOn(mockAnnotatedEl, 'addEventListener');
+
+            (getIsInitialized as jest.Mock).mockReturnValueOnce(true);
+
+            highlightListener.init(mockAnnotatedEl);
+
+            expect(mockAnnotatedEl.addEventListener).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('setSelection()', () => {
+        test('should dispatch selection', () => {
+            highlightListener.setSelection();
+
+            expect(defaults.store.dispatch).toHaveBeenCalledWith({ location: 1, range: mockRange });
+        });
+    });
+
+    describe('handleMouseDown', () => {
+        test('should clear timeout and selection', () => {
+            highlightListener.selectionChangeTimer = 1;
+
+            highlightListener.handleMouseDown(new MouseEvent('mousedown', { buttons: 1 }));
+
+            expect(highlightListener.isMouseSelecting).toBe(true);
+            expect(clearTimeout).toHaveBeenCalledWith(1);
+            expect(defaults.store.dispatch).toHaveBeenCalledWith(null);
+        });
+
+        test('should do nothing if is not primary button', () => {
+            highlightListener.handleMouseDown(new MouseEvent('mousedown', { buttons: 2 }));
+
+            expect(highlightListener.isMouseSelecting).toBe(false);
+        });
+    });
+
+    describe('handleMouseUp()', () => {
+        test('should set selection', () => {
+            highlightListener.isMouseSelecting = true;
+            highlightListener.setSelection = jest.fn();
+
+            highlightListener.handleMouseUp();
+
+            expect(highlightListener.isMouseSelecting).toBe(false);
+
+            jest.runAllTimers();
+
+            expect(highlightListener.setSelection).toHaveBeenCalled();
+        });
+
+        test('should do nothing if select not using mouse', () => {
+            highlightListener.handleMouseUp();
+
+            expect(window.setTimeout).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('handleSelectionChange()', () => {
+        test('should clear selection and dispatch new selection', () => {
+            highlightListener.setSelection = jest.fn();
+
+            highlightListener.handleSelectionChange();
+
+            expect(highlightListener.setSelection).toHaveBeenCalled();
+        });
+
+        test('should do nothing if select using mouse', () => {
+            highlightListener.isMouseSelecting = true;
+            highlightListener.setSelection = jest.fn();
+
+            highlightListener.handleSelectionChange();
+
+            expect(highlightListener.setSelection).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/highlight/__tests__/HighlightListener-test.ts
+++ b/src/highlight/__tests__/HighlightListener-test.ts
@@ -1,16 +1,20 @@
+import createStore from '../../store/__mocks__/createStore';
 import HighlightListener from '../HighlightListener';
-import { createStore, getIsInitialized } from '../../store';
+import { AppStore, getIsInitialized } from '../../store';
 import { mockRange } from '../../store/selection/__mocks__/range';
 
 jest.mock('lodash/debounce', () => (func: Function) => func);
-jest.mock('../../store');
+jest.mock('../../store', () => ({
+    getIsInitialized: jest.fn().mockReturnValue(false),
+    setSelectionAction: jest.fn(arg => arg),
+}));
 
 jest.useFakeTimers();
 
 describe('HighlightListener', () => {
     const defaults = {
         getSelection: jest.fn(() => ({ location: 1, range: mockRange })),
-        store: createStore(),
+        store: (createStore() as unknown) as AppStore,
     };
     const mockAnnotatedEl = document.createElement('div');
 

--- a/src/highlight/index.ts
+++ b/src/highlight/index.ts
@@ -1,1 +1,2 @@
+export { default as HighlightListener } from './HighlightListener';
 export { default as HighlightManager } from './HighlightManager';

--- a/src/store/__mocks__/index.ts
+++ b/src/store/__mocks__/index.ts
@@ -12,10 +12,8 @@ module.exports = {
     getCreatorStagedForLocation: jest.fn(),
     getCreatorStatus: jest.fn(),
     getFileId: jest.fn().mockReturnValue('0'),
-    getIsInitialized: jest.fn().mockReturnValue(false),
     getIsCurrentFileVersion: jest.fn().mockReturnValue(true),
     isCreatorStagedHighlight,
     isCreatorStagedRegion,
-    setSelectionAction: jest.fn(arg => arg),
     Mode,
 };

--- a/src/store/__mocks__/index.ts
+++ b/src/store/__mocks__/index.ts
@@ -12,8 +12,10 @@ module.exports = {
     getCreatorStagedForLocation: jest.fn(),
     getCreatorStatus: jest.fn(),
     getFileId: jest.fn().mockReturnValue('0'),
+    getIsInitialized: jest.fn().mockReturnValue(false),
     getIsCurrentFileVersion: jest.fn().mockReturnValue(true),
     isCreatorStagedHighlight,
     isCreatorStagedRegion,
+    setSelectionAction: jest.fn(arg => arg),
     Mode,
 };

--- a/src/store/selection/actions.ts
+++ b/src/store/selection/actions.ts
@@ -1,7 +1,7 @@
 import { createAction } from '@reduxjs/toolkit';
 import { DOMRectMini, SelectionItem } from './types';
 
-export type CreateArg = {
+export type SelectionArg = {
     location: number;
     range: Range;
 };
@@ -19,7 +19,7 @@ export const getDOMRectMini = ({ height, width, x, y }: DOMRect): DOMRectMini =>
 
 export const setSelectionAction = createAction(
     'SET_SELECTION',
-    (arg: CreateArg | null): Payload => {
+    (arg: SelectionArg | null): Payload => {
         if (!arg) {
             return {
                 payload: null,


### PR DESCRIPTION
This PR addresses following feedbacks from product:
1. The promotion popup shouldn't show up during mouse dragging.
2. Debounce keyboard selection 500ms.
3. When there're multiple ranges in one selection, only care about the last one.

Todo:
- [x] Fix unit tests