### PR TITLE
fix(highlight): Reset selection when creator status changes

### DIFF
--- a/src/store/highlight/__tests__/reducer-test.ts
+++ b/src/store/highlight/__tests__/reducer-test.ts
@@ -4,7 +4,7 @@ import { Annotation, NewAnnotation } from '../../../@types';
 import { createAnnotationAction } from '../../annotations';
 import { mockContainerRect, mockRange } from '../__mocks__/data';
 import { Mode, toggleAnnotationModeAction } from '../../common';
-import { resetCreatorAction } from '../../creator';
+import { CreatorStatus, resetCreatorAction, setStatusAction } from '../../creator';
 import { setIsPromotingAction, setSelectionAction, setIsSelectingAction } from '../actions';
 
 describe('store/highlight/reducer', () => {
@@ -62,6 +62,14 @@ describe('store/highlight/reducer', () => {
             const newState = reducer({ ...state, isPromoting: true }, toggleAnnotationModeAction(Mode.HIGHLIGHT));
 
             expect(newState.isPromoting).toEqual(false);
+        });
+    });
+
+    describe('setStatusAction', () => {
+        test('should reset selection when creator status changes', () => {
+            const newState = reducer(state, setStatusAction(CreatorStatus.started));
+
+            expect(newState.selection).toEqual(null);
         });
     });
 });

--- a/src/store/highlight/__tests__/reducer-test.ts
+++ b/src/store/highlight/__tests__/reducer-test.ts
@@ -9,15 +9,10 @@ import { setIsPromotingAction, setSelectionAction, setIsSelectingAction } from '
 
 describe('store/highlight/reducer', () => {
     describe('setIsPromoting', () => {
-        test.each`
-            payload  | isPromoting | selection
-            ${true}  | ${true}     | ${null}
-            ${false} | ${false}    | ${state.selection}
-        `('should set isPromoting and selection in state', ({ isPromoting, payload, selection }) => {
+        test.each([true, false])('should set isPromoting in state as %s', payload => {
             const newState = reducer(state, setIsPromotingAction(payload));
 
-            expect(newState.isPromoting).toEqual(isPromoting);
-            expect(newState.selection).toEqual(selection);
+            expect(newState.isPromoting).toEqual(payload);
         });
     });
 

--- a/src/store/highlight/reducer.ts
+++ b/src/store/highlight/reducer.ts
@@ -1,7 +1,7 @@
 import { createReducer } from '@reduxjs/toolkit';
 import { createAnnotationAction } from '../annotations';
 import { HighlightState } from './types';
-import { resetCreatorAction } from '../creator';
+import { resetCreatorAction, setStatusAction } from '../creator';
 import { setIsPromotingAction, setIsSelectingAction, setSelectionAction } from './actions';
 import { toggleAnnotationModeAction } from '../common';
 
@@ -33,5 +33,8 @@ export default createReducer<HighlightState>(initialState, builder =>
         })
         .addCase(toggleAnnotationModeAction, state => {
             state.isPromoting = false;
+        })
+        .addCase(setStatusAction, state => {
+            state.selection = null;
         }),
 );

--- a/src/store/highlight/reducer.ts
+++ b/src/store/highlight/reducer.ts
@@ -15,9 +15,6 @@ export default createReducer<HighlightState>(initialState, builder =>
     builder
         .addCase(setIsPromotingAction, (state, { payload }) => {
             state.isPromoting = payload;
-            if (payload) {
-                state.selection = null;
-            }
         })
         .addCase(setIsSelectingAction, (state, { payload }) => {
             state.isSelecting = payload;


### PR DESCRIPTION
The first selection is canceled by starting dragging, and the second selection is canceled by clicking

![reset-selection](https://user-images.githubusercontent.com/17711683/94865852-281f2c80-03f3-11eb-848d-d8c0180e11ff.gif)
