### PR TITLE
feat(highlightlistener): Avoid get selection race

### DIFF
--- a/src/highlight/HighlightListener.ts
+++ b/src/highlight/HighlightListener.ts
@@ -75,9 +75,10 @@ export default class HighlightListener {
             return;
         }
 
-        this.isMouseSelecting = false;
-
-        this.selectionChangeTimer = window.setTimeout(this.setSelection, this.selectionChangeDelay);
+        this.selectionChangeTimer = window.setTimeout(() => {
+            this.setSelection();
+            this.isMouseSelecting = false;
+        }, this.selectionChangeDelay);
     };
 
     handleSelectionChange = (): void => {

--- a/src/highlight/__tests__/HighlightListener-test.ts
+++ b/src/highlight/__tests__/HighlightListener-test.ts
@@ -105,7 +105,7 @@ describe('HighlightListener', () => {
         });
     });
 
-    describe('handleMouseDown', () => {
+    describe('handleMouseDown()', () => {
         test('should clear timeout and selection', () => {
             highlightListener.selectionChangeTimer = 1;
 
@@ -130,11 +130,12 @@ describe('HighlightListener', () => {
 
             highlightListener.handleMouseUp();
 
-            expect(highlightListener.isMouseSelecting).toBe(false);
+            expect(highlightListener.isMouseSelecting).toBe(true);
 
             jest.runAllTimers();
 
             expect(highlightListener.setSelection).toHaveBeenCalled();
+            expect(highlightListener.isMouseSelecting).toBe(false);
         });
 
         test('should do nothing if select not using mouse', () => {


### PR DESCRIPTION
If you make a quick text selection, you sometimes find that the text selection goes beyond the text. This could also cause a slight shift in the highlight promoter popup after the selection is finished

What happens is that `isMouseSelecting` is set to false on `mouseup`  but delays getting the text selection by 300ms -- meanwhile the debounced `selectionchange` event fires after 500ms and since `isMouseSelecting` is already set to false, it proceeds to grab the text selection before PDFJS has time to finish the enhanced text layer work.