### PR TITLE
fix(region): Memoize callback props passed to PointerCapture

### DIFF
--- a/src/drawing/DrawingCreator.tsx
+++ b/src/drawing/DrawingCreator.tsx
@@ -65,6 +65,7 @@ export default function DrawingCreator({ className, onStart, onStop, stroke = de
         capturedPointsRef.current = [{ x: x1, y: y1 }];
         drawingDirtyRef.current = true;
     };
+
     const stopDraw = React.useCallback((): void => {
         const adjustedPoints = getPoints();
 
@@ -84,6 +85,7 @@ export default function DrawingCreator({ className, onStart, onStop, stroke = de
             stroke,
         });
     }, [onStop, setDrawingStatus, stroke]);
+
     const updateDraw = React.useCallback(
         (x: number, y: number): void => {
             const [x2, y2] = getPosition(x, y);

--- a/src/drawing/DrawingCreator.tsx
+++ b/src/drawing/DrawingCreator.tsx
@@ -30,7 +30,7 @@ export default function DrawingCreator({ className, onStart, onStop, stroke = de
     const drawingSVGRef = React.useRef<DrawingSVGRef>(null);
     const renderHandleRef = React.useRef<number | null>(null);
 
-    const getPoints = React.useCallback((): Array<Position> => {
+    const getPoints = (): Array<Position> => {
         const { current: creatorEl } = creatorElRef;
         const { current: points } = capturedPointsRef;
 
@@ -43,34 +43,28 @@ export default function DrawingCreator({ className, onStart, onStop, stroke = de
             x: (x / width) * 100,
             y: (y / height) * 100,
         }));
-    }, [capturedPointsRef, creatorElRef]);
-    const getPosition = React.useCallback(
-        (x: number, y: number): [number, number] => {
-            const { current: creatorEl } = creatorElRef;
+    };
+    const getPosition = (x: number, y: number): [number, number] => {
+        const { current: creatorEl } = creatorElRef;
 
-            if (!creatorEl) {
-                return [x, y];
-            }
+        if (!creatorEl) {
+            return [x, y];
+        }
 
-            // Calculate the new position based on the mouse position less the page offset
-            const { left, top } = creatorEl.getBoundingClientRect();
-            return [x - left, y - top];
-        },
-        [creatorElRef],
-    );
+        // Calculate the new position based on the mouse position less the page offset
+        const { left, top } = creatorEl.getBoundingClientRect();
+        return [x - left, y - top];
+    };
 
     // Drawing Lifecycle Callbacks
-    const startDraw = React.useCallback(
-        (x: number, y: number): void => {
-            const [x1, y1] = getPosition(x, y);
+    const startDraw = (x: number, y: number): void => {
+        const [x1, y1] = getPosition(x, y);
 
-            setDrawingStatus(DrawingStatus.dragging);
+        setDrawingStatus(DrawingStatus.dragging);
 
-            capturedPointsRef.current = [{ x: x1, y: y1 }];
-            drawingDirtyRef.current = true;
-        },
-        [capturedPointsRef, drawingDirtyRef, getPosition, setDrawingStatus],
-    );
+        capturedPointsRef.current = [{ x: x1, y: y1 }];
+        drawingDirtyRef.current = true;
+    };
     const stopDraw = React.useCallback((): void => {
         const adjustedPoints = getPoints();
 
@@ -89,7 +83,7 @@ export default function DrawingCreator({ className, onStart, onStop, stroke = de
             paths: [{ points: adjustedPoints }],
             stroke,
         });
-    }, [capturedPointsRef, drawingDirtyRef, getPoints, onStop, setDrawingStatus, stroke]);
+    }, [onStop, setDrawingStatus, stroke]);
     const updateDraw = React.useCallback(
         (x: number, y: number): void => {
             const [x2, y2] = getPosition(x, y);
@@ -103,7 +97,7 @@ export default function DrawingCreator({ className, onStart, onStop, stroke = de
                 onStart();
             }
         },
-        [capturedPointsRef, drawingDirtyRef, drawingStatus, getPosition, onStart, setDrawingStatus],
+        [drawingStatus, onStart, setDrawingStatus],
     );
 
     // Event Handlers

--- a/src/region/RegionCreator.tsx
+++ b/src/region/RegionCreator.tsx
@@ -98,6 +98,7 @@ export default function RegionCreator({ className, onAbort, onStart, onStop }: P
         positionY2Ref.current = null;
         regionDirtyRef.current = true;
     };
+
     const stopDraw = React.useCallback((): void => {
         const shape = getShape();
 

--- a/src/region/RegionCreator.tsx
+++ b/src/region/RegionCreator.tsx
@@ -35,21 +35,18 @@ export default function RegionCreator({ className, onAbort, onStart, onStop }: P
     const renderHandleRef = React.useRef<number | null>(null);
 
     // Drawing Helpers
-    const getPosition = React.useCallback(
-        (x: number, y: number): [number, number] => {
-            const { current: creatorEl } = creatorElRef;
+    const getPosition = (x: number, y: number): [number, number] => {
+        const { current: creatorEl } = creatorElRef;
 
-            if (!creatorEl) {
-                return [x, y];
-            }
+        if (!creatorEl) {
+            return [x, y];
+        }
 
-            // Calculate the new position based on the mouse position less the page offset
-            const { left, top } = creatorEl.getBoundingClientRect();
-            return [x - left, y - top];
-        },
-        [creatorElRef],
-    );
-    const getShape = React.useCallback((): Rect | null => {
+        // Calculate the new position based on the mouse position less the page offset
+        const { left, top } = creatorEl.getBoundingClientRect();
+        return [x - left, y - top];
+    };
+    const getShape = (): Rect | null => {
         const { current: creatorEl } = creatorElRef;
         const { current: x1 } = positionX1Ref;
         const { current: y1 } = positionY1Ref;
@@ -87,23 +84,20 @@ export default function RegionCreator({ className, onAbort, onStart, onStop }: P
             x: (originX / width) * 100,
             y: (originY / height) * 100,
         };
-    }, [creatorElRef, positionX1Ref, positionY1Ref, positionX2Ref, positionY2Ref]);
+    };
 
     // Drawing Lifecycle Callbacks
-    const startDraw = React.useCallback(
-        (x: number, y: number): void => {
-            const [x1, y1] = getPosition(x, y);
+    const startDraw = (x: number, y: number): void => {
+        const [x1, y1] = getPosition(x, y);
 
-            setDrawingStatus(DrawingStatus.dragging);
+        setDrawingStatus(DrawingStatus.dragging);
 
-            positionX1Ref.current = x1;
-            positionY1Ref.current = y1;
-            positionX2Ref.current = null;
-            positionY2Ref.current = null;
-            regionDirtyRef.current = true;
-        },
-        [getPosition, setDrawingStatus],
-    );
+        positionX1Ref.current = x1;
+        positionY1Ref.current = y1;
+        positionX2Ref.current = null;
+        positionY2Ref.current = null;
+        regionDirtyRef.current = true;
+    };
     const stopDraw = React.useCallback((): void => {
         const shape = getShape();
 
@@ -120,17 +114,7 @@ export default function RegionCreator({ className, onAbort, onStart, onStop }: P
         } else {
             onAbort();
         }
-    }, [
-        getShape,
-        onAbort,
-        onStop,
-        positionX1Ref,
-        positionY1Ref,
-        positionX2Ref,
-        positionY2Ref,
-        regionDirtyRef,
-        setDrawingStatus,
-    ]);
+    }, [onAbort, onStop, setDrawingStatus]);
 
     const updateDraw = React.useCallback(
         (x: number, y: number): void => {
@@ -153,16 +137,16 @@ export default function RegionCreator({ className, onAbort, onStart, onStop }: P
                 onStart();
             }
         },
-        [drawingStatus, getPosition, onStart, positionX1Ref, positionY1Ref, positionX2Ref, setDrawingStatus],
+        [drawingStatus, onStart, setDrawingStatus],
     );
 
     // Event Handlers
-    const handleMouseOut = React.useCallback((): void => {
+    const handleMouseOut = (): void => {
         setIsHovering(false);
-    }, [setIsHovering]);
-    const handleMouseOver = React.useCallback((): void => {
+    };
+    const handleMouseOver = (): void => {
         setIsHovering(true);
-    }, [setIsHovering]);
+    };
     const handleScroll = (x: number, y: number): void => {
         updateDraw(x, y);
     };


### PR DESCRIPTION
There is a bug where if you create a region super quickly (you click the mouse and very quickly move and release the mouse) the `PopupReply` doesn't appear. This is because the `PointerCapture` `onDrawStop` callback is never called. 

On closer inspection, it is discovered that on every mouse move `PointerCapture` is re-rendering and as a result re-adding the listeners to the document to capture `mousemove` and `mouseup` events because `RegionCreator` is re-rendering due to state being updated.

The fix here is to use `React.useCallback` on all callback props being passed to `PointerCapture` to memoize the callback props so that `PointerCapture` doesn't need to re-render unless `drawingStatus` changes