### PR TITLE
fix(creator): Reset creator store when toggleAnnotationModeAction

### DIFF
--- a/src/store/creator/__tests__/reducer-test.ts
+++ b/src/store/creator/__tests__/reducer-test.ts
@@ -10,6 +10,7 @@ import {
     setStagedAction,
     setStatusAction,
 } from '../actions';
+import { toggleAnnotationModeAction } from '../../common';
 
 describe('store/creator/reducer', () => {
     describe('createAnnotationAction', () => {
@@ -88,6 +89,26 @@ describe('store/creator/reducer', () => {
             const newState = reducer(state, setCursorAction(2));
 
             expect(newState.cursor).toEqual(2);
+        });
+    });
+
+    describe('toggleAnnotationModeAction', () => {
+        test('should reset the creator state', () => {
+            const newState = reducer(
+                {
+                    ...state,
+                    cursor: 1,
+                    error: new Error('error'),
+                    status: CreatorStatus.rejected,
+                },
+                toggleAnnotationModeAction,
+            );
+
+            expect(newState.cursor).toEqual(0);
+            expect(newState.error).toEqual(null);
+            expect(newState.message).toEqual('');
+            expect(newState.staged).toEqual(null);
+            expect(newState.status).toEqual(CreatorStatus.init);
         });
     });
 });

--- a/src/store/creator/reducer.ts
+++ b/src/store/creator/reducer.ts
@@ -9,6 +9,7 @@ import {
     setStagedAction,
     setStatusAction,
 } from './actions';
+import { toggleAnnotationModeAction } from '../common';
 
 export const initialState = {
     cursor: 0,
@@ -48,5 +49,6 @@ export default createReducer<CreatorState>(initialState, builder =>
         })
         .addCase(setCursorAction, (state, { payload }) => {
             state.cursor = payload;
-        }),
+        })
+        .addCase(toggleAnnotationModeAction, () => initialState),
 );


### PR DESCRIPTION
Whenever the `toggleAnnotationModeAction` is dispatched, we reset the creator store so that any previously staged annotation is cleared out. 

**Before**
![toggle region fail](https://user-images.githubusercontent.com/17791289/95522770-d8f07300-0981-11eb-833b-78017871412f.gif)


**After**
![toggle region success](https://user-images.githubusercontent.com/17791289/95522774-dd1c9080-0981-11eb-8891-f46d89bab13e.gif)
