### PR TITLE
fix(tests): BaseAnnotator test emitter leak

### DIFF
--- a/src/common/__tests__/BaseAnnotator-test.ts
+++ b/src/common/__tests__/BaseAnnotator-test.ts
@@ -38,11 +38,19 @@ describe('BaseAnnotator', () => {
         locale: 'en-US',
         token: '1234567890',
     };
-    const getAnnotator = (options = {}): MockAnnotator => new MockAnnotator({ ...defaults, ...options });
-    let annotator = getAnnotator();
+    const annotatorFactory = {
+        annotator: new MockAnnotator({ ...defaults }),
+        getAnnotator(options = {}) {
+            this.annotator.destroy();
+            this.annotator = new MockAnnotator({ ...defaults, ...options });
+            return this.annotator;
+        },
+    };
+
+    let annotator = annotatorFactory.getAnnotator();
 
     beforeEach(() => {
-        annotator = getAnnotator();
+        annotator = annotatorFactory.getAnnotator();
     });
 
     afterEach(() => {
@@ -64,7 +72,7 @@ describe('BaseAnnotator', () => {
                         annotations: { activeId: '123' },
                     },
                 };
-                annotator = getAnnotator({ fileOptions });
+                annotator = annotatorFactory.getAnnotator({ fileOptions });
 
                 expect(store.createStore).toHaveBeenLastCalledWith(
                     expect.objectContaining({
@@ -92,7 +100,7 @@ describe('BaseAnnotator', () => {
                 },
             };
 
-            annotator = getAnnotator({ fileOptions });
+            annotator = annotatorFactory.getAnnotator({ fileOptions });
 
             expect(store.createStore).toHaveBeenLastCalledWith(
                 expect.objectContaining({
@@ -131,7 +139,7 @@ describe('BaseAnnotator', () => {
                     },
                 };
 
-                annotator = getAnnotator({ file, fileOptions });
+                annotator = annotatorFactory.getAnnotator({ file, fileOptions });
 
                 expect(store.createStore).toHaveBeenLastCalledWith(
                     expect.objectContaining({ options: expect.objectContaining({ isCurrentFileVersion }) }),
@@ -141,13 +149,13 @@ describe('BaseAnnotator', () => {
         );
 
         test('should set features option', () => {
-            annotator = getAnnotator({ features });
+            annotator = annotatorFactory.getAnnotator({ features });
 
             expect(annotator.features).toEqual(features);
         });
 
         test('should set initial mode', () => {
-            annotator = getAnnotator({ initialMode: Mode.REGION });
+            annotator = annotatorFactory.getAnnotator({ initialMode: Mode.REGION });
 
             expect(store.createStore).toHaveBeenLastCalledWith(
                 expect.objectContaining({ common: { mode: Mode.REGION } }),
@@ -209,7 +217,7 @@ describe('BaseAnnotator', () => {
         });
 
         test('should emit error if no root element exists', () => {
-            annotator = getAnnotator({ container: 'non-existent' });
+            annotator = annotatorFactory.getAnnotator({ container: 'non-existent' });
             annotator.emit = jest.fn();
             annotator.init(5);
 

--- a/src/common/__tests__/BaseAnnotator-test.ts
+++ b/src/common/__tests__/BaseAnnotator-test.ts
@@ -38,19 +38,17 @@ describe('BaseAnnotator', () => {
         locale: 'en-US',
         token: '1234567890',
     };
-    const annotatorFactory = {
-        annotator: new MockAnnotator({ ...defaults }),
-        getAnnotator(options = {}) {
-            this.annotator.destroy();
-            this.annotator = new MockAnnotator({ ...defaults, ...options });
-            return this.annotator;
-        },
+
+    let annotator: MockAnnotator;
+    const initAnnotator = (options = {}): void => {
+        if (annotator) {
+            annotator.destroy();
+        }
+        annotator = new MockAnnotator({ ...defaults, ...options });
     };
 
-    let annotator = annotatorFactory.getAnnotator();
-
     beforeEach(() => {
-        annotator = annotatorFactory.getAnnotator();
+        initAnnotator();
     });
 
     afterEach(() => {
@@ -72,7 +70,7 @@ describe('BaseAnnotator', () => {
                         annotations: { activeId: '123' },
                     },
                 };
-                annotator = annotatorFactory.getAnnotator({ fileOptions });
+                initAnnotator({ fileOptions });
 
                 expect(store.createStore).toHaveBeenLastCalledWith(
                     expect.objectContaining({
@@ -100,7 +98,7 @@ describe('BaseAnnotator', () => {
                 },
             };
 
-            annotator = annotatorFactory.getAnnotator({ fileOptions });
+            initAnnotator({ fileOptions });
 
             expect(store.createStore).toHaveBeenLastCalledWith(
                 expect.objectContaining({
@@ -139,7 +137,7 @@ describe('BaseAnnotator', () => {
                     },
                 };
 
-                annotator = annotatorFactory.getAnnotator({ file, fileOptions });
+                initAnnotator({ file, fileOptions });
 
                 expect(store.createStore).toHaveBeenLastCalledWith(
                     expect.objectContaining({ options: expect.objectContaining({ isCurrentFileVersion }) }),
@@ -149,13 +147,13 @@ describe('BaseAnnotator', () => {
         );
 
         test('should set features option', () => {
-            annotator = annotatorFactory.getAnnotator({ features });
+            initAnnotator({ features });
 
             expect(annotator.features).toEqual(features);
         });
 
         test('should set initial mode', () => {
-            annotator = annotatorFactory.getAnnotator({ initialMode: Mode.REGION });
+            initAnnotator({ initialMode: Mode.REGION });
 
             expect(store.createStore).toHaveBeenLastCalledWith(
                 expect.objectContaining({ common: { mode: Mode.REGION } }),
@@ -217,7 +215,7 @@ describe('BaseAnnotator', () => {
         });
 
         test('should emit error if no root element exists', () => {
-            annotator = annotatorFactory.getAnnotator({ container: 'non-existent' });
+            initAnnotator({ container: 'non-existent' });
             annotator.emit = jest.fn();
             annotator.init(5);
 


### PR DESCRIPTION
Clean up the existing annotator before getting a new one.

This cleans up the following when running tests:
```
(node:6655) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 scaleannotations listeners added to [EventManager]. Use emitter.setMaxListeners() to increase limit
(node:6655) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 annotations_active_set listeners added to [EventManager]. Use emitter.setMaxListeners() to increase limit
(node:6655) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 annotations_remove listeners added to [EventManager]. Use emitter.setMaxListeners() to increase limit
(node:6655) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 annotations_visible_set listeners added to [EventManager]. Use emitter.setMaxListeners() to increase limit
```

