### PR TITLE
feat(annotations): ftux cursor experience

### DIFF
--- a/src/@types/events.ts
+++ b/src/@types/events.ts
@@ -4,6 +4,8 @@ enum Event {
     CREATOR_STAGED_CHANGE = 'creator_staged_change',
     CREATOR_STATUS_CHANGE = 'creator_status_change',
     ANNOTATION_CREATE = 'annotations_create',
+    ANNOTATIONS_DOCUMENT_EXPLICIT_CREATE_TOGGLED = 'annotations_document_explicit_create_toggled',
+    ANNOTATIONS_IMAGE_EXPLICIT_CREATE_TOGGLED = 'annotations_image_explicit_create_toggled',
     ANNOTATION_FETCH_ERROR = 'annotations_fetch_error',
     ANNOTATION_REMOVE = 'annotations_remove',
     ANNOTATIONS_INITIALIZED = 'annotations_initialized',

--- a/src/common/BaseAnnotator.ts
+++ b/src/common/BaseAnnotator.ts
@@ -36,8 +36,6 @@ export type Options = {
     hasTouch?: boolean;
     initialMode?: store.Mode;
     intl: IntlOptions;
-    isDocumentFtuxCursorDisabled: boolean;
-    isImageFtuxCursorDisabled: boolean;
     locale?: string;
     token: string;
 };

--- a/src/common/BaseAnnotator.ts
+++ b/src/common/BaseAnnotator.ts
@@ -36,6 +36,8 @@ export type Options = {
     hasTouch?: boolean;
     initialMode?: store.Mode;
     intl: IntlOptions;
+    isDocumentFtuxCursorDisabled: boolean;
+    isImageFtuxCursorDisabled: boolean;
     locale?: string;
     token: string;
 };
@@ -78,6 +80,8 @@ export default class BaseAnnotator extends EventEmitter {
                 fileId: file.id,
                 fileVersionId: fileOptionsVersionId ?? fileVersionId,
                 isCurrentFileVersion: !fileOptionsVersionId || fileOptionsVersionId === currentFileVersionId,
+                isDocumentFtuxCursorDisabled: false,
+                isImageFtuxCursorDisabled: false,
                 permissions: file.permissions,
             },
         };
@@ -94,6 +98,8 @@ export default class BaseAnnotator extends EventEmitter {
         this.addListener(Event.ACTIVE_SET, this.handleSetActive);
         this.addListener(Event.ANNOTATION_REMOVE, this.handleRemove);
         this.addListener(Event.VISIBLE_SET, this.handleSetVisible);
+        this.addListener(Event.ANNOTATIONS_DOCUMENT_EXPLICIT_CREATE_TOGGLED, this.handleSetDocumentRegionCursor);
+        this.addListener(Event.ANNOTATIONS_IMAGE_EXPLICIT_CREATE_TOGGLED, this.handleSetImageRegionCursor);
 
         // Load any required data at startup
         this.hydrate();
@@ -189,6 +195,14 @@ export default class BaseAnnotator extends EventEmitter {
 
     protected handleSetActive = (annotationId: string | null): void => {
         this.setActiveId(annotationId);
+    };
+
+    protected handleSetDocumentRegionCursor = (): void => {
+        this.store.dispatch(store.setDocumentFtuxCursorDisabledAction());
+    };
+
+    protected handleSetImageRegionCursor = (): void => {
+        this.store.dispatch(store.setImageFtuxCursorDisabledAction());
     };
 
     protected handleSetVisible = (visibility: boolean): void => {

--- a/src/common/BaseManager.ts
+++ b/src/common/BaseManager.ts
@@ -3,11 +3,13 @@ import { IntlShape } from 'react-intl';
 import { Store } from 'redux';
 
 export type Options = {
+    fileType?: string;
     location?: number;
     referenceEl: HTMLElement;
 };
 
 export type Props = {
+    fileType?: string;
     intl: IntlShape;
     store: Store;
 };
@@ -22,9 +24,12 @@ export interface Manager {
 export default class BaseManager implements Manager {
     location: number;
 
+    fileType?: string;
+
     reactEl: HTMLElement;
 
-    constructor({ location = 1, referenceEl }: Options) {
+    constructor({ fileType, location = 1, referenceEl }: Options) {
+        this.fileType = fileType;
         this.location = location;
         this.reactEl = this.insert(referenceEl);
 

--- a/src/common/__tests__/BaseAnnotator-test.ts
+++ b/src/common/__tests__/BaseAnnotator-test.ts
@@ -35,6 +35,8 @@ describe('BaseAnnotator', () => {
         intl: {
             messages: {},
         },
+        isDocumentFtuxCursorDisabled: false,
+        isImageFtuxCursorDisabled: false,
         locale: 'en-US',
         token: '1234567890',
     };
@@ -80,6 +82,8 @@ describe('BaseAnnotator', () => {
                             fileId: '12345',
                             fileVersionId: '98765',
                             isCurrentFileVersion: true,
+                            isDocumentFtuxCursorDisabled: false,
+                            isImageFtuxCursorDisabled: false,
                             permissions: {
                                 can_create_annotations: true,
                                 can_view_annotations: true,
@@ -108,6 +112,8 @@ describe('BaseAnnotator', () => {
                         fileId: '12345',
                         fileVersionId: '456',
                         isCurrentFileVersion: false,
+                        isDocumentFtuxCursorDisabled: false,
+                        isImageFtuxCursorDisabled: false,
                         permissions: {
                             can_create_annotations: true,
                             can_view_annotations: true,

--- a/src/document/DocumentAnnotator.ts
+++ b/src/document/DocumentAnnotator.ts
@@ -89,7 +89,7 @@ export default class DocumentAnnotator extends BaseAnnotator {
             const referenceEl =
                 this.isFeatureEnabled('discoverability') && canvasLayerEl ? canvasLayerEl : pageReferenceEl;
 
-            managers.add(new RegionCreationManager({ location: pageNumber, referenceEl }));
+            managers.add(new RegionCreationManager({ fileType: 'document', location: pageNumber, referenceEl }));
         }
 
         return managers;

--- a/src/image/ImageAnnotator.ts
+++ b/src/image/ImageAnnotator.ts
@@ -50,7 +50,7 @@ export default class ImageAnnotator extends BaseAnnotator {
         if (this.managers.size === 0) {
             this.managers.add(new PopupManager({ referenceEl }));
             this.managers.add(new RegionManager({ referenceEl }));
-            this.managers.add(new RegionCreationManager({ referenceEl }));
+            this.managers.add(new RegionCreationManager({ fileType: 'image', referenceEl }));
         }
 
         return this.managers;

--- a/src/region/RegionCreation.tsx
+++ b/src/region/RegionCreation.tsx
@@ -54,7 +54,7 @@ export default class RegionCreation extends React.PureComponent<Props, State> {
     };
 
     render(): JSX.Element | null {
-        const { isCreating, isDiscoverabilityEnabled, isRotated, staged } = this.props;
+        const { isCreating, isDiscoverabilityEnabled, isFtuxCursorDisabled, isRotated, staged } = this.props;
         const canCreate = isCreating && !isRotated;
 
         if (!canCreate) {
@@ -67,6 +67,7 @@ export default class RegionCreation extends React.PureComponent<Props, State> {
                     className={classNames('ba-RegionCreation-creator', {
                         'is-discoverability-enabled': isDiscoverabilityEnabled,
                     })}
+                    isFtuxCursorDisabled={isFtuxCursorDisabled}
                     onAbort={this.handleAbort}
                     onStart={this.handleStart}
                     onStop={this.handleStop}

--- a/src/region/RegionCreation.tsx
+++ b/src/region/RegionCreation.tsx
@@ -9,6 +9,7 @@ import './RegionCreation.scss';
 type Props = {
     isCreating: boolean;
     isDiscoverabilityEnabled: boolean;
+    isFtuxCursorDisabled: boolean;
     isRotated: boolean;
     location: number;
     resetCreator: () => void;

--- a/src/region/RegionCreationContainer.tsx
+++ b/src/region/RegionCreationContainer.tsx
@@ -28,12 +28,12 @@ export type Props = {
 
 export const mapStateToProps = (
     state: AppState,
-    { fileType, location }: { fileType: string; location: number },
+    { fileType, location }: { fileType?: string; location: number },
 ): Props => {
     const staged = getCreatorStagedForLocation(state, location);
 
     const isFtuxCursorDisabled =
-        fileType === 'document' ? isDocumentFtuxCursorDisabled(state) : isImageFtuxCursorDisabled(state);
+        fileType && fileType === 'document' ? isDocumentFtuxCursorDisabled(state) : isImageFtuxCursorDisabled(state);
 
     return {
         isCreating: getAnnotationMode(state) === Mode.REGION,

--- a/src/region/RegionCreationContainer.tsx
+++ b/src/region/RegionCreationContainer.tsx
@@ -7,6 +7,8 @@ import {
     getRotation,
     isCreatorStagedRegion,
     isFeatureEnabled,
+    isImageFtuxCursorDisabled,
+    isDocumentFtuxCursorDisabled,
     Mode,
     resetCreatorAction,
     setReferenceIdAction,
@@ -19,16 +21,24 @@ import withProviders from '../common/withProviders';
 export type Props = {
     isCreating: boolean;
     isDiscoverabilityEnabled: boolean;
+    isFtuxCursorDisabled: boolean;
     isRotated: boolean;
     staged: CreatorItemRegion | null;
 };
 
-export const mapStateToProps = (state: AppState, { location }: { location: number }): Props => {
+export const mapStateToProps = (
+    state: AppState,
+    { fileType, location }: { fileType: string; location: number },
+): Props => {
     const staged = getCreatorStagedForLocation(state, location);
+
+    const isFtuxCursorDisabled =
+        fileType === 'document' ? isDocumentFtuxCursorDisabled(state) : isImageFtuxCursorDisabled(state);
 
     return {
         isCreating: getAnnotationMode(state) === Mode.REGION,
         isDiscoverabilityEnabled: isFeatureEnabled(state, 'discoverability'),
+        isFtuxCursorDisabled,
         isRotated: !!getRotation(state),
         staged: isCreatorStagedRegion(staged) ? staged : null,
     };

--- a/src/region/RegionCreationManager.tsx
+++ b/src/region/RegionCreationManager.tsx
@@ -10,6 +10,9 @@ export default class RegionManager extends BaseManager {
     }
 
     render(props: Props): void {
-        ReactDOM.render(<RegionCreationContainer location={this.location} {...props} />, this.reactEl);
+        ReactDOM.render(
+            <RegionCreationContainer fileType={this.fileType} location={this.location} {...props} />,
+            this.reactEl,
+        );
     }
 }

--- a/src/region/RegionCreator.tsx
+++ b/src/region/RegionCreator.tsx
@@ -16,6 +16,7 @@ enum DrawingStatus {
 
 type Props = {
     className?: string;
+    isFtuxCursorDisabled: boolean;
     onAbort: () => void;
     onStart: () => void;
     onStop: (shape: Rect) => void;
@@ -25,7 +26,13 @@ const MIN_X = 0; // Minimum region x position must be positive
 const MIN_Y = 0; // Minimum region y position must be positive
 const MIN_SIZE = 10; // Minimum region size must be large enough to be clickable
 
-export default function RegionCreator({ className, onAbort, onStart, onStop }: Props): JSX.Element {
+export default function RegionCreator({
+    className,
+    isFtuxCursorDisabled,
+    onAbort,
+    onStart,
+    onStop,
+}: Props): JSX.Element {
     const [drawingStatus, setDrawingStatus] = React.useState<DrawingStatus>(DrawingStatus.init);
     const [isHovering, setIsHovering] = React.useState<boolean>(false);
     const creatorElRef = React.useRef<HTMLDivElement>(null);
@@ -255,7 +262,7 @@ export default function RegionCreator({ className, onAbort, onStart, onStop }: P
             {drawingStatus === DrawingStatus.drawing && (
                 <RegionRect ref={regionRectRef} className="ba-RegionCreator-rect" isActive />
             )}
-            {drawingStatus === DrawingStatus.init && isHovering && <PopupCursor />}
+            {drawingStatus === DrawingStatus.init && isHovering && !isFtuxCursorDisabled && <PopupCursor />}
         </div>
     );
 }

--- a/src/region/__tests__/RegionCreation-test.tsx
+++ b/src/region/__tests__/RegionCreation-test.tsx
@@ -12,6 +12,7 @@ jest.mock('../RegionRect');
 
 describe('RegionCreation', () => {
     const defaults = {
+        isFtuxCursorDisabled: false,
         location: 1,
         resetCreator: jest.fn(),
         setMessage: jest.fn(),

--- a/src/region/__tests__/RegionCreationContainer-test.tsx
+++ b/src/region/__tests__/RegionCreationContainer-test.tsx
@@ -10,6 +10,7 @@ jest.mock('../RegionCreation');
 
 describe('RegionCreationContainer', () => {
     const defaults = {
+        fileType: 'document',
         intl: {} as IntlShape,
         location: 1,
         store: createStore(),
@@ -22,6 +23,7 @@ describe('RegionCreationContainer', () => {
 
             expect(wrapper.exists('RootProvider')).toBe(true);
             expect(wrapper.find(RegionCreation).props()).toMatchObject({
+                fileType: defaults.fileType,
                 isCreating: false,
                 isDiscoverabilityEnabled: false,
                 location: 1,

--- a/src/region/__tests__/RegionCreator-test.tsx
+++ b/src/region/__tests__/RegionCreator-test.tsx
@@ -14,6 +14,7 @@ jest.mock('../regionUtil');
 
 describe('RegionCreator', () => {
     const defaults = {
+        isFtuxCursorDisabled: false,
         onAbort: jest.fn(),
         onStart: jest.fn(),
         onStop: jest.fn(),

--- a/src/store/options/__tests__/selectors-test.ts
+++ b/src/store/options/__tests__/selectors-test.ts
@@ -6,6 +6,8 @@ import {
     getRotation,
     getScale,
     isFeatureEnabled,
+    isDocumentFtuxCursorDisabled,
+    isImageFtuxCursorDisabled,
 } from '../selectors';
 
 describe('store/options/selectors', () => {
@@ -14,6 +16,8 @@ describe('store/options/selectors', () => {
         fileId: '12345',
         fileVersionId: '67890',
         isCurrentFileVersion: true,
+        isImageFtuxCursorDisabled: true,
+        isDocumentFtuxCursorDisabled: true,
         permissions: {
             can_create_annotations: true,
             can_view_annotations: true,
@@ -68,6 +72,18 @@ describe('store/options/selectors', () => {
 
         test('should return false for feature not in the features object', () => {
             expect(isFeatureEnabled({ options: optionsState }, 'nonExistentFeature')).toBe(false);
+        });
+    });
+
+    describe('isDocumentFtuxCursorDisabled', () => {
+        test('should return the current document ftux cursor disabled state', () => {
+            expect(isDocumentFtuxCursorDisabled({ options: optionsState })).toBe(false);
+        });
+    });
+
+    describe('isImageFtuxCursorDisabled', () => {
+        test('should return the current image ftux cursor disabled state', () => {
+            expect(isImageFtuxCursorDisabled({ options: optionsState })).toBe(false);
         });
     });
 });

--- a/src/store/options/__tests__/selectors-test.ts
+++ b/src/store/options/__tests__/selectors-test.ts
@@ -77,13 +77,13 @@ describe('store/options/selectors', () => {
 
     describe('isDocumentFtuxCursorDisabled', () => {
         test('should return the current document ftux cursor disabled state', () => {
-            expect(isDocumentFtuxCursorDisabled({ options: optionsState })).toBe(false);
+            expect(isDocumentFtuxCursorDisabled({ options: optionsState })).toBe(true);
         });
     });
 
     describe('isImageFtuxCursorDisabled', () => {
         test('should return the current image ftux cursor disabled state', () => {
-            expect(isImageFtuxCursorDisabled({ options: optionsState })).toBe(false);
+            expect(isImageFtuxCursorDisabled({ options: optionsState })).toBe(true);
         });
     });
 });

--- a/src/store/options/actions.ts
+++ b/src/store/options/actions.ts
@@ -1,8 +1,10 @@
 import { createAction } from '@reduxjs/toolkit';
 import { Permissions } from '../../@types';
 
+export const setDocumentFtuxCursorDisabledAction = createAction('SET_DOCUMENT_FTUX_CURSOR_DISABLED');
 export const setFileIdAction = createAction<string | null>('SET_FIlE_ID');
 export const setFileVersionIdAction = createAction<string | null>('SET_FILE_VERSION_ID');
+export const setImageFtuxCursorDisabledAction = createAction('SET_IMAGE_FTUX_CURSOR_DISABLED');
 export const setPermissionsAction = createAction<Permissions>('SET_PERMISSIONS');
 export const setRotationAction = createAction<number>('SET_ROTATION');
 export const setScaleAction = createAction<number>('SET_SCALE');

--- a/src/store/options/reducer.ts
+++ b/src/store/options/reducer.ts
@@ -1,8 +1,10 @@
 import { createReducer } from '@reduxjs/toolkit';
 import { OptionsState } from './types';
 import {
+    setDocumentFtuxCursorDisabledAction,
     setFileIdAction,
     setFileVersionIdAction,
+    setImageFtuxCursorDisabledAction,
     setPermissionsAction,
     setRotationAction,
     setScaleAction,
@@ -13,6 +15,8 @@ export const initialState = {
     fileId: null,
     fileVersionId: null,
     isCurrentFileVersion: true,
+    isDocumentFtuxCursorDisabled: false,
+    isImageFtuxCursorDisabled: false,
     permissions: {},
     rotation: 0,
     scale: 1,
@@ -20,11 +24,17 @@ export const initialState = {
 
 export default createReducer<OptionsState>(initialState, builder =>
     builder
+        .addCase(setDocumentFtuxCursorDisabledAction, state => {
+            state.isDocumentFtuxCursorDisabled = true;
+        })
         .addCase(setFileIdAction, (state, { payload }) => {
             state.fileId = payload;
         })
         .addCase(setFileVersionIdAction, (state, { payload }) => {
             state.fileVersionId = payload;
+        })
+        .addCase(setImageFtuxCursorDisabledAction, state => {
+            state.isImageFtuxCursorDisabled = true;
         })
         .addCase(setPermissionsAction, (state, { payload }) => {
             state.permissions = payload;

--- a/src/store/options/selectors.ts
+++ b/src/store/options/selectors.ts
@@ -12,5 +12,7 @@ export const getIsCurrentFileVersion = (state: State): boolean => state.options.
 export const getPermissions = (state: State): Permissions => state.options.permissions;
 export const getRotation = (state: State): number => state.options.rotation;
 export const getScale = (state: State): number => state.options.scale;
+export const isDocumentFtuxCursorDisabled = (state: State): boolean => state.options.isDocumentFtuxCursorDisabled;
 export const isFeatureEnabled = (state: State, featurename: string): boolean =>
     getProp(getFeatures(state), featurename, false);
+export const isImageFtuxCursorDisabled = (state: State): boolean => state.options.isImageFtuxCursorDisabled;

--- a/src/store/options/types.ts
+++ b/src/store/options/types.ts
@@ -6,6 +6,8 @@ export type OptionsState = {
     fileId: string | null;
     fileVersionId: string | null;
     isCurrentFileVersion: boolean;
+    isDocumentFtuxCursorDisabled: boolean;
+    isImageFtuxCursorDisabled: boolean;
     permissions: Permissions;
     rotation: number;
     scale: number;


### PR DESCRIPTION
Changes in this PR:
- [x] depending on whether the file is a 'document' or an 'image' as well as the state of the flag in localStorage, we will decide whether or not to show the PopupCursor