### PR TITLE
fix(popuplayer): Ensure the staged type matches the mode

### DIFF
--- a/src/popup/PopupContainer.tsx
+++ b/src/popup/PopupContainer.tsx
@@ -20,9 +20,9 @@ import { Shape } from '../@types';
 import { createRegionAction } from '../region';
 
 export type Props = {
-    isCreating: boolean;
     isPromoting: boolean;
     message: string;
+    mode: Mode;
     popupReference?: Shape;
     staged: CreatorItem | null;
     status: CreatorStatus;
@@ -30,9 +30,9 @@ export type Props = {
 
 export const mapStateToProps = (state: AppState, { location }: { location: number }): Props => {
     return {
-        isCreating: getAnnotationMode(state) !== Mode.NONE,
         isPromoting: getIsPromoting(state),
         message: getCreatorMessage(state),
+        mode: getAnnotationMode(state),
         popupReference: getCreatorReferenceShape(state),
         staged: getCreatorStagedForLocation(state, location),
         status: getCreatorStatus(state),

--- a/src/popup/__tests__/PopupContainer-test.tsx
+++ b/src/popup/__tests__/PopupContainer-test.tsx
@@ -3,7 +3,7 @@ import { IntlShape } from 'react-intl';
 import { mount, ReactWrapper } from 'enzyme';
 import PopupLayer from '../PopupLayer';
 import PopupContainer, { Props } from '../PopupContainer';
-import { createStore, CreatorStatus } from '../../store';
+import { createStore, CreatorStatus, Mode } from '../../store';
 
 jest.mock('../PopupLayer');
 jest.mock('../../common/withProviders');
@@ -22,8 +22,8 @@ describe('PopupContainer', () => {
 
             expect(wrapper.exists('RootProvider')).toBe(true);
             expect(wrapper.find(PopupLayer).props()).toMatchObject({
-                isCreating: false,
                 isPromoting: false,
+                mode: Mode.NONE,
                 staged: null,
                 status: CreatorStatus.init,
                 store: defaults.store,

--- a/src/popup/__tests__/PopupLayer-test.tsx
+++ b/src/popup/__tests__/PopupLayer-test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ReactWrapper, mount } from 'enzyme';
 import PopupLayer from '../PopupLayer';
 import PopupReply from '../../components/Popups/PopupReply';
-import { CreatorStatus, CreatorItemHighlight, CreatorItemRegion } from '../../store';
+import { CreatorStatus, CreatorItemHighlight, CreatorItemRegion, Mode } from '../../store';
 import { Rect } from '../../@types';
 
 jest.mock('../../components/Popups/PopupReply');
@@ -27,10 +27,10 @@ describe('PopupLayer', () => {
     const defaults = {
         createHighlight: jest.fn(),
         createRegion: jest.fn(),
-        isCreating: true,
         isPromoting: false,
         location: 1,
         message: '',
+        mode: Mode.HIGHLIGHT,
         popupReference,
         resetCreator: jest.fn(),
         setMessage: jest.fn(),
@@ -76,6 +76,18 @@ describe('PopupLayer', () => {
 
             expect(wrapper.find(PopupReply).prop('isPending')).toBe(isPending);
         });
+
+        test('should not render PopupReply if there is a staged type and mode mismatch', () => {
+            // defaults has staged as highlight
+            const wrapper = getWrapper({ mode: Mode.REGION });
+
+            expect(wrapper.exists(PopupReply)).toBe(false);
+        });
+
+        test('should render PopupReply if promoting a highlight', () => {
+            const wrapper = getWrapper({ mode: Mode.NONE, isPromoting: true });
+            expect(wrapper.exists(PopupReply)).toBe(true);
+        });
     });
 
     describe('event handlers', () => {
@@ -117,7 +129,7 @@ describe('PopupLayer', () => {
             });
 
             test('should create region if staged item is type region', () => {
-                const wrapper = getWrapper({ staged: getStagedRegion() });
+                const wrapper = getWrapper({ mode: Mode.REGION, staged: getStagedRegion() });
                 wrapper.find(PopupReply).prop('onSubmit')('');
 
                 expect(defaults.createHighlight).not.toHaveBeenCalled();


### PR DESCRIPTION
This solves the issue where toggling between annotation modes doesn't hide the `PopupReply`