### PR TITLE
fix(highlight): getBoundingRect to handle negative y-axis

### DIFF
--- a/src/highlight/__tests__/highlightUtil-test.ts
+++ b/src/highlight/__tests__/highlightUtil-test.ts
@@ -22,6 +22,20 @@ const shape2: Shape = {
     y: 10,
 };
 
+const shape3: Shape = {
+    height: 1,
+    width: 1,
+    x: 1,
+    y: -2,
+};
+
+const shape4: Shape = {
+    height: 1,
+    width: 1,
+    x: 2,
+    y: -4,
+};
+
 describe('highlightUtil', () => {
     describe('getBoundingRect()', () => {
         test('should be the same rect for a single shape', () => {
@@ -34,6 +48,15 @@ describe('highlightUtil', () => {
                 width: 30,
                 x: 0,
                 y: 0,
+            });
+        });
+
+        test('should get the bounding rect for multiple shapes, even with negative y values', () => {
+            expect(getBoundingRect([shape3, shape4])).toEqual({
+                height: 3,
+                width: 2,
+                x: 1,
+                y: -4,
             });
         });
     });

--- a/src/highlight/__tests__/highlightUtil-test.ts
+++ b/src/highlight/__tests__/highlightUtil-test.ts
@@ -31,8 +31,8 @@ const shape3: Shape = {
 
 const shape4: Shape = {
     height: 1,
-    width: 1,
-    x: 2,
+    width: 3,
+    x: -2,
     y: -4,
 };
 
@@ -54,8 +54,8 @@ describe('highlightUtil', () => {
         test('should get the bounding rect for multiple shapes, even with negative y values', () => {
             expect(getBoundingRect([shape3, shape4])).toEqual({
                 height: 3,
-                width: 2,
-                x: 1,
+                width: 4,
+                x: -2,
                 y: -4,
             });
         });
@@ -154,6 +154,17 @@ describe('highlightUtil', () => {
                 width: 10,
                 x: 20,
                 y: 20,
+            });
+        });
+
+        test('should default to 0,0 if coordinates end up negative', () => {
+            const { containerRect } = selection;
+
+            expect(getShapeRelativeToContainer(shape4, containerRect)).toEqual({
+                height: 0.1,
+                width: 0.3,
+                x: 0,
+                y: 0,
             });
         });
     });

--- a/src/highlight/highlightUtil.ts
+++ b/src/highlight/highlightUtil.ts
@@ -133,10 +133,11 @@ export const getShapeRelativeToContainer = (shape: Shape, containerShape: Shape)
     const { height, width, x, y } = shape;
     const { height: containerHeight, width: containerWidth, x: containerX, y: containerY } = containerShape;
 
+    // If for some reason the x or y turns out to be negative in relation to the container, assume 0 instead
     return {
         height: (height / containerHeight) * 100,
         width: (width / containerWidth) * 100,
-        x: ((x - containerX) / containerWidth) * 100,
-        y: ((y - containerY) / containerHeight) * 100,
+        x: (Math.max(0, x - containerX) / containerWidth) * 100,
+        y: (Math.max(0, y - containerY) / containerHeight) * 100,
     };
 };

--- a/src/highlight/highlightUtil.ts
+++ b/src/highlight/highlightUtil.ts
@@ -3,8 +3,8 @@ import { Annotation, AnnotationHighlight, Position, Shape, Type } from '../@type
 export const getBoundingRect = (shapes: Shape[]): Shape => {
     let minX = Number.MAX_VALUE;
     let minY = Number.MAX_VALUE;
-    let maxX = Number.MIN_VALUE;
-    let maxY = Number.MIN_VALUE;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let maxY = Number.NEGATIVE_INFINITY;
 
     shapes.forEach(({ height, width, x, y }) => {
         const x2 = x + width;


### PR DESCRIPTION
`Number.MIN_VALUE` is actually the smallest positive number closest to zero. Combined with negative y-axis values for client rects (which happens when the text selection is involved with a vertical page scroll) resulted in incorrect logic when attempting to smoothen and combine the rects.

### **Before**
![highlight-select-before](https://user-images.githubusercontent.com/17791289/99351596-c9542c00-2855-11eb-8e22-2df62e8159ab.gif)

### **After**
![highlight-select-after](https://user-images.githubusercontent.com/17791289/99351606-ce18e000-2855-11eb-9028-10daf25d747b.gif)
