### PR TITLE
feat(mode): Remove toggle logic

### DIFF
--- a/src/store/common/__tests__/reducer-test.ts
+++ b/src/store/common/__tests__/reducer-test.ts
@@ -9,7 +9,7 @@ describe('store/common/reducer', () => {
         test.each`
             payloadMode | currentMode | expectedMode
             ${REGION}   | ${NONE}     | ${REGION}
-            ${REGION}   | ${REGION}   | ${NONE}
+            ${REGION}   | ${REGION}   | ${REGION}
         `('should toggle the current mode appropriately', ({ payloadMode, currentMode, expectedMode }) => {
             const newState = reducer({ ...state, mode: currentMode }, toggleAnnotationModeAction(payloadMode));
             expect(newState.mode).toEqual(expectedMode);

--- a/src/store/common/reducer.ts
+++ b/src/store/common/reducer.ts
@@ -3,9 +3,7 @@ import { CommonState, Mode } from './types';
 import { toggleAnnotationModeAction } from './actions';
 
 const modeReducer = createReducer<CommonState['mode']>(Mode.NONE, builder =>
-    builder.addCase(toggleAnnotationModeAction, (state, { payload: mode }: { payload: Mode }) =>
-        state === mode ? Mode.NONE : mode,
-    ),
+    builder.addCase(toggleAnnotationModeAction, (state, { payload: mode }: { payload: Mode }) => mode),
 );
 
 export default combineReducers({


### PR DESCRIPTION
The FSM in Preview SDK maintains the source of truth. So there is no need to have extra logic for setting mode in annotations.