### PR TITLE
fix(popupreply): Add back flip to keep within viewport

### DIFF
--- a/src/components/Popups/PopupReply.tsx
+++ b/src/components/Popups/PopupReply.tsx
@@ -54,7 +54,7 @@ export const options: Partial<Popper.Options> = {
     ],
 };
 
-const getModifiers = (): Partial<Popper.Options> => {
+const getOptions = (): Partial<Popper.Options> => {
     const { modifiers: defaultModifiers = [] } = options;
     const placement = isIE() ? 'top' : 'bottom';
     const modifiers = isIE()
@@ -84,7 +84,7 @@ export default function PopupReply({
     ...rest
 }: Props): JSX.Element {
     const popupRef = React.useRef<PopupBase>(null);
-    const popupOptions = React.useRef<Partial<Popper.Options>>(getModifiers()); // Keep the options reference the same between renders
+    const popupOptions = React.useRef<Partial<Popper.Options>>(getOptions()); // Keep the options reference the same between renders
     const rotation = ReactRedux.useSelector(getRotation);
     const prevRotation = usePrevious(rotation);
     const scale = ReactRedux.useSelector(getScale);

--- a/src/components/Popups/PopupReply.tsx
+++ b/src/components/Popups/PopupReply.tsx
@@ -23,7 +23,7 @@ const isIE = (): boolean => {
     return userAgent.indexOf('Trident/') > 0;
 };
 
-export const options: Partial<Popper.Options> = {
+export const options: Pick<Popper.Options, 'modifiers'> = {
     modifiers: [
         {
             name: 'arrow',
@@ -55,7 +55,7 @@ export const options: Partial<Popper.Options> = {
 };
 
 const getOptions = (): Partial<Popper.Options> => {
-    const { modifiers: defaultModifiers = [] } = options;
+    const { modifiers: defaultModifiers } = options;
     const placement = isIE() ? 'top' : 'bottom';
     const modifiers = isIE()
         ? [

--- a/src/components/Popups/__tests__/PopupReply-test.tsx
+++ b/src/components/Popups/__tests__/PopupReply-test.tsx
@@ -69,10 +69,17 @@ describe('PopupReply', () => {
     });
 
     describe('Popup options', () => {
+        const eventListenersModifier = {
+            name: 'eventListeners',
+            options: { scroll: false },
+        };
+        const IEUserAgent = 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko';
+        const otherUserAgent = 'Other';
+
         test.each`
-            userAgent                                                                  | expectedPlacement
-            ${'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko'} | ${'top'}
-            ${'Other'}                                                                 | ${'bottom'}
+            userAgent         | expectedPlacement
+            ${IEUserAgent}    | ${'top'}
+            ${otherUserAgent} | ${'bottom'}
         `(
             'should set placement option as $expectedPlacement based on userAgent=$userAgent',
             ({ userAgent, expectedPlacement }) => {
@@ -84,5 +91,23 @@ describe('PopupReply', () => {
                 expect(wrapper.find(PopupBase).prop('options').placement).toBe(expectedPlacement);
             },
         );
+
+        test('should disable scroll event listeners if browser is IE', () => {
+            global.window.navigator.userAgent = IEUserAgent;
+
+            const wrapper = getWrapper();
+
+            expect(window.navigator.userAgent).toEqual(IEUserAgent);
+            expect(wrapper.find(PopupBase).prop('options').modifiers).toContainEqual(eventListenersModifier);
+        });
+
+        test('should not disable scroll event listeners for non IE browsers', () => {
+            global.window.navigator.userAgent = otherUserAgent;
+
+            const wrapper = getWrapper();
+
+            expect(window.navigator.userAgent).toEqual(otherUserAgent);
+            expect(wrapper.find(PopupBase).prop('options').modifiers).not.toContainEqual(eventListenersModifier);
+        });
     });
 });


### PR DESCRIPTION
A previous commit removed the functionality of the `PopupReply` automatically flipping if it would extend outside the viewport. This adds that functionality back, with the exception made for IE11 because of the issue where it gets covered by the next page of a document due to z-index issues.