### PR TITLE
fix(drawing): fix Add Comment text wrapping in Safari

### DIFF
--- a/src/components/Popups/PopupDrawingToolbar.scss
+++ b/src/components/Popups/PopupDrawingToolbar.scss
@@ -66,7 +66,7 @@
 }
 
 .ba-PopupDrawingToolbar-comment {
-    @include ba-PopupDrawingToolbarButton($width: auto);
+    @include ba-PopupDrawingToolbarButton($width: max-content);
     @include common-typography;
 
     padding-right: 18px;


### PR DESCRIPTION
**Main Issue:**
<img width="596" alt="Screen Shot 2021-01-19 at 2 44 18 PM" src="https://user-images.githubusercontent.com/7213887/105105596-38721a80-5a69-11eb-950b-975f71eb6112.png">

- [x]  In Safari, the Add Comment text was being incorrectly wrapped due to the `width: auto` attribute on the button style. The fix is to use `max-content` instead.
- [x] Cross browser testing

**IE**
<img width="484" alt="ie" src="https://user-images.githubusercontent.com/7213887/105105431-ef21cb00-5a68-11eb-9a47-9c036c0fa4ac.png">

**Edge**
<img width="623" alt="edge" src="https://user-images.githubusercontent.com/7213887/105105434-f0eb8e80-5a68-11eb-9d62-83298259f23d.png">

**Firefox**
<img width="695" alt="firefox" src="https://user-images.githubusercontent.com/7213887/105105439-f1842500-5a68-11eb-9706-d60465b3f4a8.png">

**Chrome**
<img width="541" alt="chrome" src="https://user-images.githubusercontent.com/7213887/105105441-f21cbb80-5a68-11eb-9354-cb4278d86c51.png">

**Safari**
<img width="761" alt="safari" src="https://user-images.githubusercontent.com/7213887/105105442-f2b55200-5a68-11eb-881b-74205b5f2c14.png">
