### PR TITLE
refactor(highlight): Refactor handleMouseDown

### DIFF
--- a/src/drawing/DrawingTarget.tsx
+++ b/src/drawing/DrawingTarget.tsx
@@ -34,20 +34,16 @@ export const DrawingTarget = (props: Props, ref: React.Ref<DrawingTargetRef>): J
         if (event.buttons !== MOUSE_PRIMARY) {
             return;
         }
-        const activeElement = document.activeElement as HTMLElement;
 
         event.preventDefault(); // Prevents focus from leaving the button immediately in some browsers
         event.nativeEvent.stopImmediatePropagation(); // Prevents document event handlers from executing
-
-        // IE11 won't apply the focus to the SVG anchor, so this workaround attempts to blur the existing
-        // active element.
-        if (activeElement && activeElement !== event.currentTarget && activeElement.blur) {
-            activeElement.blur();
+        if (event.currentTarget.focus) {
+            // Buttons do not receive focus in Firefox and Safari on MacOS; triggers handleFocus
+            event.currentTarget.focus();
+        } else {
+            // IE11 won't apply the focus to the SVG anchor and does not have focus function; call handleFocus directly
+            handleFocus();
         }
-
-        event.currentTarget.focus(); // Buttons do not receive focus in Firefox and Safari on MacOS; triggers handleFocus
-
-        onSelect(annotationId);
     };
 
     return (

--- a/src/drawing/__tests__/DrawingTarget-test.tsx
+++ b/src/drawing/__tests__/DrawingTarget-test.tsx
@@ -47,7 +47,8 @@ describe('DrawingTarget', () => {
         });
 
         describe('handleMouseDown()', () => {
-            const mockEvent = {
+            // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+            const getEvent = () => ({
                 buttons: 1,
                 currentTarget: {
                     focus: jest.fn(),
@@ -56,49 +57,48 @@ describe('DrawingTarget', () => {
                 nativeEvent: {
                     stopImmediatePropagation: jest.fn(),
                 },
-            };
+            });
 
             test('should do nothing if button is not MOUSE_PRIMARY', () => {
                 const wrapper = getWrapper();
                 const anchor = wrapper.find('a');
                 const event = {
-                    ...mockEvent,
+                    ...getEvent(),
                     buttons: 2,
                 };
 
                 anchor.simulate('mousedown', event);
 
-                expect(mockEvent.preventDefault).not.toHaveBeenCalled();
-                expect(mockEvent.nativeEvent.stopImmediatePropagation).not.toHaveBeenCalled();
+                expect(event.preventDefault).not.toHaveBeenCalled();
+                expect(event.nativeEvent.stopImmediatePropagation).not.toHaveBeenCalled();
             });
 
-            test('should call onSelect', () => {
-                const mockOnSelect = jest.fn();
-                const wrapper = getWrapper({ onSelect: mockOnSelect });
+            test('should call focus if focus is supported', () => {
+                const wrapper = getWrapper();
                 const anchor = wrapper.find('a');
+                const mockEvent = getEvent();
 
-                anchor.prop('onMouseDown')!((mockEvent as unknown) as React.MouseEvent);
+                anchor.simulate('mousedown', mockEvent);
 
-                expect(mockOnSelect).toHaveBeenCalledWith('123');
                 expect(mockEvent.preventDefault).toHaveBeenCalled();
                 expect(mockEvent.nativeEvent.stopImmediatePropagation).toHaveBeenCalled();
                 expect(mockEvent.currentTarget.focus).toHaveBeenCalled();
             });
 
-            test('should call blur on the document.activeElement', () => {
-                const blurSpy = jest.spyOn(document.body, 'blur');
-                const wrapper = getWrapper();
+            test('should call onSelect if focus is not supported', () => {
+                const onSelect = jest.fn();
+                const wrapper = getWrapper({ onSelect });
                 const anchor = wrapper.find('a');
                 const event = {
-                    ...mockEvent,
-                    buttons: 1,
+                    ...getEvent(),
+                    currentTarget: {},
                 };
-
-                expect(document.activeElement).toBe(document.body);
 
                 anchor.simulate('mousedown', event);
 
-                expect(blurSpy).toHaveBeenCalled();
+                expect(onSelect).toHaveBeenCalledWith('123');
+                expect(event.preventDefault).toHaveBeenCalled();
+                expect(event.nativeEvent.stopImmediatePropagation).toHaveBeenCalled();
             });
         });
     });

--- a/src/highlight/HighlightTarget.tsx
+++ b/src/highlight/HighlightTarget.tsx
@@ -8,7 +8,7 @@ import { MOUSE_PRIMARY } from '../constants';
 import { Rect } from '../@types/model';
 import './HighlightTarget.scss';
 
-type Props = {
+export type Props = {
     annotationId: string;
     className?: string;
     isActive?: boolean;
@@ -48,20 +48,16 @@ const HighlightTarget = (props: Props, ref: React.Ref<HighlightTargetRef>): JSX.
         if (event.buttons !== MOUSE_PRIMARY) {
             return;
         }
-        const activeElement = document.activeElement as HTMLElement;
 
-        onSelect(annotationId);
-
-        event.preventDefault(); // Prevents focus from leaving the anchor immediately in some browsers
+        event.preventDefault(); // Prevents focus from leaving the button immediately in some browsers
         event.nativeEvent.stopImmediatePropagation(); // Prevents document event handlers from executing
-
-        // IE11 won't apply the focus to the SVG anchor, so this workaround attempts to blur the existing
-        // active element.
-        if (activeElement && activeElement !== event.currentTarget && activeElement.blur) {
-            activeElement.blur();
+        if (event.currentTarget.focus) {
+            // Buttons do not receive focus in Firefox and Safari on MacOS; triggers handleFocus
+            event.currentTarget.focus();
+        } else {
+            // IE11 won't apply the focus to the SVG anchor and does not have focus function; call handleFocus directly
+            handleFocus();
         }
-
-        event.currentTarget.focus();
     };
 
     React.useEffect(() => {


### PR DESCRIPTION
I find that it's not `blur` that does `focus` on IE, it's `onSelect` instead. So I refactor the code a little bit to make the logic simple. It works on all browsers.