### PR TITLE
fix(drawing): fix blur not visible for drawn annotation in Safari

### DIFF
--- a/src/drawing/__tests__/DrawingList-test.tsx
+++ b/src/drawing/__tests__/DrawingList-test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { shallow, ShallowWrapper } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 import DrawingTarget from '../DrawingTarget';
 import DrawingList, { Props } from '../DrawingList';
+import DrawingSVG from '../DrawingSVG';
 import useIsListInteractive from '../../common/useIsListInteractive';
 import { AnnotationDrawing } from '../../@types';
 import { annotations } from '../__mocks__/drawingData';
@@ -12,7 +13,7 @@ describe('DrawingList', () => {
     const getDefaults = (): Props => ({
         annotations: annotations as AnnotationDrawing[],
     });
-    const getWrapper = (props = {}): ShallowWrapper => shallow(<DrawingList {...getDefaults()} {...props} />);
+    const getWrapper = (props = {}): ReactWrapper => mount(<DrawingList {...getDefaults()} {...props} />);
 
     beforeEach(() => {
         jest.spyOn(React, 'useState').mockImplementation(() => [null, jest.fn()]);
@@ -24,7 +25,12 @@ describe('DrawingList', () => {
 
             const wrapper = getWrapper();
 
-            expect(wrapper.hasClass('is-listening')).toBe(isListening);
+            expect(
+                wrapper
+                    .find(DrawingSVG)
+                    .prop('className')
+                    .includes('is-listening'),
+            ).toBe(isListening);
         });
 
         test('should filter all invalid annotations', () => {
@@ -56,6 +62,33 @@ describe('DrawingList', () => {
             // annotations[1] has a larger area, so renders first
             expect(children.get(0).props.target).toBe(annotations[1].target);
             expect(children.get(1).props.target).toBe(annotations[0].target);
+        });
+    });
+
+    describe('useEffect', () => {
+        const rootEl = { style: { display: 'block ' } };
+        const userAgentStr =
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.2';
+
+        beforeEach(() => {
+            jest.useFakeTimers();
+            jest.spyOn(React, 'useState').mockImplementation(() => [rootEl, jest.fn()]);
+        });
+
+        test.each`
+            browser     | userAgent                            | expected   | should
+            ${'Safari'} | ${`${userAgentStr} Safari/605.1.15`} | ${'none'}  | ${'should set display to none'}
+            ${'Chrome'} | ${userAgentStr}                      | ${'block'} | ${'should not set display to none'}
+        `('$should when rootEl and activeId are defined and browser is $browser', ({ expected, userAgent }) => {
+            global.window.navigator.userAgent = userAgent;
+
+            getWrapper({ activeId: 'drawing_anno_1' });
+
+            expect(rootEl.style.display).toBe(expected);
+
+            jest.runAllTimers();
+
+            expect(rootEl.style.display).toBe('block');
         });
     });
 });

--- a/src/drawing/__tests__/DrawingList-test.tsx
+++ b/src/drawing/__tests__/DrawingList-test.tsx
@@ -20,17 +20,15 @@ describe('DrawingList', () => {
     });
 
     describe('render', () => {
-        test.each([true, false])('should render the class based on isListening %s', isListening => {
+        test.each([
+            { className: 'is-listening', isListening: true },
+            { className: '', isListening: false },
+        ])('should render the class based on isListening $isListening', ({ className, isListening }) => {
             (useIsListInteractive as jest.Mock).mockReturnValue(isListening);
 
             const wrapper = getWrapper();
 
-            expect(
-                wrapper
-                    .find(DrawingSVG)
-                    .prop('className')
-                    .includes('is-listening'),
-            ).toBe(isListening);
+            expect(wrapper.find(DrawingSVG).prop('className')).toBe(className);
         });
 
         test('should filter all invalid annotations', () => {

--- a/src/drawing/__tests__/DrawingList-test.tsx
+++ b/src/drawing/__tests__/DrawingList-test.tsx
@@ -66,7 +66,7 @@ describe('DrawingList', () => {
     describe('useEffect', () => {
         const rootEl = { style: { display: 'block ' } };
         const userAgentStr =
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.2';
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.2 Safari/605.1.15';
 
         beforeEach(() => {
             jest.useFakeTimers();
@@ -75,8 +75,8 @@ describe('DrawingList', () => {
 
         test.each`
             browser     | userAgent                            | expected   | should
-            ${'Safari'} | ${`${userAgentStr} Safari/605.1.15`} | ${'none'}  | ${'should set display to none'}
-            ${'Chrome'} | ${userAgentStr}                      | ${'block'} | ${'should not set display to none'}
+            ${'Safari'} | ${`${userAgentStr}`}                 | ${'none'}  | ${'should set display to none'}
+            ${'Chrome'} | ${`${userAgentStr} Chrome/123.1.10`} | ${'block'} | ${'should not set display to none'}
         `('$should when rootEl and activeId are defined and browser is $browser', ({ expected, userAgent }) => {
             global.window.navigator.userAgent = userAgent;
 


### PR DESCRIPTION
**Main Issue:**
Currently, Safari browser does not perform a repaint for the SVG element whenever the user adds a new annotation. This results in no blur showing when the user hovers over a newly drawn annotation.
- [x] cross browser testing
- [x] add unit tests

**Demo:**
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/7213887/105257664-1b0e8080-5b3d-11eb-94ff-d79675b84180.gif)


