### PR TITLE
test(cypress): Bump Preview SDK version

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -3,10 +3,10 @@
         <meta name="viewport" content="width=device-width" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <link rel="stylesheet" href="./styles.css" />
-        <link rel="stylesheet" href="https://cdn01.boxcdn.net/platform/preview/2.47.0/en-US/preview.css" />
+        <link rel="stylesheet" href="https://cdn01.boxcdn.net/platform/preview/2.51.0/en-US/preview.css" />
         <link rel="stylesheet" href="./annotations.css" />
         <script src="https://cdn01.boxcdn.net/polyfills/core-js/2.5.3/core.min.js"></script>
-        <script src="https://cdn01.boxcdn.net/platform/preview/2.47.0/en-US/preview.js"></script>
+        <script src="https://cdn01.boxcdn.net/platform/preview/2.51.0/en-US/preview.js"></script>
         <script src="./annotations.js"></script>
     </head>
 


### PR DESCRIPTION
E2E test is failing because https://github.com/box/box-annotations/pull/590 (Remove toggle logic) needs Preview version >= 2.51.0.