### PR TITLE
fix(region): text alignment for at mentions in annotation popup in IE

### DIFF
--- a/src/components/ItemList/ItemList.scss
+++ b/src/components/ItemList/ItemList.scss
@@ -4,6 +4,7 @@
         margin: 0;
         padding: 0;
         overflow-y: auto;
+        text-align: left;
         list-style: none;
     }
 }


### PR DESCRIPTION
**Main Issue:**
In IE, there was an text alignment issue with at-mentions. Text should be left-aligned rather than centered.

**Demo:**
<img width="1126" alt="Screen Shot 2021-01-28 at 1 48 49 PM" src="https://user-images.githubusercontent.com/7213887/106204148-5c241780-6171-11eb-8b03-640f9a7baf55.png">

