### PR TITLE
fix(drawing): apply blur to smaller drawn annotations

### DIFF
--- a/src/drawing/DrawingSVG.tsx
+++ b/src/drawing/DrawingSVG.tsx
@@ -20,9 +20,6 @@ export function DrawingSVG({ className, children, ...rest }: Props, ref: React.R
             <defs>
                 <filter id="ba-DrawingSVG-shadow">
                     <feGaussianBlur in="SourceGraphic" stdDeviation="1" />
-                    <feComponentTransfer>
-                        <feFuncA slope="1" type="linear" />
-                    </feComponentTransfer>
                 </filter>
             </defs>
             {children}

--- a/src/drawing/DrawingSVG.tsx
+++ b/src/drawing/DrawingSVG.tsx
@@ -18,10 +18,10 @@ export function DrawingSVG({ className, children, ...rest }: Props, ref: React.R
             {...rest}
         >
             <defs>
-                <filter id="ba-DrawingSVG-shadow" primitiveUnits="objectBoundingBox">
-                    <feGaussianBlur in="SourceGraphic" stdDeviation="0.02" />
+                <filter id="ba-DrawingSVG-shadow">
+                    <feGaussianBlur in="SourceGraphic" stdDeviation="1" />
                     <feComponentTransfer>
-                        <feFuncA slope="0.8" type="linear" />
+                        <feFuncA slope="1" type="linear" />
                     </feComponentTransfer>
                 </filter>
             </defs>


### PR DESCRIPTION
**Main Issue:**
We were seeing a bug where because we were using `primitiveUnits="objectBoundingBox"`, this was causing the annotated elements that were smaller to not have a prominent blur applied. Removing the primitiveUnits attribute + making the opacity darker helped solve this issue.

**Demo:**
**Chrome**
<img width="574" alt="Screen Shot 2021-01-12 at 4 22 47 PM" src="https://user-images.githubusercontent.com/7213887/104390632-ff7af880-54f2-11eb-8a4d-200ef100703d.png">

**Safari**
<img width="646" alt="safari" src="https://user-images.githubusercontent.com/7213887/104392559-2e936900-54f7-11eb-9da9-4995d1a9f7ea.png">

**Firefox**
<img width="433" alt="firefox" src="https://user-images.githubusercontent.com/7213887/104392573-35ba7700-54f7-11eb-8088-ab69d0d0d1a0.png">

**Edge**
<img width="397" alt="edge" src="https://user-images.githubusercontent.com/7213887/104392582-394dfe00-54f7-11eb-8db3-21e135a61b64.png">

**IE11**
<img width="271" alt="ie11" src="https://user-images.githubusercontent.com/7213887/104392621-4f5bbe80-54f7-11eb-82ad-ae71a9b2e74c.png">
