### PR TITLE
refactor(manager): BaseManager class

### DIFF
--- a/src/common/BaseManager.ts
+++ b/src/common/BaseManager.ts
@@ -1,3 +1,4 @@
+import * as ReactDOM from 'react-dom';
 import { IntlShape } from 'react-intl';
 import { Store } from 'redux';
 
@@ -11,9 +12,59 @@ export type Props = {
     store: Store;
 };
 
-export default interface BaseManager {
+export interface Manager {
     destroy(): void;
     exists(parentEl: HTMLElement): boolean;
     render(props: Props): void;
     style(styles: Partial<CSSStyleDeclaration>): CSSStyleDeclaration;
+}
+
+export default class BaseManager implements Manager {
+    location: number;
+
+    reactEl: HTMLElement;
+
+    constructor({ location = 1, referenceEl }: Options) {
+        this.location = location;
+        this.reactEl = this.insert(referenceEl);
+
+        this.decorate();
+    }
+
+    decorate(): void {
+        throw new Error('Method not implemented.');
+    }
+
+    destroy(): void {
+        ReactDOM.unmountComponentAtNode(this.reactEl);
+
+        this.reactEl.remove();
+    }
+
+    exists(parentEl: HTMLElement): boolean {
+        return parentEl.contains(this.reactEl);
+    }
+
+    insert(referenceEl: HTMLElement): HTMLElement {
+        // Find the nearest applicable reference and document elements
+        const documentEl = referenceEl.ownerDocument || document;
+        const parentEl = referenceEl.parentNode || documentEl;
+
+        // Construct a layer element where we can inject a root React component
+        const rootLayerEl = documentEl.createElement('div');
+        rootLayerEl.classList.add('ba-Layer');
+        rootLayerEl.setAttribute('data-resin-feature', 'annotations');
+
+        // Insert the new layer element immediately after the reference element
+        return parentEl.insertBefore(rootLayerEl, referenceEl.nextSibling);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    render(props: Props): void {
+        throw new Error('Method not implemented.');
+    }
+
+    style(styles: Partial<CSSStyleDeclaration>): CSSStyleDeclaration {
+        return Object.assign(this.reactEl.style, styles);
+    }
 }

--- a/src/document/DocumentAnnotator.ts
+++ b/src/document/DocumentAnnotator.ts
@@ -1,5 +1,4 @@
 import BaseAnnotator, { ANNOTATION_CLASSES, Options } from '../common/BaseAnnotator';
-import BaseManager from '../common/BaseManager';
 import PopupManager from '../popup/PopupManager';
 import { centerHighlight, isHighlight } from '../highlight/highlightUtil';
 import { centerRegion, isRegion, RegionCreationManager, RegionManager } from '../region';
@@ -7,6 +6,7 @@ import { Event } from '../@types';
 import { getAnnotation } from '../store/annotations';
 import { getSelection } from './docUtil';
 import { HighlightCreatorManager, HighlightListener, HighlightManager } from '../highlight';
+import { Manager } from '../common/BaseManager';
 import { Mode } from '../store';
 import { scrollToLocation } from '../utils/scroll';
 import './DocumentAnnotator.scss';
@@ -19,7 +19,7 @@ export default class DocumentAnnotator extends BaseAnnotator {
 
     highlightListener?: HighlightListener;
 
-    managers: Map<number, Set<BaseManager>> = new Map();
+    managers: Map<number, Set<Manager>> = new Map();
 
     constructor(options: Options) {
         super(options);
@@ -49,7 +49,7 @@ export default class DocumentAnnotator extends BaseAnnotator {
         return this.containerEl?.querySelector('.bp-doc');
     }
 
-    getPageManagers(pageEl: HTMLElement): Set<BaseManager> {
+    getPageManagers(pageEl: HTMLElement): Set<Manager> {
         const pageNumber = this.getPageNumber(pageEl);
         const pageReferenceEl = this.getPageReference(pageEl);
         const managers = this.managers.get(pageNumber) || new Set();

--- a/src/document/__tests__/DocumentAnnotator-test.ts
+++ b/src/document/__tests__/DocumentAnnotator-test.ts
@@ -1,4 +1,3 @@
-import BaseManager from '../../common/BaseManager';
 import DocumentAnnotator from '../DocumentAnnotator';
 import HighlightListener from '../../highlight/HighlightListener';
 import PopupManager from '../../popup/PopupManager';
@@ -10,6 +9,7 @@ import { annotation as highlight } from '../../highlight/__mocks__/data';
 import { annotations as regions } from '../../region/__mocks__/data';
 import { fetchAnnotationsAction, Mode } from '../../store';
 import { HighlightCreatorManager, HighlightManager } from '../../highlight';
+import { Manager } from '../../common/BaseManager';
 import { scrollToLocation } from '../../utils/scroll';
 
 jest.mock('../../highlight/HighlightManager');
@@ -105,7 +105,7 @@ describe('DocumentAnnotator', () => {
         test('should destroy existing managers', () => {
             annotator = getAnnotator();
 
-            const mockManager = ({ destroy: jest.fn() } as unknown) as BaseManager;
+            const mockManager = ({ destroy: jest.fn() } as unknown) as Manager;
             const mockManagersSet = new Set([mockManager]);
             annotator.managers.set(1, mockManagersSet);
 
@@ -255,7 +255,7 @@ describe('DocumentAnnotator', () => {
 
     describe('renderPage()', () => {
         test('should initialize a manager for a new page', () => {
-            const mockManager = ({ destroy: jest.fn(), render: jest.fn() } as unknown) as BaseManager;
+            const mockManager = ({ destroy: jest.fn(), render: jest.fn() } as unknown) as Manager;
             const pageNumber = 1;
             const pageEl = getPage(pageNumber);
 

--- a/src/highlight/HighlightCreatorManager.ts
+++ b/src/highlight/HighlightCreatorManager.ts
@@ -5,7 +5,7 @@ import {
     setIsSelectingAction,
     setSelectionAction,
 } from '../store';
-import BaseManager, { Options as BaseOptions } from '../common/BaseManager';
+import { Manager, Options as BaseOptions } from '../common/BaseManager';
 import { MOUSE_PRIMARY } from '../constants';
 
 export type Options = {
@@ -14,7 +14,7 @@ export type Options = {
     store: AppStore;
 } & BaseOptions;
 
-export default class HighlightCreatorManager implements BaseManager {
+export default class HighlightCreatorManager implements Manager {
     referenceEl: HTMLElement;
 
     getSelection: () => Selection | null;

--- a/src/highlight/HighlightManager.tsx
+++ b/src/highlight/HighlightManager.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import BaseManager, { Props } from '../common/BaseManager';
 import HighlightContainer from './HighlightContainer';
-import BaseManager, { Manager, Props } from '../common/BaseManager';
 
-export default class HighlightManager extends BaseManager implements Manager {
+export default class HighlightManager extends BaseManager {
     decorate(): void {
         this.reactEl.classList.add('ba-Layer--highlight');
         this.reactEl.dataset.testid = 'ba-Layer--highlight';

--- a/src/highlight/HighlightManager.tsx
+++ b/src/highlight/HighlightManager.tsx
@@ -1,49 +1,15 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import BaseManager, { Options, Props } from '../common/BaseManager';
 import HighlightContainer from './HighlightContainer';
+import BaseManager, { Manager, Props } from '../common/BaseManager';
 
-export default class HighlightManager implements BaseManager {
-    location: number;
-
-    reactEl: HTMLElement;
-
-    constructor({ location = 1, referenceEl }: Options) {
-        this.location = location;
-        this.reactEl = this.insert(referenceEl);
-    }
-
-    destroy(): void {
-        ReactDOM.unmountComponentAtNode(this.reactEl);
-
-        this.reactEl.remove();
-    }
-
-    exists(parentEl: HTMLElement): boolean {
-        return parentEl.contains(this.reactEl);
-    }
-
-    insert(referenceEl: HTMLElement): HTMLElement {
-        // Find the nearest applicable reference and document elements
-        const documentEl = referenceEl.ownerDocument || document;
-        const parentEl = referenceEl.parentNode || documentEl;
-
-        // Construct a layer element where we can inject a root React component
-        const rootLayerEl = documentEl.createElement('div');
-        rootLayerEl.classList.add('ba-Layer');
-        rootLayerEl.classList.add('ba-Layer--highlight');
-        rootLayerEl.dataset.testid = 'ba-Layer--highlight';
-        rootLayerEl.setAttribute('data-resin-feature', 'annotations');
-
-        // Insert the new layer element immediately after the reference element
-        return parentEl.insertBefore(rootLayerEl, referenceEl.nextSibling);
+export default class HighlightManager extends BaseManager implements Manager {
+    decorate(): void {
+        this.reactEl.classList.add('ba-Layer--highlight');
+        this.reactEl.dataset.testid = 'ba-Layer--highlight';
     }
 
     render(props: Props): void {
         ReactDOM.render(<HighlightContainer location={this.location} {...props} />, this.reactEl);
-    }
-
-    style(styles: Partial<CSSStyleDeclaration>): CSSStyleDeclaration {
-        return Object.assign(this.reactEl.style, styles);
     }
 }

--- a/src/image/ImageAnnotator.ts
+++ b/src/image/ImageAnnotator.ts
@@ -1,10 +1,10 @@
 import { Unsubscribe } from 'redux';
 import BaseAnnotator, { Options } from '../common/BaseAnnotator';
-import BaseManager from '../common/BaseManager';
 import PopupManager from '../popup/PopupManager';
 import { getAnnotation, getRotation } from '../store';
 import { centerRegion, getTransformedShape, isRegion, RegionCreationManager, RegionManager } from '../region';
 import { CreatorStatus, getCreatorStatus } from '../store/creator';
+import { Manager } from '../common/BaseManager';
 import { scrollToLocation } from '../utils/scroll';
 import './ImageAnnotator.scss';
 
@@ -13,7 +13,7 @@ export const CSS_IS_DRAWING_CLASS = 'ba-is-drawing';
 export default class ImageAnnotator extends BaseAnnotator {
     annotatedEl?: HTMLElement;
 
-    managers: Set<BaseManager> = new Set();
+    managers: Set<Manager> = new Set();
 
     storeHandler?: Unsubscribe;
 
@@ -39,7 +39,7 @@ export default class ImageAnnotator extends BaseAnnotator {
         return this.containerEl?.querySelector('.bp-image');
     }
 
-    getManagers(parentEl: HTMLElement, referenceEl: HTMLElement): Set<BaseManager> {
+    getManagers(parentEl: HTMLElement, referenceEl: HTMLElement): Set<Manager> {
         this.managers.forEach(manager => {
             if (!manager.exists(parentEl)) {
                 manager.destroy();

--- a/src/popup/PopupManager.tsx
+++ b/src/popup/PopupManager.tsx
@@ -1,49 +1,15 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import BaseManager, { Options, Props } from '../common/BaseManager';
+import BaseManager, { Manager, Props } from '../common/BaseManager';
 import PopupContainer from './PopupContainer';
 
-export default class PopupManager implements BaseManager {
-    location: number;
-
-    reactEl: HTMLElement;
-
-    constructor({ location = 1, referenceEl }: Options) {
-        this.location = location;
-        this.reactEl = this.insert(referenceEl);
-    }
-
-    destroy(): void {
-        ReactDOM.unmountComponentAtNode(this.reactEl);
-
-        this.reactEl.remove();
-    }
-
-    exists(parentEl: HTMLElement): boolean {
-        return parentEl.contains(this.reactEl);
-    }
-
-    insert(referenceEl: HTMLElement): HTMLElement {
-        // Find the nearest applicable reference and document elements
-        const documentEl = referenceEl.ownerDocument || document;
-        const parentEl = referenceEl.parentNode || documentEl;
-
-        // Construct a layer element where we can inject a root React component
-        const rootLayerEl = documentEl.createElement('div');
-        rootLayerEl.classList.add('ba-Layer');
-        rootLayerEl.classList.add('ba-Layer--popup');
-        rootLayerEl.dataset.testid = 'ba-Layer--popup';
-        rootLayerEl.setAttribute('data-resin-feature', 'annotations');
-
-        // Insert the new layer element immediately after the reference element
-        return parentEl.insertBefore(rootLayerEl, referenceEl.nextSibling);
+export default class PopupManager extends BaseManager implements Manager {
+    decorate(): void {
+        this.reactEl.classList.add('ba-Layer--popup');
+        this.reactEl.dataset.testid = 'ba-Layer--popup';
     }
 
     render(props: Props): void {
         ReactDOM.render(<PopupContainer location={this.location} {...props} />, this.reactEl);
-    }
-
-    style(styles: Partial<CSSStyleDeclaration>): CSSStyleDeclaration {
-        return Object.assign(this.reactEl.style, styles);
     }
 }

--- a/src/popup/PopupManager.tsx
+++ b/src/popup/PopupManager.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import BaseManager, { Manager, Props } from '../common/BaseManager';
+import BaseManager, { Props } from '../common/BaseManager';
 import PopupContainer from './PopupContainer';
 
-export default class PopupManager extends BaseManager implements Manager {
+export default class PopupManager extends BaseManager {
     decorate(): void {
         this.reactEl.classList.add('ba-Layer--popup');
         this.reactEl.dataset.testid = 'ba-Layer--popup';

--- a/src/region/RegionCreationManager.tsx
+++ b/src/region/RegionCreationManager.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import BaseManager, { Manager, Props } from '../common/BaseManager';
+import BaseManager, { Props } from '../common/BaseManager';
 import RegionCreationContainer from './RegionCreationContainer';
 
-export default class RegionManager extends BaseManager implements Manager {
+export default class RegionManager extends BaseManager {
     decorate(): void {
         this.reactEl.classList.add('ba-Layer--regionCreation');
         this.reactEl.dataset.testid = 'ba-Layer--regionCreation';

--- a/src/region/RegionCreationManager.tsx
+++ b/src/region/RegionCreationManager.tsx
@@ -1,49 +1,15 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import BaseManager, { Options, Props } from '../common/BaseManager';
+import BaseManager, { Manager, Props } from '../common/BaseManager';
 import RegionCreationContainer from './RegionCreationContainer';
 
-export default class RegionManager implements BaseManager {
-    location: number;
-
-    reactEl: HTMLElement;
-
-    constructor({ location = 1, referenceEl }: Options) {
-        this.location = location;
-        this.reactEl = this.insert(referenceEl);
-    }
-
-    destroy(): void {
-        ReactDOM.unmountComponentAtNode(this.reactEl);
-
-        this.reactEl.remove();
-    }
-
-    exists(parentEl: HTMLElement): boolean {
-        return parentEl.contains(this.reactEl);
-    }
-
-    insert(referenceEl: HTMLElement): HTMLElement {
-        // Find the nearest applicable reference and document elements
-        const documentEl = referenceEl.ownerDocument || document;
-        const parentEl = referenceEl.parentNode || documentEl;
-
-        // Construct a layer element where we can inject a root React component
-        const rootLayerEl = documentEl.createElement('div');
-        rootLayerEl.classList.add('ba-Layer');
-        rootLayerEl.classList.add('ba-Layer--regionCreation');
-        rootLayerEl.dataset.testid = 'ba-Layer--regionCreation';
-        rootLayerEl.setAttribute('data-resin-feature', 'annotations');
-
-        // Insert the new layer element immediately after the reference element
-        return parentEl.insertBefore(rootLayerEl, referenceEl.nextSibling);
+export default class RegionManager extends BaseManager implements Manager {
+    decorate(): void {
+        this.reactEl.classList.add('ba-Layer--regionCreation');
+        this.reactEl.dataset.testid = 'ba-Layer--regionCreation';
     }
 
     render(props: Props): void {
         ReactDOM.render(<RegionCreationContainer location={this.location} {...props} />, this.reactEl);
-    }
-
-    style(styles: Partial<CSSStyleDeclaration>): CSSStyleDeclaration {
-        return Object.assign(this.reactEl.style, styles);
     }
 }

--- a/src/region/RegionManager.tsx
+++ b/src/region/RegionManager.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import BaseManager, { Manager, Props } from '../common/BaseManager';
+import BaseManager, { Props } from '../common/BaseManager';
 import RegionAnnotationsContainer from './RegionAnnotationsContainer';
 
-export default class RegionListManager extends BaseManager implements Manager {
+export default class RegionListManager extends BaseManager {
     decorate(): void {
         this.reactEl.classList.add('ba-Layer--region');
         this.reactEl.dataset.testid = 'ba-Layer--region';

--- a/src/region/RegionManager.tsx
+++ b/src/region/RegionManager.tsx
@@ -1,49 +1,15 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import BaseManager, { Options, Props } from '../common/BaseManager';
+import BaseManager, { Manager, Props } from '../common/BaseManager';
 import RegionAnnotationsContainer from './RegionAnnotationsContainer';
 
-export default class RegionListManager implements BaseManager {
-    location: number;
-
-    reactEl: HTMLElement;
-
-    constructor({ location = 1, referenceEl }: Options) {
-        this.location = location;
-        this.reactEl = this.insert(referenceEl);
-    }
-
-    destroy(): void {
-        ReactDOM.unmountComponentAtNode(this.reactEl);
-
-        this.reactEl.remove();
-    }
-
-    exists(parentEl: HTMLElement): boolean {
-        return parentEl.contains(this.reactEl);
-    }
-
-    insert(referenceEl: HTMLElement): HTMLElement {
-        // Find the nearest applicable reference and document elements
-        const documentEl = referenceEl.ownerDocument || document;
-        const parentEl = referenceEl.parentNode || documentEl;
-
-        // Construct a layer element where we can inject a root React component
-        const rootLayerEl = documentEl.createElement('div');
-        rootLayerEl.classList.add('ba-Layer');
-        rootLayerEl.classList.add('ba-Layer--region');
-        rootLayerEl.dataset.testid = 'ba-Layer--region';
-        rootLayerEl.setAttribute('data-resin-feature', 'annotations');
-
-        // Insert the new layer element immediately after the reference element
-        return parentEl.insertBefore(rootLayerEl, referenceEl.nextSibling);
+export default class RegionListManager extends BaseManager implements Manager {
+    decorate(): void {
+        this.reactEl.classList.add('ba-Layer--region');
+        this.reactEl.dataset.testid = 'ba-Layer--region';
     }
 
     render(props: Props): void {
         ReactDOM.render(<RegionAnnotationsContainer location={this.location} {...props} />, this.reactEl);
-    }
-
-    style(styles: Partial<CSSStyleDeclaration>): CSSStyleDeclaration {
-        return Object.assign(this.reactEl.style, styles);
     }
 }


### PR DESCRIPTION
Pulling a lot of the repetitive `Manager` logic (constructor, destroy, style, insert, etc...) into a `BaseManager` class. 