### PR TITLE
fix(popupreply): Move PopupReply into new PopupManager layer

### DIFF
--- a/src/@types/global.ts
+++ b/src/@types/global.ts
@@ -5,6 +5,7 @@ declare namespace Intl {
 
 declare namespace NodeJS {
     interface Global {
+        window: any;
         BoxAnnotations: any;
     }
 }

--- a/src/common/__tests__/useWindowSize-test.tsx
+++ b/src/common/__tests__/useWindowSize-test.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { act } from 'react-dom/test-utils';
+import { mount, ReactWrapper } from 'enzyme';
+import useWindowSize from '../useWindowSize';
+
+describe('useWindowSize', () => {
+    function TestComponent(): JSX.Element {
+        const windowSize = useWindowSize();
+
+        return (
+            <div id="container">
+                <span id="height">{windowSize?.height}</span>
+                <span id="width">{windowSize?.width}</span>
+            </div>
+        );
+    }
+
+    const getWrapper = (): ReactWrapper =>
+        mount(
+            <div>
+                <TestComponent />
+            </div>,
+            { attachTo: document.getElementById('test') },
+        );
+
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="test"></div>';
+        global.window.innerHeight = 100;
+        global.window.innerWidth = 100;
+    });
+
+    test('should return the window size', () => {
+        const wrapper = getWrapper();
+
+        expect(wrapper.find('#height').text()).toBe('100');
+        expect(wrapper.find('#width').text()).toBe('100');
+
+        global.window.innerHeight = 200;
+        global.window.innerWidth = 200;
+
+        act(() => {
+            global.window.dispatchEvent(new Event('resize'));
+        });
+
+        expect(wrapper.find('#height').text()).toBe('200');
+        expect(wrapper.find('#width').text()).toBe('200');
+    });
+});

--- a/src/common/useWindowSize.ts
+++ b/src/common/useWindowSize.ts
@@ -1,0 +1,31 @@
+import * as React from 'react';
+
+type WindowSize = {
+    height: number;
+    width: number;
+};
+
+export default function useWindowSize(): WindowSize | null {
+    const [windowSize, setWindowSize] = React.useState<WindowSize | null>(null);
+
+    const handleResize = (): void => {
+        // Set window width/height to state
+        setWindowSize({
+            width: window.innerWidth,
+            height: window.innerHeight,
+        });
+    };
+
+    React.useEffect(() => {
+        // Add event listener
+        window.addEventListener('resize', handleResize);
+
+        // Call handler right away so state gets updated with initial window size
+        handleResize();
+
+        // Remove event listener on cleanup
+        return () => window.removeEventListener('resize', handleResize);
+    }, []); // Empty array ensures that effect is only run on mount
+
+    return windowSize;
+}

--- a/src/components/Popups/PopupReply.tsx
+++ b/src/components/Popups/PopupReply.tsx
@@ -5,6 +5,7 @@ import PopupBase from './PopupBase';
 import ReplyForm from '../ReplyForm';
 import usePrevious from '../../common/usePrevious';
 import { getScale, getRotation } from '../../store/options';
+import { PopupReference } from './Popper';
 import './PopupReply.scss';
 
 export type Props = {
@@ -13,7 +14,7 @@ export type Props = {
     onCancel: (text?: string) => void;
     onChange: (text?: string) => void;
     onSubmit: (text: string) => void;
-    reference: Element;
+    reference: PopupReference;
     value?: string;
 };
 
@@ -24,6 +25,12 @@ export const options: Partial<Popper.Options> = {
             options: {
                 element: '.ba-Popup-arrow',
                 padding: 10,
+            },
+        },
+        {
+            name: 'eventListeners',
+            options: {
+                scroll: false,
             },
         },
         {

--- a/src/document/DocumentAnnotator.ts
+++ b/src/document/DocumentAnnotator.ts
@@ -1,5 +1,6 @@
 import BaseAnnotator, { ANNOTATION_CLASSES, Options } from '../common/BaseAnnotator';
 import BaseManager from '../common/BaseManager';
+import PopupReplyManager from '../popup/PopupReplyManager';
 import { centerHighlight, isHighlight } from '../highlight/highlightUtil';
 import { centerRegion, isRegion, RegionManager } from '../region';
 import { Event } from '../@types';
@@ -59,6 +60,8 @@ export default class DocumentAnnotator extends BaseAnnotator {
 
         // Lazily instantiate managers as pages are added or re-rendered
         if (managers.size === 0) {
+            managers.add(new PopupReplyManager({ location: pageNumber, referenceEl: pageReferenceEl }));
+
             if (this.isFeatureEnabled('highlightText')) {
                 const textLayer = pageEl.querySelector('.textLayer') as HTMLElement;
 

--- a/src/document/DocumentAnnotator.ts
+++ b/src/document/DocumentAnnotator.ts
@@ -1,6 +1,6 @@
 import BaseAnnotator, { ANNOTATION_CLASSES, Options } from '../common/BaseAnnotator';
 import BaseManager from '../common/BaseManager';
-import PopupReplyManager from '../popup/PopupReplyManager';
+import PopupManager from '../popup/PopupManager';
 import { centerHighlight, isHighlight } from '../highlight/highlightUtil';
 import { centerRegion, isRegion, RegionManager } from '../region';
 import { Event } from '../@types';
@@ -60,7 +60,7 @@ export default class DocumentAnnotator extends BaseAnnotator {
 
         // Lazily instantiate managers as pages are added or re-rendered
         if (managers.size === 0) {
-            managers.add(new PopupReplyManager({ location: pageNumber, referenceEl: pageReferenceEl }));
+            managers.add(new PopupManager({ location: pageNumber, referenceEl: pageReferenceEl }));
 
             if (this.isFeatureEnabled('highlightText')) {
                 const textLayer = pageEl.querySelector('.textLayer') as HTMLElement;

--- a/src/document/__tests__/DocumentAnnotator-test.ts
+++ b/src/document/__tests__/DocumentAnnotator-test.ts
@@ -123,7 +123,6 @@ describe('DocumentAnnotator', () => {
             const managers = annotator.getPageManagers(getPage());
             const managerIterator = managers.values();
 
-            expect(managers.size).toBe(2);
             expect(managerIterator.next().value).toBeInstanceOf(PopupManager);
             expect(managerIterator.next().value).toBeInstanceOf(RegionManager);
         });
@@ -134,7 +133,6 @@ describe('DocumentAnnotator', () => {
             const managers = annotator.getPageManagers(getPage());
             const managerIterator = managers.values();
 
-            expect(managers.size).toBe(3);
             expect(managerIterator.next().value).toBeInstanceOf(PopupManager);
             expect(managerIterator.next().value).toBeInstanceOf(HighlightManager);
             expect(managerIterator.next().value).toBeInstanceOf(RegionManager);
@@ -146,7 +144,6 @@ describe('DocumentAnnotator', () => {
             const managers = annotator.getPageManagers(getPage(2));
             const managerIterator = managers.values();
 
-            expect(managers.size).toBe(4);
             expect(managerIterator.next().value).toBeInstanceOf(PopupManager);
             expect(managerIterator.next().value).toBeInstanceOf(HighlightCreatorManager);
             expect(managerIterator.next().value).toBeInstanceOf(HighlightManager);

--- a/src/document/__tests__/DocumentAnnotator-test.ts
+++ b/src/document/__tests__/DocumentAnnotator-test.ts
@@ -1,6 +1,7 @@
 import BaseManager from '../../common/BaseManager';
 import DocumentAnnotator from '../DocumentAnnotator';
 import HighlightListener from '../../highlight/HighlightListener';
+import PopupManager from '../../popup/PopupManager';
 import RegionManager from '../../region/RegionManager';
 import { Annotation, Event } from '../../@types';
 import { ANNOTATION_CLASSES } from '../../common/BaseAnnotator';
@@ -11,6 +12,7 @@ import { HighlightCreatorManager, HighlightManager } from '../../highlight';
 import { scrollToLocation } from '../../utils/scroll';
 
 jest.mock('../../highlight/HighlightManager');
+jest.mock('../../popup/PopupManager');
 jest.mock('../../region/RegionManager');
 jest.mock('../../utils/scroll');
 
@@ -121,7 +123,8 @@ describe('DocumentAnnotator', () => {
             const managers = annotator.getPageManagers(getPage());
             const managerIterator = managers.values();
 
-            expect(managers.size).toBe(1);
+            expect(managers.size).toBe(2);
+            expect(managerIterator.next().value).toBeInstanceOf(PopupManager);
             expect(managerIterator.next().value).toBeInstanceOf(RegionManager);
         });
 
@@ -131,7 +134,8 @@ describe('DocumentAnnotator', () => {
             const managers = annotator.getPageManagers(getPage());
             const managerIterator = managers.values();
 
-            expect(managers.size).toBe(2);
+            expect(managers.size).toBe(3);
+            expect(managerIterator.next().value).toBeInstanceOf(PopupManager);
             expect(managerIterator.next().value).toBeInstanceOf(HighlightManager);
             expect(managerIterator.next().value).toBeInstanceOf(RegionManager);
         });
@@ -142,7 +146,8 @@ describe('DocumentAnnotator', () => {
             const managers = annotator.getPageManagers(getPage(2));
             const managerIterator = managers.values();
 
-            expect(managers.size).toBe(3);
+            expect(managers.size).toBe(4);
+            expect(managerIterator.next().value).toBeInstanceOf(PopupManager);
             expect(managerIterator.next().value).toBeInstanceOf(HighlightCreatorManager);
             expect(managerIterator.next().value).toBeInstanceOf(HighlightManager);
             expect(managerIterator.next().value).toBeInstanceOf(RegionManager);

--- a/src/highlight/HighlightAnnotations.tsx
+++ b/src/highlight/HighlightAnnotations.tsx
@@ -95,12 +95,12 @@ const HighlightAnnotations = (props: Props): JSX.Element => {
     }, [isCreating, selection]); // eslint-disable-line react-hooks/exhaustive-deps
 
     React.useEffect(() => {
-        if (highlightRef === null || !staged) {
+        if (highlightRef === null) {
             return;
         }
 
         setReferenceShape(highlightRef.getBoundingClientRect());
-    }, [highlightRef, staged, windowSize]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [highlightRef, windowSize]); // eslint-disable-line react-hooks/exhaustive-deps
 
     return (
         <>

--- a/src/highlight/HighlightAnnotations.tsx
+++ b/src/highlight/HighlightAnnotations.tsx
@@ -7,7 +7,7 @@ import HighlightTarget from './HighlightTarget';
 import PopupHighlight from '../components/Popups/PopupHighlight';
 import PopupHighlightError from '../components/Popups/PopupHighlightError';
 import useWindowSize from '../common/useWindowSize';
-import { AnnotationHighlight, Shape } from '../@types';
+import { AnnotationHighlight } from '../@types';
 import { CreateArg } from './actions';
 import { CreatorItemHighlight, CreatorStatus, SelectionItem } from '../store';
 import { getBoundingRect, getShapeRelativeToContainer } from './highlightUtil';
@@ -24,7 +24,7 @@ type Props = {
     selection: SelectionItem | null;
     setActiveAnnotationId: (annotationId: string | null) => void;
     setIsPromoting: (isPromoting: boolean) => void;
-    setReferenceShape: (element: Shape) => void;
+    setReferenceShape: (rect: DOMRect) => void;
     setStaged: (staged: CreatorItemHighlight | null) => void;
     setStatus: (status: CreatorStatus) => void;
     staged?: CreatorItemHighlight | null;
@@ -99,14 +99,7 @@ const HighlightAnnotations = (props: Props): JSX.Element => {
             return;
         }
 
-        const { height, width, top, left } = highlightRef.getBoundingClientRect();
-
-        setReferenceShape({
-            height,
-            width,
-            x: left,
-            y: top,
-        });
+        setReferenceShape(highlightRef.getBoundingClientRect());
     }, [highlightRef, staged, windowSize]); // eslint-disable-line react-hooks/exhaustive-deps
 
     return (

--- a/src/highlight/HighlightAnnotations.tsx
+++ b/src/highlight/HighlightAnnotations.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import noop from 'lodash/noop';
 import HighlightCanvas from './HighlightCanvas';
 import HighlightCreator from './HighlightCreator';
 import HighlightList from './HighlightList';
@@ -7,8 +6,8 @@ import HighlightSvg from './HighlightSvg';
 import HighlightTarget from './HighlightTarget';
 import PopupHighlight from '../components/Popups/PopupHighlight';
 import PopupHighlightError from '../components/Popups/PopupHighlightError';
-import PopupReply from '../components/Popups/PopupReply';
-import { AnnotationHighlight } from '../@types';
+import useWindowSize from '../common/useWindowSize';
+import { AnnotationHighlight, Shape } from '../@types';
 import { CreateArg } from './actions';
 import { CreatorItemHighlight, CreatorStatus, SelectionItem } from '../store';
 import { getBoundingRect, getShapeRelativeToContainer } from './highlightUtil';
@@ -22,61 +21,37 @@ type Props = {
     isPromoting: boolean;
     isSelecting: boolean;
     location: number;
-    message: string;
-    resetCreator: () => void;
     selection: SelectionItem | null;
     setActiveAnnotationId: (annotationId: string | null) => void;
     setIsPromoting: (isPromoting: boolean) => void;
-    setMessage: (message: string) => void;
+    setReferenceShape: (element: Shape) => void;
     setStaged: (staged: CreatorItemHighlight | null) => void;
     setStatus: (status: CreatorStatus) => void;
     staged?: CreatorItemHighlight | null;
-    status: CreatorStatus;
 };
 
 const HighlightAnnotations = (props: Props): JSX.Element => {
     const {
         activeAnnotationId,
         annotations = [],
-        createHighlight = noop,
         isCreating = false,
         isPromoting = false,
         isSelecting = false,
-        message,
-        resetCreator,
         selection,
         setActiveAnnotationId,
         setIsPromoting,
-        setMessage,
+        setReferenceShape,
         setStaged,
         setStatus,
         staged,
-        status,
     } = props;
     const [highlightRef, setHighlightRef] = React.useState<HTMLAnchorElement | null>(null);
+    const windowSize = useWindowSize();
 
     const canCreate = isCreating || isPromoting;
-    const canReply = status !== CreatorStatus.started && status !== CreatorStatus.init;
-    const isPending = status === CreatorStatus.pending;
 
     const handleAnnotationActive = (annotationId: string | null): void => {
         setActiveAnnotationId(annotationId);
-    };
-
-    const handleCancel = (): void => {
-        resetCreator();
-    };
-
-    const handleChange = (text = ''): void => {
-        setMessage(text);
-    };
-
-    const handleSubmit = (): void => {
-        if (!staged) {
-            return;
-        }
-
-        createHighlight({ ...staged, message });
     };
 
     const stageSelection = (): void => {
@@ -119,6 +94,21 @@ const HighlightAnnotations = (props: Props): JSX.Element => {
         stageSelection();
     }, [isCreating, selection]); // eslint-disable-line react-hooks/exhaustive-deps
 
+    React.useEffect(() => {
+        if (highlightRef === null || !staged) {
+            return;
+        }
+
+        const { height, width, top, left } = highlightRef.getBoundingClientRect();
+
+        setReferenceShape({
+            height,
+            width,
+            x: left,
+            y: top,
+        });
+    }, [highlightRef, staged, windowSize]); // eslint-disable-line react-hooks/exhaustive-deps
+
     return (
         <>
             {/* Layer 1: Saved annotations */}
@@ -127,27 +117,13 @@ const HighlightAnnotations = (props: Props): JSX.Element => {
             {/* Layer 2: Drawn (unsaved) incomplete annotation target, if any */}
             {canCreate && <HighlightCreator className="ba-HighlightAnnotations-creator" />}
 
-            {/* Layer 3a: Staged (unsaved) highlight target, if any */}
+            {/* Layer 3: Staged (unsaved) highlight target, if any */}
             {canCreate && staged && (
                 <div className="ba-HighlightAnnotations-target">
                     <HighlightCanvas shapes={staged.shapes} />
                     <HighlightSvg>
                         <HighlightTarget ref={setHighlightRef} annotationId="staged" shapes={staged.shapes} />
                     </HighlightSvg>
-                </div>
-            )}
-
-            {/* Layer 3b: Staged (unsaved) annotation description popup, if 3a is ready */}
-            {canCreate && staged && canReply && highlightRef && (
-                <div className="ba-HighlightAnnotations-popup">
-                    <PopupReply
-                        isPending={isPending}
-                        onCancel={handleCancel}
-                        onChange={handleChange}
-                        onSubmit={handleSubmit}
-                        reference={highlightRef}
-                        value={message}
-                    />
                 </div>
             )}
 

--- a/src/highlight/HighlightContainer.tsx
+++ b/src/highlight/HighlightContainer.tsx
@@ -5,27 +5,22 @@ import { AnnotationHighlight } from '../@types';
 import {
     AppState,
     CreatorItemHighlight,
-    CreatorStatus,
     getActiveAnnotationId,
     getAnnotationMode,
     getAnnotationsForLocation,
-    getCreatorMessage,
     getCreatorStagedForLocation,
-    getCreatorStatus,
     getIsPromoting,
     getIsSelecting,
     getSelectionForLocation,
     isCreatorStagedHighlight,
     Mode,
-    resetCreatorAction,
     SelectionItem,
     setActiveAnnotationIdAction,
     setIsPromotingAction,
-    setMessageAction,
+    setReferenceShapeAction,
     setStagedAction,
     setStatusAction,
 } from '../store';
-import { createHighlightAction } from './actions';
 import { isHighlight } from './highlightUtil';
 
 export type Props = {
@@ -34,10 +29,8 @@ export type Props = {
     isCreating: boolean;
     isPromoting: boolean;
     isSelecting: boolean;
-    message: string;
     selection: SelectionItem | null;
     staged: CreatorItemHighlight | null;
-    status: CreatorStatus;
 };
 
 export const mapStateToProps = (state: AppState, { location }: { location: number }): Props => {
@@ -49,19 +42,15 @@ export const mapStateToProps = (state: AppState, { location }: { location: numbe
         isCreating: getAnnotationMode(state) === Mode.HIGHLIGHT,
         isPromoting: getIsPromoting(state),
         isSelecting: getIsSelecting(state),
-        message: getCreatorMessage(state),
         selection: getSelectionForLocation(state, location),
         staged: isCreatorStagedHighlight(staged) ? staged : null,
-        status: getCreatorStatus(state),
     };
 };
 
 export const mapDispatchToProps = {
-    createHighlight: createHighlightAction,
-    resetCreator: resetCreatorAction,
     setActiveAnnotationId: setActiveAnnotationIdAction,
     setIsPromoting: setIsPromotingAction,
-    setMessage: setMessageAction,
+    setReferenceShape: setReferenceShapeAction,
     setStaged: setStagedAction,
     setStatus: setStatusAction,
 };

--- a/src/highlight/__mocks__/HighlightTarget.tsx
+++ b/src/highlight/__mocks__/HighlightTarget.tsx
@@ -3,6 +3,15 @@ import * as React from 'react';
 export default class HighlightTarget extends React.Component<{ children: React.ReactNode }> {
     name = 'HighlightTargetMock';
 
+    getBoundingClientRect(): Partial<DOMRect> {
+        return {
+            height: 10,
+            width: 10,
+            top: 10,
+            left: 10,
+        };
+    }
+
     render(): JSX.Element {
         const { children } = this.props;
 

--- a/src/highlight/__tests__/HighlightAnnotations-test.tsx
+++ b/src/highlight/__tests__/HighlightAnnotations-test.tsx
@@ -12,7 +12,6 @@ import { CreatorStatus, CreatorItemHighlight } from '../../store';
 import { Rect } from '../../@types';
 import { selection as selectionMock } from '../__mocks__/data';
 
-jest.mock('../../components/Popups/PopupHighlight');
 jest.mock('../HighlightList');
 jest.mock('../HighlightTarget');
 jest.mock('../../components/Popups/PopupHighlight');
@@ -23,21 +22,17 @@ describe('HighlightAnnotations', () => {
     const defaults = {
         activeAnnotationId: null,
         annotations: [],
-        createHighlight: jest.fn(),
         isCreating: false,
         isPromoting: false,
         isSelecting: false,
         location: 1,
-        message: 'test',
-        resetCreator: jest.fn(),
         selection: null,
         setActiveAnnotationId: jest.fn(),
         setIsPromoting: jest.fn(),
-        setMessage: jest.fn(),
+        setReferenceShape: jest.fn(),
         setStaged: jest.fn(),
         setStatus: jest.fn(),
         staged: null,
-        status: CreatorStatus.init,
     };
 
     const getRect = (): Rect => ({
@@ -78,37 +73,6 @@ describe('HighlightAnnotations', () => {
                 staged: getStaged(),
             });
             expect(wrapper.exists('.ba-HighlightAnnotations-target')).toBe(true);
-        });
-
-        test.each`
-            status                    | showReply
-            ${CreatorStatus.init}     | ${false}
-            ${CreatorStatus.pending}  | ${true}
-            ${CreatorStatus.rejected} | ${true}
-            ${CreatorStatus.staged}   | ${true}
-        `('should render a reply popup if the creator status is $status', ({ status, showReply }) => {
-            const wrapper = getWrapper({
-                isCreating: true,
-                staged: getStaged(),
-                status,
-            });
-
-            expect(wrapper.exists(PopupReply)).toBe(showReply);
-        });
-
-        test.each`
-            status                    | isPending
-            ${CreatorStatus.rejected} | ${false}
-            ${CreatorStatus.pending}  | ${true}
-            ${CreatorStatus.staged}   | ${false}
-        `('should render reply popup with isPending $isPending', ({ status, isPending }) => {
-            const wrapper = getWrapper({
-                isCreating: true,
-                staged: getStaged(),
-                status,
-            });
-
-            expect(wrapper.find(PopupReply).prop('isPending')).toBe(isPending);
         });
 
         test.each`
@@ -190,54 +154,6 @@ describe('HighlightAnnotations', () => {
             });
             expect(defaults.setStatus).toHaveBeenCalledWith('staged');
             expect(defaults.setIsPromoting).toHaveBeenCalledWith(true);
-        });
-    });
-
-    describe('event handlers', () => {
-        const mockSetHighlightRef = jest.fn();
-        let wrapper: ReactWrapper;
-
-        beforeEach(() => {
-            jest.spyOn(React, 'useState').mockImplementation(() => [true, mockSetHighlightRef]);
-            wrapper = getWrapper({
-                isCreating: true,
-                isPromoting: true,
-                staged: getStaged(),
-                status: CreatorStatus.staged,
-            });
-        });
-
-        describe('handleCancel()', () => {
-            test('should reset creator and reset isPromoting', () => {
-                wrapper.find(PopupReply).prop('onCancel')();
-
-                expect(defaults.resetCreator).toHaveBeenCalled();
-            });
-        });
-
-        describe('handleChange', () => {
-            test('should set the staged state with the new message', () => {
-                wrapper.find(PopupReply).prop('onChange')('foo');
-
-                expect(defaults.setMessage).toHaveBeenCalledWith('foo');
-            });
-
-            test('should set the staged state with empty string', () => {
-                wrapper.find(PopupReply).prop('onChange')();
-
-                expect(defaults.setMessage).toHaveBeenCalledWith('');
-            });
-        });
-
-        describe('handleSubmit', () => {
-            test('should save the staged annotation and reset isPromoting', () => {
-                wrapper.find(PopupReply).prop('onSubmit')('');
-
-                expect(defaults.createHighlight).toHaveBeenCalledWith({
-                    ...getStaged(),
-                    message: defaults.message,
-                });
-            });
         });
     });
 

--- a/src/highlight/__tests__/HighlightContainer-test.tsx
+++ b/src/highlight/__tests__/HighlightContainer-test.tsx
@@ -3,7 +3,7 @@ import { IntlShape } from 'react-intl';
 import { ReactWrapper, mount } from 'enzyme';
 import HighlightAnnotations from '../HighlightAnnotations';
 import HighlightContainer, { Props } from '../HighlightContainer';
-import { CreatorItemHighlight, CreatorItemRegion, Mode, createStore, CreatorStatus } from '../../store';
+import { createStore, CreatorItemHighlight, CreatorItemRegion, Mode } from '../../store';
 import { rect as highlightRect } from '../__mocks__/data';
 import { rect as regionRect } from '../../region/__mocks__/data';
 
@@ -36,20 +36,16 @@ describe('HighlightContainer', () => {
             expect(wrapper.find(HighlightAnnotations).props()).toMatchObject({
                 activeAnnotationId: null,
                 annotations: [],
-                createHighlight: expect.any(Function),
                 isCreating: false,
                 isPromoting: false,
                 location: 1,
-                message: '',
-                resetCreator: expect.any(Function),
                 selection: null,
                 setActiveAnnotationId: expect.any(Function),
                 setIsPromoting: expect.any(Function),
-                setMessage: expect.any(Function),
+                setReferenceShape: expect.any(Function),
                 setStaged: expect.any(Function),
                 setStatus: expect.any(Function),
                 staged: null,
-                status: CreatorStatus.init,
                 store: defaults.store,
             });
         });

--- a/src/image/ImageAnnotator.ts
+++ b/src/image/ImageAnnotator.ts
@@ -1,7 +1,7 @@
 import { Unsubscribe } from 'redux';
 import BaseAnnotator, { Options } from '../common/BaseAnnotator';
 import BaseManager from '../common/BaseManager';
-import PopupReplyManager from '../popup/PopupReplyManager';
+import PopupManager from '../popup/PopupManager';
 import { getAnnotation, getRotation } from '../store';
 import { centerRegion, getTransformedShape, isRegion, RegionManager } from '../region';
 import { CreatorStatus, getCreatorStatus } from '../store/creator';
@@ -44,7 +44,7 @@ export default class ImageAnnotator extends BaseAnnotator {
         });
 
         if (this.managers.size === 0) {
-            this.managers.add(new PopupReplyManager({ referenceEl }));
+            this.managers.add(new PopupManager({ referenceEl }));
             this.managers.add(new RegionManager({ referenceEl }));
         }
 

--- a/src/image/ImageAnnotator.ts
+++ b/src/image/ImageAnnotator.ts
@@ -1,6 +1,7 @@
 import { Unsubscribe } from 'redux';
 import BaseAnnotator, { Options } from '../common/BaseAnnotator';
 import BaseManager from '../common/BaseManager';
+import PopupReplyManager from '../popup/PopupReplyManager';
 import { getAnnotation, getRotation } from '../store';
 import { centerRegion, getTransformedShape, isRegion, RegionManager } from '../region';
 import { CreatorStatus, getCreatorStatus } from '../store/creator';
@@ -43,6 +44,7 @@ export default class ImageAnnotator extends BaseAnnotator {
         });
 
         if (this.managers.size === 0) {
+            this.managers.add(new PopupReplyManager({ referenceEl }));
             this.managers.add(new RegionManager({ referenceEl }));
         }
 

--- a/src/image/__tests__/ImageAnnotator-test.ts
+++ b/src/image/__tests__/ImageAnnotator-test.ts
@@ -1,10 +1,12 @@
 import ImageAnnotator, { CSS_IS_DRAWING_CLASS } from '../ImageAnnotator';
+import PopupManager from '../../popup/PopupManager';
 import RegionManager from '../../region/RegionManager';
 import { Annotation } from '../../@types';
 import { CreatorStatus, fetchAnnotationsAction, setStatusAction } from '../../store';
 import { annotations as regions } from '../../region/__mocks__/data';
 import { scrollToLocation } from '../../utils/scroll';
 
+jest.mock('../../popup/PopupManager');
 jest.mock('../../region/RegionManager');
 jest.mock('../../utils/scroll');
 
@@ -78,9 +80,11 @@ describe('ImageAnnotator', () => {
     describe('getManagers()', () => {
         test('should create new managers if they are not present in the annotated element', () => {
             const managers = annotator.getManagers(getParent(), getImage());
+            const managerIterator = managers.values();
 
-            expect(managers.size).toBe(1);
-            expect(managers.values().next().value).toBeInstanceOf(RegionManager);
+            expect(managers.size).toBe(2);
+            expect(managerIterator.next().value).toBeInstanceOf(PopupManager);
+            expect(managerIterator.next().value).toBeInstanceOf(RegionManager);
         });
 
         test('should destroy any existing managers if they are not present in the annotated element', () => {

--- a/src/image/__tests__/ImageAnnotator-test.ts
+++ b/src/image/__tests__/ImageAnnotator-test.ts
@@ -82,7 +82,6 @@ describe('ImageAnnotator', () => {
             const managers = annotator.getManagers(getParent(), getImage());
             const managerIterator = managers.values();
 
-            expect(managers.size).toBe(2);
             expect(managerIterator.next().value).toBeInstanceOf(PopupManager);
             expect(managerIterator.next().value).toBeInstanceOf(RegionManager);
         });

--- a/src/popup/PopupContainer.tsx
+++ b/src/popup/PopupContainer.tsx
@@ -1,0 +1,49 @@
+import { connect } from 'react-redux';
+import PopupLayer from './PopupLayer';
+import withProviders from '../common/withProviders';
+import {
+    AppState,
+    CreatorItem,
+    CreatorStatus,
+    getAnnotationMode,
+    getCreatorMessage,
+    getCreatorStagedForLocation,
+    getCreatorStatus,
+    getIsPromoting,
+    Mode,
+    resetCreatorAction,
+    setMessageAction,
+    getCreatorReferenceShape,
+} from '../store';
+import { createHighlightAction } from '../highlight/actions';
+import { Shape } from '../@types';
+import { createRegionAction } from '../region';
+
+export type Props = {
+    isCreating: boolean;
+    isPromoting: boolean;
+    message: string;
+    popupReference?: Shape;
+    staged: CreatorItem | null;
+    status: CreatorStatus;
+};
+
+export const mapStateToProps = (state: AppState, { location }: { location: number }): Props => {
+    return {
+        isCreating: getAnnotationMode(state) !== Mode.NONE,
+        isPromoting: getIsPromoting(state),
+        message: getCreatorMessage(state),
+        popupReference: getCreatorReferenceShape(state),
+        staged: getCreatorStagedForLocation(state, location),
+        status: getCreatorStatus(state),
+    };
+};
+
+export const mapDispatchToProps = {
+    createHighlight: createHighlightAction,
+    createRegion: createRegionAction,
+    resetCreator: resetCreatorAction,
+    setMessage: setMessageAction,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(withProviders(PopupLayer));

--- a/src/popup/PopupLayer.scss
+++ b/src/popup/PopupLayer.scss
@@ -1,0 +1,3 @@
+.ba-PopupLayer-popup {
+    pointer-events: auto;
+}

--- a/src/popup/PopupLayer.tsx
+++ b/src/popup/PopupLayer.tsx
@@ -4,9 +4,9 @@ import PopupReply from '../components/Popups/PopupReply';
 import { CreateArg as HighlightCreateArg } from '../highlight/actions';
 import { CreateArg as RegionCreateArg } from '../region/actions';
 import { CreatorItem, CreatorStatus, isCreatorStagedHighlight, isCreatorStagedRegion } from '../store';
+import { PopupReference } from '../components/Popups/Popper';
 import { Shape } from '../@types';
 import './PopupLayer.scss';
-import { PopupReference } from '../components/Popups/Popper';
 
 type Props = {
     createHighlight?: (arg: HighlightCreateArg) => void;
@@ -22,7 +22,7 @@ type Props = {
     status: CreatorStatus;
 };
 
-const Popup = (props: Props): JSX.Element | null => {
+const PopupLayer = (props: Props): JSX.Element | null => {
     const {
         createHighlight = noop,
         createRegion = noop,
@@ -100,4 +100,4 @@ const Popup = (props: Props): JSX.Element | null => {
     );
 };
 
-export default Popup;
+export default PopupLayer;

--- a/src/popup/PopupLayer.tsx
+++ b/src/popup/PopupLayer.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import noop from 'lodash/noop';
+import PopupReply from '../components/Popups/PopupReply';
+import { CreateArg as HighlightCreateArg } from '../highlight/actions';
+import { CreateArg as RegionCreateArg } from '../region/actions';
+import { CreatorItem, CreatorStatus, isCreatorStagedHighlight, isCreatorStagedRegion } from '../store';
+import { Shape } from '../@types';
+import './PopupLayer.scss';
+import { PopupReference } from '../components/Popups/Popper';
+
+type Props = {
+    createHighlight?: (arg: HighlightCreateArg) => void;
+    createRegion?: (arg: RegionCreateArg) => void;
+    isCreating: boolean;
+    isPromoting: boolean;
+    location: number;
+    message: string;
+    popupReference?: Shape;
+    resetCreator: () => void;
+    setMessage: (message: string) => void;
+    staged?: CreatorItem | null;
+    status: CreatorStatus;
+};
+
+const Popup = (props: Props): JSX.Element | null => {
+    const {
+        createHighlight = noop,
+        createRegion = noop,
+        isCreating = false,
+        isPromoting = false,
+        message,
+        popupReference,
+        resetCreator,
+        setMessage,
+        staged,
+        status,
+    } = props;
+
+    const [reference, setReference] = React.useState<PopupReference | null>(null);
+    const canCreate = isCreating || isPromoting;
+    const canReply = status !== CreatorStatus.started && status !== CreatorStatus.init;
+    const isPending = status === CreatorStatus.pending;
+
+    const handleCancel = (): void => {
+        resetCreator();
+    };
+
+    const handleChange = (text = ''): void => {
+        setMessage(text);
+    };
+
+    const handleSubmit = (): void => {
+        if (!staged) {
+            return;
+        }
+
+        if (isCreatorStagedHighlight(staged)) {
+            createHighlight({ ...staged, message });
+        } else if (isCreatorStagedRegion(staged)) {
+            createRegion({ ...staged, message });
+        }
+    };
+
+    React.useEffect(() => {
+        if (!popupReference) {
+            return;
+        }
+
+        const { height, width, x, y } = popupReference;
+
+        const virtualElement = {
+            getBoundingClientRect: () => ({
+                bottom: y + height,
+                height,
+                left: x,
+                right: x + width,
+                top: y,
+                width,
+            }),
+        };
+
+        setReference(virtualElement);
+    }, [popupReference]);
+
+    return (
+        <>
+            {canCreate && staged && canReply && reference && (
+                <div className="ba-PopupLayer-popup">
+                    <PopupReply
+                        isPending={isPending}
+                        onCancel={handleCancel}
+                        onChange={handleChange}
+                        onSubmit={handleSubmit}
+                        reference={reference}
+                        value={message}
+                    />
+                </div>
+            )}
+        </>
+    );
+};
+
+export default Popup;

--- a/src/popup/PopupManager.tsx
+++ b/src/popup/PopupManager.tsx
@@ -3,7 +3,7 @@ import * as ReactDOM from 'react-dom';
 import BaseManager, { Options, Props } from '../common/BaseManager';
 import PopupContainer from './PopupContainer';
 
-export default class PopupReplyManager implements BaseManager {
+export default class PopupManager implements BaseManager {
     location: number;
 
     reactEl: HTMLElement;

--- a/src/popup/PopupReplyManager.tsx
+++ b/src/popup/PopupReplyManager.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import BaseManager, { Options, Props } from '../common/BaseManager';
+import PopupContainer from './PopupContainer';
+
+export default class PopupReplyManager implements BaseManager {
+    location: number;
+
+    reactEl: HTMLElement;
+
+    constructor({ location = 1, referenceEl }: Options) {
+        this.location = location;
+        this.reactEl = this.insert(referenceEl);
+    }
+
+    destroy(): void {
+        ReactDOM.unmountComponentAtNode(this.reactEl);
+
+        this.reactEl.remove();
+    }
+
+    exists(parentEl: HTMLElement): boolean {
+        return parentEl.contains(this.reactEl);
+    }
+
+    insert(referenceEl: HTMLElement): HTMLElement {
+        // Find the nearest applicable reference and document elements
+        const documentEl = referenceEl.ownerDocument || document;
+        const parentEl = referenceEl.parentNode || documentEl;
+
+        // Construct a layer element where we can inject a root React component
+        const rootLayerEl = documentEl.createElement('div');
+        rootLayerEl.classList.add('ba-Layer');
+        rootLayerEl.classList.add('ba-Layer--popup');
+        rootLayerEl.dataset.testid = 'ba-Layer--popup';
+        rootLayerEl.setAttribute('data-resin-feature', 'annotations');
+
+        // Insert the new layer element immediately after the reference element
+        return parentEl.insertBefore(rootLayerEl, referenceEl.nextSibling);
+    }
+
+    render(props: Props): void {
+        ReactDOM.render(<PopupContainer location={this.location} {...props} />, this.reactEl);
+    }
+
+    style(styles: Partial<CSSStyleDeclaration>): CSSStyleDeclaration {
+        return Object.assign(this.reactEl.style, styles);
+    }
+}

--- a/src/popup/__mocks__/PopupLayer.tsx
+++ b/src/popup/__mocks__/PopupLayer.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export default class PopupLayer extends React.Component<{ children: React.ReactNode }> {
+    name = 'PopupLayerMock';
+
+    render(): JSX.Element {
+        const { children } = this.props;
+
+        return <div>{children}</div>;
+    }
+}

--- a/src/popup/__tests__/PopupContainer-test.tsx
+++ b/src/popup/__tests__/PopupContainer-test.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { IntlShape } from 'react-intl';
+import { mount, ReactWrapper } from 'enzyme';
+import PopupLayer from '../PopupLayer';
+import PopupContainer, { Props } from '../PopupContainer';
+import { createStore, CreatorStatus } from '../../store';
+
+jest.mock('../PopupLayer');
+jest.mock('../../common/withProviders');
+
+describe('PopupContainer', () => {
+    const defaults = {
+        intl: {} as IntlShape,
+        location: 1,
+        store: createStore(),
+    };
+    const getWrapper = (props = {}): ReactWrapper<Props> => mount(<PopupContainer {...defaults} {...props} />);
+
+    describe('render', () => {
+        test('should connect the underlying component and wrap it with a root provider', () => {
+            const wrapper = getWrapper();
+
+            expect(wrapper.exists('RootProvider')).toBe(true);
+            expect(wrapper.find(PopupLayer).props()).toMatchObject({
+                isCreating: false,
+                isPromoting: false,
+                staged: null,
+                status: CreatorStatus.init,
+                store: defaults.store,
+            });
+        });
+    });
+});

--- a/src/popup/__tests__/PopupLayer-test.tsx
+++ b/src/popup/__tests__/PopupLayer-test.tsx
@@ -116,7 +116,7 @@ describe('PopupLayer', () => {
                 expect(defaults.createRegion).not.toHaveBeenCalled();
             });
 
-            test('should create region if staged item is type highlight', () => {
+            test('should create region if staged item is type region', () => {
                 const wrapper = getWrapper({ staged: getStagedRegion() });
                 wrapper.find(PopupReply).prop('onSubmit')('');
 

--- a/src/popup/__tests__/PopupLayer-test.tsx
+++ b/src/popup/__tests__/PopupLayer-test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { ReactWrapper, mount } from 'enzyme';
+import PopupLayer from '../PopupLayer';
+import PopupReply from '../../components/Popups/PopupReply';
+import { CreatorStatus, CreatorItemHighlight, CreatorItemRegion } from '../../store';
+import { Rect } from '../../@types';
+
+jest.mock('../../components/Popups/PopupReply');
+
+describe('PopupLayer', () => {
+    const popupReference = { height: 10, width: 10, x: 10, y: 10 };
+    const getRect = (): Rect => ({
+        type: 'rect',
+        height: 50,
+        width: 50,
+        x: 10,
+        y: 10,
+    });
+    const getStagedHighlight = (): CreatorItemHighlight => ({
+        location: 1,
+        shapes: [getRect()],
+    });
+    const getStagedRegion = (): CreatorItemRegion => ({
+        location: 1,
+        shape: getRect(),
+    });
+    const defaults = {
+        createHighlight: jest.fn(),
+        createRegion: jest.fn(),
+        isCreating: true,
+        isPromoting: false,
+        location: 1,
+        message: '',
+        popupReference,
+        resetCreator: jest.fn(),
+        setMessage: jest.fn(),
+        staged: getStagedHighlight(),
+        status: CreatorStatus.staged,
+    };
+    const getWrapper = (props = {}): ReactWrapper => mount(<PopupLayer {...defaults} {...props} />);
+
+    const mockSetReference = jest.fn();
+    const mockReference = {
+        getBoundingClientRect: () => ({
+            height: 10,
+            width: 10,
+            top: 10,
+            left: 10,
+        }),
+    };
+
+    beforeEach(() => {
+        jest.spyOn(React, 'useState').mockImplementation(() => [mockReference, mockSetReference]);
+    });
+
+    describe('render()', () => {
+        test.each`
+            status                    | showReply
+            ${CreatorStatus.init}     | ${false}
+            ${CreatorStatus.pending}  | ${true}
+            ${CreatorStatus.rejected} | ${true}
+            ${CreatorStatus.staged}   | ${true}
+        `('should render a reply popup ($showReply) if the creator status is $status', ({ status, showReply }) => {
+            const wrapper = getWrapper({ status });
+
+            expect(wrapper.exists(PopupReply)).toBe(showReply);
+        });
+
+        test.each`
+            status                    | isPending
+            ${CreatorStatus.rejected} | ${false}
+            ${CreatorStatus.pending}  | ${true}
+            ${CreatorStatus.staged}   | ${false}
+        `('should render reply popup with isPending $isPending', ({ status, isPending }) => {
+            const wrapper = getWrapper({ status });
+
+            expect(wrapper.find(PopupReply).prop('isPending')).toBe(isPending);
+        });
+    });
+
+    describe('event handlers', () => {
+        describe('handleCancel()', () => {
+            test('should reset creator and reset isPromoting', () => {
+                const wrapper = getWrapper();
+                wrapper.find(PopupReply).prop('onCancel')();
+
+                expect(defaults.resetCreator).toHaveBeenCalled();
+            });
+        });
+
+        describe('handleChange', () => {
+            test('should set the staged state with the new message', () => {
+                const wrapper = getWrapper();
+                wrapper.find(PopupReply).prop('onChange')('foo');
+
+                expect(defaults.setMessage).toHaveBeenCalledWith('foo');
+            });
+
+            test('should set the staged state with empty string', () => {
+                const wrapper = getWrapper();
+                wrapper.find(PopupReply).prop('onChange')();
+
+                expect(defaults.setMessage).toHaveBeenCalledWith('');
+            });
+        });
+
+        describe('handleSubmit', () => {
+            test('should create highlight if staged item is type highlight', () => {
+                const wrapper = getWrapper();
+                wrapper.find(PopupReply).prop('onSubmit')('');
+
+                expect(defaults.createHighlight).toHaveBeenCalledWith({
+                    ...getStagedHighlight(),
+                    message: defaults.message,
+                });
+                expect(defaults.createRegion).not.toHaveBeenCalled();
+            });
+
+            test('should create region if staged item is type highlight', () => {
+                const wrapper = getWrapper({ staged: getStagedRegion() });
+                wrapper.find(PopupReply).prop('onSubmit')('');
+
+                expect(defaults.createHighlight).not.toHaveBeenCalled();
+                expect(defaults.createRegion).toHaveBeenCalledWith({
+                    ...getStagedRegion(),
+                    message: defaults.message,
+                });
+            });
+        });
+    });
+});

--- a/src/popup/__tests__/PopupManager-test.tsx
+++ b/src/popup/__tests__/PopupManager-test.tsx
@@ -1,0 +1,64 @@
+import ReactDOM from 'react-dom';
+import { createIntl } from 'react-intl';
+import PopupManager from '../PopupManager';
+import { createStore } from '../../store';
+import { Options } from '../../common/BaseManager';
+
+jest.mock('react-dom', () => ({
+    render: jest.fn(),
+    unmountComponentAtNode: jest.fn(),
+}));
+
+describe('PopupManager', () => {
+    const intl = createIntl({ locale: 'en' });
+    const rootEl = document.createElement('div');
+    const getOptions = (options: Partial<Options> = {}): Options => ({
+        referenceEl: rootEl.querySelector('.reference') as HTMLElement,
+        ...options,
+    });
+    const getLayer = (): HTMLElement => rootEl.querySelector('[data-testid="ba-Layer--popup"]') as HTMLElement;
+    const getWrapper = (options?: Partial<Options>): PopupManager => new PopupManager(getOptions(options));
+
+    beforeEach(() => {
+        rootEl.classList.add('root');
+        rootEl.innerHTML = '<div class="reference" />'; // referenceEl
+    });
+
+    describe('constructor', () => {
+        test('should set all necessary properties', () => {
+            const wrapper = getWrapper();
+
+            expect(wrapper.location).toEqual(1);
+            expect(wrapper.reactEl).toEqual(getLayer());
+        });
+    });
+
+    describe('destroy()', () => {
+        test('should unmount the React node and remove the root element', () => {
+            const wrapper = getWrapper();
+
+            wrapper.destroy();
+
+            expect(ReactDOM.unmountComponentAtNode).toHaveBeenCalledWith(wrapper.reactEl);
+        });
+    });
+
+    describe('exists()', () => {
+        test('should return a boolean based on its presence in the page element', () => {
+            const wrapper = getWrapper();
+
+            expect(wrapper.exists(rootEl)).toBe(true);
+            expect(wrapper.exists(document.createElement('div'))).toBe(false);
+        });
+    });
+
+    describe('render()', () => {
+        test('should format the props and pass them to the underlying components', () => {
+            const wrapper = getWrapper();
+
+            wrapper.render({ intl, store: createStore() });
+
+            expect(ReactDOM.render).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/region/RegionAnnotations.scss
+++ b/src/region/RegionAnnotations.scss
@@ -23,10 +23,6 @@
     }
 }
 
-.ba-RegionAnnotations-popup {
-    pointer-events: auto; // Swallow all pointer events that occur within the popup
-}
-
 .ba-RegionAnnotations-target {
     pointer-events: none;
 }

--- a/src/region/RegionAnnotations.tsx
+++ b/src/region/RegionAnnotations.tsx
@@ -36,11 +36,11 @@ export default class RegionAnnotations extends React.PureComponent<Props, State>
     state: State = {};
 
     componentDidUpdate(_prevProps: Props, prevState: State): void {
-        const { setReferenceShape, staged } = this.props;
+        const { setReferenceShape } = this.props;
         const { rectRef } = this.state;
         const { rectRef: prevRectRef } = prevState;
 
-        if (prevRectRef !== rectRef && rectRef && staged) {
+        if (prevRectRef !== rectRef && rectRef) {
             setReferenceShape(rectRef.getBoundingClientRect());
         }
     }

--- a/src/region/RegionAnnotations.tsx
+++ b/src/region/RegionAnnotations.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import RegionCreator from './RegionCreator';
 import RegionList from './RegionList';
 import RegionRect, { RegionRectRef } from './RegionRect';
-import { AnnotationRegion, Rect, Shape } from '../@types';
+import { AnnotationRegion, Rect } from '../@types';
 import { CreatorItemRegion, CreatorStatus } from '../store/creator';
 import './RegionAnnotations.scss';
 
@@ -15,7 +15,7 @@ type Props = {
     isRotated: boolean;
     location: number;
     setActiveAnnotationId: (annotationId: string | null) => void;
-    setReferenceShape: (element: Shape) => void;
+    setReferenceShape: (rect: DOMRect) => void;
     setStaged: (staged: CreatorItemRegion | null) => void;
     setStatus: (status: CreatorStatus) => void;
     staged?: CreatorItemRegion | null;
@@ -41,13 +41,7 @@ export default class RegionAnnotations extends React.PureComponent<Props, State>
         const { rectRef: prevRectRef } = prevState;
 
         if (prevRectRef !== rectRef && rectRef && staged) {
-            const { height, width, top, left } = rectRef.getBoundingClientRect();
-            setReferenceShape({
-                height,
-                width,
-                x: left,
-                y: top,
-            });
+            setReferenceShape(rectRef.getBoundingClientRect());
         }
     }
 

--- a/src/region/RegionAnnotations.tsx
+++ b/src/region/RegionAnnotations.tsx
@@ -1,30 +1,24 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import PopupReply from '../components/Popups/PopupReply';
 import RegionCreator from './RegionCreator';
 import RegionList from './RegionList';
 import RegionRect, { RegionRectRef } from './RegionRect';
-import { AnnotationRegion, Rect } from '../@types';
-import { CreateArg } from './actions';
+import { AnnotationRegion, Rect, Shape } from '../@types';
 import { CreatorItemRegion, CreatorStatus } from '../store/creator';
 import './RegionAnnotations.scss';
 
 type Props = {
     activeAnnotationId: string | null;
     annotations: AnnotationRegion[];
-    createRegion: (arg: CreateArg) => void;
     isCreating: boolean;
     isDiscoverabilityEnabled: boolean;
     isRotated: boolean;
     location: number;
-    message: string;
-    resetCreator: () => void;
     setActiveAnnotationId: (annotationId: string | null) => void;
-    setMessage: (message: string) => void;
+    setReferenceShape: (element: Shape) => void;
     setStaged: (staged: CreatorItemRegion | null) => void;
     setStatus: (status: CreatorStatus) => void;
     staged?: CreatorItemRegion | null;
-    status: CreatorStatus;
 };
 
 type State = {
@@ -41,20 +35,26 @@ export default class RegionAnnotations extends React.PureComponent<Props, State>
 
     state: State = {};
 
+    componentDidUpdate(_prevProps: Props, prevState: State): void {
+        const { setReferenceShape, staged } = this.props;
+        const { rectRef } = this.state;
+        const { rectRef: prevRectRef } = prevState;
+
+        if (prevRectRef !== rectRef && rectRef && staged) {
+            const { height, width, top, left } = rectRef.getBoundingClientRect();
+            setReferenceShape({
+                height,
+                width,
+                x: left,
+                y: top,
+            });
+        }
+    }
+
     handleAnnotationActive = (annotationId: string | null): void => {
         const { setActiveAnnotationId } = this.props;
 
         setActiveAnnotationId(annotationId);
-    };
-
-    handleCancel = (): void => {
-        const { resetCreator } = this.props;
-        resetCreator();
-    };
-
-    handleChange = (text = ''): void => {
-        const { setMessage } = this.props;
-        setMessage(text);
     };
 
     handleStart = (): void => {
@@ -67,16 +67,6 @@ export default class RegionAnnotations extends React.PureComponent<Props, State>
         const { location, setStaged, setStatus } = this.props;
         setStaged({ location, shape });
         setStatus(CreatorStatus.staged);
-    };
-
-    handleSubmit = (): void => {
-        const { createRegion, message, staged } = this.props;
-
-        if (!staged) {
-            return;
-        }
-
-        createRegion({ ...staged, message });
     };
 
     renderCreator = (): JSX.Element => {
@@ -116,11 +106,8 @@ export default class RegionAnnotations extends React.PureComponent<Props, State>
     };
 
     render(): JSX.Element {
-        const { isCreating, isDiscoverabilityEnabled, isRotated, message, staged, status } = this.props;
-        const { rectRef } = this.state;
+        const { isCreating, isDiscoverabilityEnabled, isRotated, staged } = this.props;
         const canCreate = isCreating && !isRotated;
-        const canReply = status !== CreatorStatus.started && status !== CreatorStatus.init;
-        const isPending = status === CreatorStatus.pending;
 
         return (
             <>
@@ -141,20 +128,6 @@ export default class RegionAnnotations extends React.PureComponent<Props, State>
                 {canCreate && staged && (
                     <div className="ba-RegionAnnotations-target">
                         <RegionRect ref={this.setRectRef} isActive shape={staged.shape} />
-                    </div>
-                )}
-
-                {/* Layer 3b: Staged (unsaved) annotation description popup, if 3a is ready */}
-                {canCreate && staged && canReply && rectRef && (
-                    <div className="ba-RegionAnnotations-popup">
-                        <PopupReply
-                            isPending={isPending}
-                            onCancel={this.handleCancel}
-                            onChange={this.handleChange}
-                            onSubmit={this.handleSubmit}
-                            reference={rectRef}
-                            value={message}
-                        />
                     </div>
                 )}
             </>

--- a/src/region/RegionContainer.tsx
+++ b/src/region/RegionContainer.tsx
@@ -3,26 +3,21 @@ import { AnnotationRegion } from '../@types';
 import {
     AppState,
     CreatorItemRegion,
-    CreatorStatus,
     getActiveAnnotationId,
     getAnnotationMode,
     getAnnotationsForLocation,
-    getCreatorMessage,
     getCreatorStagedForLocation,
-    getCreatorStatus,
     getRotation,
     isCreatorStagedRegion,
     isFeatureEnabled,
     Mode,
-    resetCreatorAction,
     setActiveAnnotationIdAction,
-    setMessageAction,
+    setReferenceShapeAction,
     setStagedAction,
     setStatusAction,
 } from '../store';
 import RegionAnnotations from './RegionAnnotations';
 import withProviders from '../common/withProviders';
-import { createRegionAction } from './actions';
 import { isRegion } from './regionUtil';
 
 export type Props = {
@@ -31,9 +26,7 @@ export type Props = {
     isCreating: boolean;
     isDiscoverabilityEnabled: boolean;
     isRotated: boolean;
-    message: string;
     staged: CreatorItemRegion | null;
-    status: CreatorStatus;
 };
 
 export const mapStateToProps = (state: AppState, { location }: { location: number }): Props => {
@@ -45,17 +38,13 @@ export const mapStateToProps = (state: AppState, { location }: { location: numbe
         isCreating: getAnnotationMode(state) === Mode.REGION,
         isDiscoverabilityEnabled: isFeatureEnabled(state, 'discoverability'),
         isRotated: !!getRotation(state),
-        message: getCreatorMessage(state),
         staged: isCreatorStagedRegion(staged) ? staged : null,
-        status: getCreatorStatus(state),
     };
 };
 
 export const mapDispatchToProps = {
-    createRegion: createRegionAction,
-    resetCreator: resetCreatorAction,
     setActiveAnnotationId: setActiveAnnotationIdAction,
-    setMessage: setMessageAction,
+    setReferenceShape: setReferenceShapeAction,
     setStaged: setStagedAction,
     setStatus: setStatusAction,
 };

--- a/src/region/__tests__/RegionAnnotations-test.tsx
+++ b/src/region/__tests__/RegionAnnotations-test.tsx
@@ -197,7 +197,7 @@ describe('RegionAnnotations', () => {
             }),
         };
 
-        test('should call setReferenceShape current rectRef and staged exist', () => {
+        test('should call setReferenceShape if current rectRef and staged exist', () => {
             const wrapper = getWrapper({ staged: {} });
 
             wrapper.setState({ rectRef: mockRectRef });

--- a/src/region/__tests__/RegionAnnotations-test.tsx
+++ b/src/region/__tests__/RegionAnnotations-test.tsx
@@ -213,23 +213,16 @@ describe('RegionAnnotations', () => {
             expect(defaults.setReferenceShape).not.toHaveBeenCalled();
         });
 
-        test('should not call setReferenceShape if staged does not exist', () => {
-            const wrapper = getWrapper();
-
-            wrapper.setState({ rectRef: mockRectRef });
-            wrapper.setProps({ annotations: [] });
-
-            expect(defaults.setReferenceShape).not.toHaveBeenCalled();
-        });
-
         test('should not call setReferenceShape if rectRef does not exist', () => {
             const wrapper = getWrapper();
 
             wrapper.setState({ rectRef: mockRectRef });
-            wrapper.setState({ rectRef: undefined });
-            wrapper.setProps({ staged: {} });
 
-            expect(defaults.setReferenceShape).not.toHaveBeenCalled();
+            expect(defaults.setReferenceShape).toHaveBeenCalledTimes(1);
+
+            wrapper.setState({ rectRef: undefined });
+
+            expect(defaults.setReferenceShape).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/src/region/__tests__/RegionAnnotations-test.tsx
+++ b/src/region/__tests__/RegionAnnotations-test.tsx
@@ -17,16 +17,13 @@ jest.mock('../RegionRect');
 describe('RegionAnnotations', () => {
     const defaults = {
         activeAnnotationId: null,
-        createRegion: jest.fn(),
         location: 1,
-        message: 'test',
-        resetCreator: jest.fn(),
         setActiveAnnotationId: jest.fn(),
         setMessage: jest.fn(),
+        setReferenceShape: jest.fn(),
         setStaged: jest.fn(),
         setStatus: jest.fn(),
         staged: null,
-        status: CreatorStatus.init,
     };
     const getRect = (): Rect => ({
         type: 'rect',
@@ -35,7 +32,6 @@ describe('RegionAnnotations', () => {
         x: 10,
         y: 10,
     });
-    const getRectRef = (): HTMLDivElement => document.createElement('div');
     const getStaged = (): CreatorItem => ({
         location: 1,
         shape: getRect(),
@@ -51,22 +47,6 @@ describe('RegionAnnotations', () => {
                 staged: getStaged(),
             });
             instance = wrapper.instance() as InstanceType<typeof RegionAnnotations>;
-        });
-
-        describe('handleCancel', () => {
-            test('should reset the staged state and status', () => {
-                instance.handleCancel();
-
-                expect(defaults.resetCreator).toHaveBeenCalled();
-            });
-        });
-
-        describe('handleChange', () => {
-            test('should set the staged state with the new message', () => {
-                instance.handleChange('test');
-
-                expect(defaults.setMessage).toHaveBeenCalledWith('test');
-            });
         });
 
         describe('handleStart', () => {
@@ -95,17 +75,6 @@ describe('RegionAnnotations', () => {
                     shape,
                 });
                 expect(defaults.setStatus).toHaveBeenCalledWith(CreatorStatus.staged);
-            });
-        });
-
-        describe('handleSubmit', () => {
-            test('should save the staged annotation', () => {
-                instance.handleSubmit();
-
-                expect(defaults.createRegion).toHaveBeenCalledWith({
-                    ...getStaged(),
-                    message: defaults.message,
-                });
             });
         });
 
@@ -147,59 +116,6 @@ describe('RegionAnnotations', () => {
 
             expect(wrapper.exists(RegionCreator)).toBe(true);
             expect(wrapper.find(RegionRect).prop('shape')).toEqual(shape);
-        });
-
-        test('should pass the creator item message value to the reply popup', () => {
-            const wrapper = getWrapper({
-                isCreating: true,
-                staged: getStaged(),
-                status: CreatorStatus.staged,
-            });
-            wrapper.setState({
-                rectRef: getRectRef(),
-            });
-
-            expect(wrapper.find(PopupReply).props()).toMatchObject({
-                value: 'test',
-            });
-        });
-
-        test.each`
-            status                    | showReply
-            ${CreatorStatus.init}     | ${false}
-            ${CreatorStatus.pending}  | ${true}
-            ${CreatorStatus.rejected} | ${true}
-            ${CreatorStatus.staged}   | ${true}
-        `('should render a reply popup if the creator status is $status', ({ status, showReply }) => {
-            const wrapper = getWrapper({
-                isCreating: true,
-                staged: getStaged(),
-                status,
-            });
-
-            wrapper.setState({
-                rectRef: getRectRef(),
-            });
-
-            expect(wrapper.exists(PopupReply)).toBe(showReply);
-        });
-
-        test.each`
-            status                    | isPending
-            ${CreatorStatus.rejected} | ${false}
-            ${CreatorStatus.pending}  | ${true}
-            ${CreatorStatus.staged}   | ${false}
-        `('should render reply popup with isPending $isPending', ({ status, isPending }) => {
-            const wrapper = getWrapper({
-                isCreating: true,
-                staged: getStaged(),
-                status,
-            });
-            wrapper.setState({
-                rectRef: getRectRef(),
-            });
-
-            expect(wrapper.find(PopupReply).prop('isPending')).toBe(isPending);
         });
 
         test('should pass activeId to the region list', () => {
@@ -268,6 +184,52 @@ describe('RegionAnnotations', () => {
                   />
                 </Fragment>
             `);
+        });
+    });
+
+    describe('componentDidUpdate', () => {
+        const mockRectRef = {
+            getBoundingClientRect: () => ({
+                height: 10,
+                width: 10,
+                top: 10,
+                left: 10,
+            }),
+        };
+
+        test('should call setReferenceShape current rectRef and staged exist', () => {
+            const wrapper = getWrapper({ staged: {} });
+
+            wrapper.setState({ rectRef: mockRectRef });
+
+            expect(defaults.setReferenceShape).toHaveBeenCalled();
+        });
+
+        test('should not call setReferenceShape if prev and current rectRef are the same', () => {
+            const wrapper = getWrapper();
+
+            wrapper.setProps({ staged: {} });
+
+            expect(defaults.setReferenceShape).not.toHaveBeenCalled();
+        });
+
+        test('should not call setReferenceShape if staged does not exist', () => {
+            const wrapper = getWrapper();
+
+            wrapper.setState({ rectRef: mockRectRef });
+            wrapper.setProps({ annotations: [] });
+
+            expect(defaults.setReferenceShape).not.toHaveBeenCalled();
+        });
+
+        test('should not call setReferenceShape if rectRef does not exist', () => {
+            const wrapper = getWrapper();
+
+            wrapper.setState({ rectRef: mockRectRef });
+            wrapper.setState({ rectRef: undefined });
+            wrapper.setProps({ staged: {} });
+
+            expect(defaults.setReferenceShape).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/region/__tests__/RegionContainer-test.tsx
+++ b/src/region/__tests__/RegionContainer-test.tsx
@@ -3,7 +3,7 @@ import { IntlShape } from 'react-intl';
 import { mount, ReactWrapper } from 'enzyme';
 import RegionAnnotations from '../RegionAnnotations';
 import RegionContainer, { Props } from '../RegionContainer';
-import { createStore, CreatorStatus } from '../../store';
+import { createStore } from '../../store';
 
 jest.mock('../../common/withProviders');
 jest.mock('../RegionAnnotations');
@@ -24,15 +24,12 @@ describe('RegionContainer', () => {
             expect(wrapper.find(RegionAnnotations).props()).toMatchObject({
                 activeAnnotationId: null,
                 annotations: [],
-                createRegion: expect.any(Function),
                 isCreating: false,
                 isDiscoverabilityEnabled: false,
                 location: 1,
-                message: '',
                 staged: null,
-                status: CreatorStatus.init,
                 setActiveAnnotationId: expect.any(Function),
-                setMessage: expect.any(Function),
+                setReferenceShape: expect.any(Function),
                 setStaged: expect.any(Function),
                 setStatus: expect.any(Function),
                 store: defaults.store,

--- a/src/store/creator/__mocks__/creatorState.ts
+++ b/src/store/creator/__mocks__/creatorState.ts
@@ -4,6 +4,12 @@ export default {
     cursor: 0,
     error: null,
     message: 'test',
+    referenceShape: {
+        height: 10,
+        width: 10,
+        x: 10,
+        y: 10,
+    },
     staged: {
         location: 1,
         shape: {

--- a/src/store/creator/__tests__/actions-test.ts
+++ b/src/store/creator/__tests__/actions-test.ts
@@ -1,0 +1,19 @@
+import state from '../__mocks__/creatorState';
+import { setReferenceShapeAction } from '../actions';
+
+describe('creator/actions', () => {
+    describe('setReferenceShapeAction', () => {
+        const arg = {
+            height: 10,
+            width: 10,
+            left: 10,
+            top: 10,
+        } as DOMRect;
+        test('should prepare the argument for the payload', async () => {
+            expect(setReferenceShapeAction(arg)).toEqual({
+                payload: state.referenceShape,
+                type: 'SET_REFERENCE_SHAPE',
+            });
+        });
+    });
+});

--- a/src/store/creator/__tests__/reducer-test.ts
+++ b/src/store/creator/__tests__/reducer-test.ts
@@ -3,7 +3,13 @@ import state from '../__mocks__/creatorState';
 import { createAnnotationAction } from '../../annotations';
 import { CreatorStatus } from '../types';
 import { NewAnnotation } from '../../../@types';
-import { setCursorAction, setMessageAction, setStagedAction, setStatusAction } from '../actions';
+import {
+    setCursorAction,
+    setMessageAction,
+    setReferenceShapeAction,
+    setStagedAction,
+    setStatusAction,
+} from '../actions';
 
 describe('store/creator/reducer', () => {
     describe('createAnnotationAction', () => {
@@ -48,6 +54,15 @@ describe('store/creator/reducer', () => {
             const newState = reducer(state, setMessageAction(payload));
 
             expect(newState.message).toEqual(payload);
+        });
+    });
+
+    describe('setReferenceShapeAction', () => {
+        test('should set the reference shape in state', () => {
+            const payload = { height: 10, left: 10, top: 10, width: 10 } as DOMRect;
+            const newState = reducer(state, setReferenceShapeAction(payload));
+
+            expect(newState.referenceShape).toEqual({ height: 10, width: 10, x: 10, y: 10 });
         });
     });
 

--- a/src/store/creator/__tests__/selectors-test.ts
+++ b/src/store/creator/__tests__/selectors-test.ts
@@ -1,6 +1,12 @@
 import creatorState from '../__mocks__/creatorState';
 import { CreatorStatus } from '../types';
-import { getCreatorMessage, getCreatorStaged, getCreatorStagedForLocation, getCreatorStatus } from '../selectors';
+import {
+    getCreatorMessage,
+    getCreatorReferenceShape,
+    getCreatorStaged,
+    getCreatorStagedForLocation,
+    getCreatorStatus,
+} from '../selectors';
 
 describe('store/annotations/selectors', () => {
     const state = { creator: creatorState };
@@ -8,6 +14,17 @@ describe('store/annotations/selectors', () => {
     describe('getCreatorStatus', () => {
         test('should return the current creator status', () => {
             expect(getCreatorStatus(state)).toBe(CreatorStatus.init);
+        });
+    });
+
+    describe('getCreatorReferenceShape', () => {
+        test('should return the current creator reference shape', () => {
+            expect(getCreatorReferenceShape(state)).toEqual({
+                height: 10,
+                width: 10,
+                x: 10,
+                y: 10,
+            });
         });
     });
 

--- a/src/store/creator/actions.ts
+++ b/src/store/creator/actions.ts
@@ -2,9 +2,26 @@ import { createAction } from '@reduxjs/toolkit';
 import { CreatorItem, CreatorStatus } from './types';
 import { Shape } from '../../@types';
 
+type Payload = {
+    payload: Shape;
+};
+
 export const resetCreatorAction = createAction('RESET_CREATOR');
 export const setCursorAction = createAction<number>('SET_CREATOR_CURSOR');
 export const setMessageAction = createAction<string>('SET_CREATOR_MESSAGE');
-export const setReferenceShapeAction = createAction<Shape | undefined>('SET_REFERENCE_SHAPE');
+export const setReferenceShapeAction = createAction(
+    'SET_REFERENCE_SHAPE',
+    (arg: DOMRect): Payload => {
+        const { height, width, top, left } = arg;
+        return {
+            payload: {
+                height,
+                width,
+                x: left,
+                y: top,
+            },
+        };
+    },
+);
 export const setStagedAction = createAction<CreatorItem | null>('SET_CREATOR_STAGED');
 export const setStatusAction = createAction<CreatorStatus>('SET_CREATOR_STATUS');

--- a/src/store/creator/actions.ts
+++ b/src/store/creator/actions.ts
@@ -12,7 +12,7 @@ export const setMessageAction = createAction<string>('SET_CREATOR_MESSAGE');
 export const setReferenceShapeAction = createAction(
     'SET_REFERENCE_SHAPE',
     (arg: DOMRect): Payload => {
-        const { height, width, top, left } = arg;
+        const { height, left, top, width } = arg;
         return {
             payload: {
                 height,

--- a/src/store/creator/actions.ts
+++ b/src/store/creator/actions.ts
@@ -1,8 +1,10 @@
 import { createAction } from '@reduxjs/toolkit';
 import { CreatorItem, CreatorStatus } from './types';
+import { Shape } from '../../@types';
 
 export const resetCreatorAction = createAction('RESET_CREATOR');
 export const setCursorAction = createAction<number>('SET_CREATOR_CURSOR');
 export const setMessageAction = createAction<string>('SET_CREATOR_MESSAGE');
+export const setReferenceShapeAction = createAction<Shape | undefined>('SET_REFERENCE_SHAPE');
 export const setStagedAction = createAction<CreatorItem | null>('SET_CREATOR_STAGED');
 export const setStatusAction = createAction<CreatorStatus>('SET_CREATOR_STATUS');

--- a/src/store/creator/reducer.ts
+++ b/src/store/creator/reducer.ts
@@ -1,7 +1,14 @@
 import { createReducer } from '@reduxjs/toolkit';
 import { CreatorState, CreatorStatus } from './types';
 import { createAnnotationAction } from '../annotations';
-import { setMessageAction, setCursorAction, setStagedAction, setStatusAction, resetCreatorAction } from './actions';
+import {
+    resetCreatorAction,
+    setCursorAction,
+    setMessageAction,
+    setReferenceShapeAction,
+    setStagedAction,
+    setStatusAction,
+} from './actions';
 
 export const initialState = {
     cursor: 0,
@@ -29,6 +36,9 @@ export default createReducer<CreatorState>(initialState, builder =>
         })
         .addCase(setMessageAction, (state, { payload }) => {
             state.message = payload;
+        })
+        .addCase(setReferenceShapeAction, (state, { payload }) => {
+            state.referenceShape = payload;
         })
         .addCase(setStagedAction, (state, { payload }) => {
             state.staged = payload;

--- a/src/store/creator/selectors.ts
+++ b/src/store/creator/selectors.ts
@@ -1,10 +1,12 @@
 import { AppState } from '../types';
 import { CreatorItem, CreatorItemHighlight, CreatorItemRegion, CreatorStatus } from './types';
+import { Shape } from '../../@types';
 
 type State = Pick<AppState, 'creator'>;
 
 export const getCreatorCursor = (state: State): number => state.creator.cursor;
 export const getCreatorMessage = (state: State): string => state.creator.message;
+export const getCreatorReferenceShape = (state: State): Shape | undefined => state.creator.referenceShape;
 export const getCreatorStaged = (state: State): CreatorItem | null => state.creator.staged;
 export const getCreatorStagedForLocation = (state: State, location: number): CreatorItem | null => {
     const staged = getCreatorStaged(state);

--- a/src/store/creator/types.ts
+++ b/src/store/creator/types.ts
@@ -1,4 +1,4 @@
-import { Rect, SerializedError } from '../../@types';
+import { Rect, SerializedError, Shape } from '../../@types';
 
 export enum CreatorStatus {
     init = 'init',
@@ -26,6 +26,7 @@ export type CreatorState = {
     cursor: number;
     error: SerializedError | null;
     message: string;
+    referenceShape?: Shape;
     staged: CreatorItem;
     status: CreatorStatus;
 };


### PR DESCRIPTION
**Issue**
With the way that `PopupReply` was rendered in the same layer as the annotation-specific layer (region, highlight), the popup in some browsers (ie11) would be beneath other drawn annotation elements, depending on what order the annotation layers were configured.

**Overview**
Creates a new `PopupManager` that renders the `PopupReply` for the staged annotation, regardless of annotation type so that it can always be the top layer.

**Before**
![Screen Shot 2020-09-24 at 11 24 30 AM](https://user-images.githubusercontent.com/17791289/94184493-d574cc00-fe58-11ea-9277-03c607d21b7f.png)


**After**
![Screen Shot 2020-09-24 at 11 25 43 AM](https://user-images.githubusercontent.com/17791289/94184476-d0b01800-fe58-11ea-8719-e698ec107d06.png)


**TODO**
- [x] unit tests
- [x] cross-browser testing