### PR TITLE
fix(drawing): hide drawing toolbar when user starts drawing

### DIFF
--- a/src/drawing/DrawingAnnotations.scss
+++ b/src/drawing/DrawingAnnotations.scss
@@ -33,7 +33,7 @@
     pointer-events: auto;
 
     &.ba-is-drawing {
-        opacity: .3;
+        opacity: 0;
         pointer-events: none;
     }
 }


### PR DESCRIPTION
**Changes in this PR:**
- [x] set opacity to be 0 when the user is actively drawing on the preview content
- [x] cross browser testing

**Demo:**
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/7213887/102287004-55598200-3eee-11eb-85bc-eff77e085cff.gif)


