### PR TITLE
chore: Updating eslint rules to support non-null assertion in tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
             files: ['**/__mocks__/*', '**/__tests__/*'],
             rules: {
                 '@typescript-eslint/camelcase': 'off',
+                '@typescript-eslint/no-non-null-assertion': 'off',
             },
         },
         {

--- a/src/highlight/__tests__/HighlightAnnotations-test.tsx
+++ b/src/highlight/__tests__/HighlightAnnotations-test.tsx
@@ -126,7 +126,7 @@ describe('HighlightAnnotations', () => {
     describe('handleAnnotationActive()', () => {
         test('should call setActiveAnnotationId', () => {
             const wrapper = getWrapper();
-            (wrapper.find(HighlightList).prop('onSelect') as Function)('123');
+            wrapper.find(HighlightList).prop('onSelect')!('123');
 
             expect(defaults.setActiveAnnotationId).toHaveBeenCalledWith('123');
         });
@@ -135,7 +135,7 @@ describe('HighlightAnnotations', () => {
     describe('handlePromote()', () => {
         test('should clear selection and set isPromoting', () => {
             const wrapper = getWrapper({ selection: selectionMock });
-            (wrapper.find(PopupHighlight).prop('onClick') as Function)();
+            wrapper.find(PopupHighlight).prop('onClick')!({} as React.MouseEvent<HTMLButtonElement>);
 
             expect(defaults.setStaged).toHaveBeenCalledWith({
                 location: 1,
@@ -157,7 +157,7 @@ describe('HighlightAnnotations', () => {
     describe('handleCancel()', () => {
         test('should clear selection in store', () => {
             const wrapper = getWrapper({ selection: selectionMock });
-            (wrapper.find(PopupHighlight).prop('onCancel') as Function)();
+            wrapper.find(PopupHighlight).prop('onCancel')!();
 
             expect(defaults.setSelection).toHaveBeenCalledWith(null);
         });

--- a/src/highlight/__tests__/HighlightList-test.tsx
+++ b/src/highlight/__tests__/HighlightList-test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import noop from 'lodash/noop';
 import { act } from 'react-dom/test-utils';
 import { mount, ReactWrapper } from 'enzyme';
 import HighlightCanvas, { CanvasShape } from '../HighlightCanvas';
@@ -88,9 +87,10 @@ describe('HighlightList', () => {
             expect(shapes[3].isHover).toBe(false);
 
             act(() => {
-                const target = wrapper.find(HighlightTarget).at(2);
-                const handleTargetHover = target.prop('onHover') || noop;
-                handleTargetHover('anno_1');
+                wrapper
+                    .find(HighlightTarget)
+                    .at(2)
+                    .prop('onHover')!('anno_1');
             });
 
             wrapper.update();

--- a/src/region/__tests__/RegionAnnotations-test.tsx
+++ b/src/region/__tests__/RegionAnnotations-test.tsx
@@ -17,9 +17,9 @@ describe('RegionAnnotations', () => {
     describe('event handlers', () => {
         describe('handleAnnotationActive()', () => {
             test('should call setActiveAnnotationId with annotation id', () => {
-                (getWrapper()
+                getWrapper()
                     .find(RegionList)
-                    .prop('onSelect') as Function)('123');
+                    .prop('onSelect')!('123');
 
                 expect(defaults.setActiveAnnotationId).toHaveBeenCalledWith('123');
             });


### PR DESCRIPTION
Disabling the non-null assertion eslint rule for tests