### PR TITLE
fix(highlights): Change pointer-events for highlight svg to visible

### DIFF
--- a/src/highlight/HighlightList.scss
+++ b/src/highlight/HighlightList.scss
@@ -7,7 +7,7 @@
 
     .ba-HighlightSvg.is-listening {
         .ba-HighlightTarget-rect {
-            pointer-events: all;
+            pointer-events: visible;
         }
     }
 }


### PR DESCRIPTION
`pointer-events: all` was causing an issue in Presentation files where all the pages are overlayed on top of each other, `HighlightTarget` SVG accepting click events even though they weren't the visible Presentation page