### PR TITLE
feat(highlights): Better rect smoothing

### DIFF
--- a/src/highlight/__tests__/highlightUtil-test.ts
+++ b/src/highlight/__tests__/highlightUtil-test.ts
@@ -1,6 +1,6 @@
 import {
     centerHighlight,
-    combineRectsByRow,
+    combineRects,
     dedupeRects,
     getBoundingRect,
     getShapeRelativeToContainer,
@@ -74,7 +74,7 @@ describe('highlightUtil', () => {
         });
     });
 
-    describe('combineRectsByRow()', () => {
+    describe('combineRects()', () => {
         test('should combine rects by row', () => {
             const rects = [
                 {
@@ -109,7 +109,7 @@ describe('highlightUtil', () => {
                 },
             ];
 
-            const result = combineRectsByRow(rects);
+            const result = combineRects(rects);
             expect(result).toHaveLength(3);
             expect(result[0]).toEqual({
                 height: 22,

--- a/src/highlight/__tests__/highlightUtil-test.ts
+++ b/src/highlight/__tests__/highlightUtil-test.ts
@@ -96,6 +96,12 @@ describe('highlightUtil', () => {
                     y: 199.5,
                 },
                 {
+                    height: 21,
+                    width: 100,
+                    x: 500,
+                    y: 200,
+                }, // this rect, while having the same y coordinate as the previous rects is not near enough in the x coordinate to combine so should be it's own rect
+                {
                     height: 23,
                     width: 100,
                     x: 400,
@@ -104,7 +110,7 @@ describe('highlightUtil', () => {
             ];
 
             const result = combineRectsByRow(rects);
-            expect(result).toHaveLength(2);
+            expect(result).toHaveLength(3);
             expect(result[0]).toEqual({
                 height: 22,
                 width: 300,
@@ -112,6 +118,7 @@ describe('highlightUtil', () => {
                 y: 199.5,
             });
             expect(result[1]).toEqual(rects[3]);
+            expect(result[2]).toEqual(rects[4]);
         });
     });
 

--- a/src/highlight/highlightUtil.ts
+++ b/src/highlight/highlightUtil.ts
@@ -124,7 +124,7 @@ export const combineRectsByRow = (rects: Shape[]): Shape[] => {
             rows.push(lastRect);
             rows.push(rect);
         }
-    }, [] as Shape[]);
+    });
 
     return rows;
 };

--- a/src/highlight/highlightUtil.ts
+++ b/src/highlight/highlightUtil.ts
@@ -93,15 +93,15 @@ export const dedupeRects = (rects: Shape[], threshold = 0.1): Shape[] => {
     return dedupedRects;
 };
 
-export const combineRectsByRow = (rects: Shape[]): Shape[] => {
-    const rows: Shape[] = [];
+export const combineRects = (rects: Shape[]): Shape[] => {
+    const result: Shape[] = [];
 
     dedupeRects(rects).forEach(rect => {
         const { height, width, x, y } = rect;
-        const lastRect = rows.pop();
+        const lastRect = result.pop();
 
         if (!lastRect) {
-            rows.push(rect);
+            result.push(rect);
             return;
         }
 
@@ -119,14 +119,14 @@ export const combineRectsByRow = (rects: Shape[]): Shape[] => {
 
         // If rect is close enough, add the rect to the existing entry, otherwise add it as a new entry
         if (isXCloseEnough && isYCloseEnough) {
-            rows.push(getBoundingRect([lastRect, rect]));
+            result.push(getBoundingRect([lastRect, rect]));
         } else {
-            rows.push(lastRect);
-            rows.push(rect);
+            result.push(lastRect);
+            result.push(rect);
         }
     });
 
-    return rows;
+    return result;
 };
 
 export const getShapeRelativeToContainer = (shape: Shape, containerShape: Shape): Shape => {

--- a/src/store/highlight/actions.ts
+++ b/src/store/highlight/actions.ts
@@ -1,5 +1,5 @@
 import { createAction } from '@reduxjs/toolkit';
-import { combineRectsByRow } from '../../highlight/highlightUtil';
+import { combineRects } from '../../highlight/highlightUtil';
 import { SelectionItem } from './types';
 import { Shape } from '../../@types';
 
@@ -94,7 +94,7 @@ export const setSelectionAction = createAction(
             payload: {
                 containerRect: getShape(containerRect),
                 location,
-                rects: combineRectsByRow(rects.map(getShape)),
+                rects: combineRects(rects.map(getShape)),
             },
         };
     },


### PR DESCRIPTION
Attempted an improvement to the existing rect combining strategy. Previously, we would round the rect's y coordinate to the nearest integer and use that as the key to combine all of those rects into such "rows". 

This approach attempts to combine rects that have the y coordinate within a certain threshold (% of height).
An additional enhancement is that it also combines based on whether the x coordinate is also within a certain threshold (% of width).

**Before:**
![Screen Shot 2020-09-16 at 11 43 56 AM](https://user-images.githubusercontent.com/17791289/93395237-62e96800-f82a-11ea-8d39-b418f19ef3cd.png)

**After:**
![Screen Shot 2020-09-16 at 11 43 39 AM](https://user-images.githubusercontent.com/17791289/93395215-5bc25a00-f82a-11ea-8fc6-b24d28962797.png)

**Before:**
![Screen Shot 2020-09-16 at 11 44 57 AM](https://user-images.githubusercontent.com/17791289/93395258-6d0b6680-f82a-11ea-8235-b58c56452fed.png)

**After:**
![Screen Shot 2020-09-16 at 11 44 47 AM](https://user-images.githubusercontent.com/17791289/93395268-709eed80-f82a-11ea-9c3f-7825acc3cbe9.png)

**Before:**
![Screen Shot 2020-09-16 at 11 46 52 AM](https://user-images.githubusercontent.com/17791289/93395285-7a285580-f82a-11ea-8356-648d72483395.png)

**After:**
![Screen Shot 2020-09-16 at 11 46 37 AM](https://user-images.githubusercontent.com/17791289/93395296-7dbbdc80-f82a-11ea-9b25-f53b7ceb792e.png)
