### PR TITLE
fix(drawing): fix blur not showing in safari

### DIFF
--- a/src/drawing/DrawingSVG.tsx
+++ b/src/drawing/DrawingSVG.tsx
@@ -18,7 +18,7 @@ export function DrawingSVG({ className, children, ...rest }: Props, ref: React.R
             {...rest}
         >
             <defs>
-                <filter filterUnits="userSpaceOnUse" height="300px" id="ba-DrawingSVG-shadow" width="300px">
+                <filter filterUnits="userSpaceOnUse" id="ba-DrawingSVG-shadow">
                     <feGaussianBlur in="SourceGraphic" stdDeviation="1" />
                 </filter>
             </defs>

--- a/src/drawing/DrawingSVG.tsx
+++ b/src/drawing/DrawingSVG.tsx
@@ -18,7 +18,7 @@ export function DrawingSVG({ className, children, ...rest }: Props, ref: React.R
             {...rest}
         >
             <defs>
-                <filter filterUnits="userSpaceOnUse" height="100vh" id="ba-DrawingSVG-shadow" width="100vw">
+                <filter filterUnits="userSpaceOnUse" height="300px" id="ba-DrawingSVG-shadow" width="300px">
                     <feGaussianBlur in="SourceGraphic" stdDeviation="1" />
                 </filter>
             </defs>


### PR DESCRIPTION
**Changes in this PR:**
- [x] Safari doesn't support `vh` and `vw` in the <filter> element so I'm opting to use specific pixel attributes
- [x] Cross browser testing

**Demo:**
Chrome
<img width="416" alt="Screen Shot 2021-01-14 at 10 34 54 AM" src="https://user-images.githubusercontent.com/7213887/104633572-30bf0a00-5654-11eb-8edb-8dcf083a4f8f.png">

Safari
<img width="441" alt="Screen Shot 2021-01-14 at 10 35 16 AM" src="https://user-images.githubusercontent.com/7213887/104633591-39afdb80-5654-11eb-8a59-033627bf7437.png">

Firefox
<img width="462" alt="Screen Shot 2021-01-14 at 10 35 32 AM" src="https://user-images.githubusercontent.com/7213887/104633627-446a7080-5654-11eb-95c1-292e37fae6fe.png">

Edge
<img width="347" alt="Screen Shot 2021-01-14 at 10 37 27 AM" src="https://user-images.githubusercontent.com/7213887/104633805-8dbac000-5654-11eb-8e53-597548baaf8b.png">


IE
<img width="406" alt="Screen Shot 2021-01-14 at 10 39 19 AM" src="https://user-images.githubusercontent.com/7213887/104634014-e38f6800-5654-11eb-945f-a8df3cfd59a3.png">


