### PR TITLE
chore(jest): Ignore mocks as modules

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
         mousetrap: '<rootDir>/scripts/jest/moduleMock.js',
         rangy: '<rootDir>/scripts/jest/moduleMock.js',
     },
+    modulePathIgnorePatterns: ['__mocks__'],
     restoreMocks: true,
     roots: ['src'],
     setupFiles: ['jest-canvas-mock', '<rootDir>/test/jest/envWindow.js'],


### PR DESCRIPTION
Cleans up the warning when running the tests

```
jest-haste-map: duplicate manual mock found: data
  The following files share their name; please delete one of them:
    * <rootDir>/src/highlight/__mocks__/data.ts
    * <rootDir>/src/region/__mocks__/data.ts

jest-haste-map: duplicate manual mock found: data
  The following files share their name; please delete one of them:
    * <rootDir>/src/region/__mocks__/data.ts
    * <rootDir>/src/store/highlight/__mocks__/data.ts

jest-haste-map: duplicate manual mock found: index
  The following files share their name; please delete one of them:
    * <rootDir>/src/components/ReplyForm/__mocks__/index.ts
    * <rootDir>/src/store/__mocks__/index.ts
```