### PR TITLE
fix(drawing): fix drawing annotation blur clipping on bounding box

### DIFF
--- a/src/drawing/DrawingSVG.tsx
+++ b/src/drawing/DrawingSVG.tsx
@@ -18,7 +18,7 @@ export function DrawingSVG({ className, children, ...rest }: Props, ref: React.R
             {...rest}
         >
             <defs>
-                <filter id="ba-DrawingSVG-shadow">
+                <filter height="300%" id="ba-DrawingSVG-shadow" width="300%" x="-100%" y="-100%">
                     <feGaussianBlur in="SourceGraphic" stdDeviation="1" />
                 </filter>
             </defs>

--- a/src/drawing/DrawingSVG.tsx
+++ b/src/drawing/DrawingSVG.tsx
@@ -18,7 +18,7 @@ export function DrawingSVG({ className, children, ...rest }: Props, ref: React.R
             {...rest}
         >
             <defs>
-                <filter height="300%" id="ba-DrawingSVG-shadow" width="300%" x="-100%" y="-100%">
+                <filter filterUnits="userSpaceOnUse" height="100vh" id="ba-DrawingSVG-shadow" width="100vw">
                     <feGaussianBlur in="SourceGraphic" stdDeviation="1" />
                 </filter>
             </defs>


### PR DESCRIPTION
**Changes in this PR:**
- [x] adjust filter attributes to fix the issue where the blur was getting clipped by the bounding box

**Demo:**
Chrome
<img width="933" alt="chrome" src="https://user-images.githubusercontent.com/7213887/104504570-808bcb80-5597-11eb-9c5c-2867cc148ad0.png">

Safari
<img width="464" alt="safari" src="https://user-images.githubusercontent.com/7213887/104504581-841f5280-5597-11eb-8815-5cf1bb370de5.png">

Firefox
<img width="786" alt="firefox" src="https://user-images.githubusercontent.com/7213887/104504625-9600f580-5597-11eb-99a7-f5dab9c2c176.png">

Edge
<img width="344" alt="edge" src="https://user-images.githubusercontent.com/7213887/104504599-8bdef700-5597-11eb-848f-c4a2172cc017.png">

IE
<img width="355" alt="ie11" src="https://user-images.githubusercontent.com/7213887/104504611-900b1480-5597-11eb-9991-5340b2fc531e.png">