### PR TITLE
fix(highlights): Allows highlight anchors to receive focus

### DIFF
--- a/src/highlight/HighlightTarget.tsx
+++ b/src/highlight/HighlightTarget.tsx
@@ -3,7 +3,6 @@ import * as ReactRedux from 'react-redux';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
 import { getIsCurrentFileVersion } from '../store';
-import { MOUSE_PRIMARY } from '../constants';
 import { Rect } from '../@types/model';
 import './HighlightTarget.scss';
 
@@ -21,12 +20,6 @@ const HighlightTarget = (props: Props, ref: React.Ref<HighlightTargetRef>): JSX.
     const { annotationId, className, onHover = noop, onSelect = noop, shapes } = props;
     const isCurrentFileVersion = ReactRedux.useSelector(getIsCurrentFileVersion);
 
-    const handleClick = (event: React.MouseEvent<HighlightTargetRef>): void => {
-        event.preventDefault();
-        event.stopPropagation();
-        event.nativeEvent.stopImmediatePropagation();
-    };
-
     const handleFocus = (): void => {
         onSelect(annotationId);
     };
@@ -39,17 +32,6 @@ const HighlightTarget = (props: Props, ref: React.Ref<HighlightTargetRef>): JSX.
         onHover(null);
     };
 
-    const handleMouseDown = (event: React.MouseEvent<HighlightTargetRef>): void => {
-        if (event.buttons !== MOUSE_PRIMARY) {
-            return;
-        }
-
-        onSelect(annotationId);
-
-        event.preventDefault(); // Prevents focus from leaving the anchor immediately in some browsers
-        event.nativeEvent.stopImmediatePropagation(); // Prevents document event handlers from executing
-    };
-
     return (
         // eslint-disable-next-line jsx-a11y/anchor-is-valid
         <a
@@ -60,9 +42,7 @@ const HighlightTarget = (props: Props, ref: React.Ref<HighlightTargetRef>): JSX.
             data-resin-target="highlightText"
             data-testid={`ba-AnnotationTarget-${annotationId}`}
             href="#"
-            onClick={handleClick}
             onFocus={handleFocus}
-            onMouseDown={handleMouseDown}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
             role="button"

--- a/src/highlight/__tests__/HighlightTarget-test.tsx
+++ b/src/highlight/__tests__/HighlightTarget-test.tsx
@@ -57,46 +57,6 @@ describe('HighlightTarget', () => {
             expect(defaults.onSelect).toHaveBeenCalledWith(defaults.annotationId);
         });
 
-        describe('handleMouseDown()', () => {
-            const mockEvent = {
-                buttons: 1,
-                preventDefault: jest.fn(),
-                nativeEvent: {
-                    stopImmediatePropagation: jest.fn(),
-                },
-            };
-
-            test('should do nothing if button is not MOUSE_PRIMARY', () => {
-                const wrapper = getWrapper();
-                const anchor = wrapper.find('a');
-                const event = {
-                    ...mockEvent,
-                    buttons: 2,
-                };
-
-                anchor.simulate('mousedown', event);
-
-                expect(defaults.onSelect).not.toHaveBeenCalled();
-                expect(mockEvent.preventDefault).not.toHaveBeenCalled();
-                expect(mockEvent.nativeEvent.stopImmediatePropagation).not.toHaveBeenCalled();
-            });
-
-            test('should call onSelect', () => {
-                const wrapper = getWrapper();
-                const anchor = wrapper.find('a');
-                const event = {
-                    ...mockEvent,
-                    buttons: 1,
-                };
-
-                anchor.simulate('mousedown', event);
-
-                expect(defaults.onSelect).toHaveBeenCalledWith(defaults.annotationId);
-                expect(mockEvent.preventDefault).toHaveBeenCalled();
-                expect(mockEvent.nativeEvent.stopImmediatePropagation).toHaveBeenCalled();
-            });
-        });
-
         describe('handleMouseEnter()', () => {
             test('should call onHover with annotationId', () => {
                 const wrapper = getWrapper();


### PR DESCRIPTION
Fixes an issue where the SVG anchor for the highlight annotation target never received focus. As a result, you would get into this situation where:

- You select a region annotation (`document.activeElement` is the region annotation button)
- Region annotation is set as active
- You select a highlight annotation (`document.activeElement` is the region annotation button)
- Highlight annotation is set as active
- You select the region annotation again (`document.activeElement` is the region annotation button)
- Highlight annotation remains active

**GIF of the issue:**
![Highlight not focusing](https://user-images.githubusercontent.com/17791289/93847933-3041d400-fc5d-11ea-804b-1a62483475f5.gif)

