### PR TITLE
fix(highlight): Fix text highlighting for PDFjs upgrade

### DIFF
--- a/src/document/docUtil.ts
+++ b/src/document/docUtil.ts
@@ -39,6 +39,10 @@ export function getSelection(): Selection | null {
     // We only care about the last range
     let range = selection.getRangeAt(selection.rangeCount - 1);
 
+    // Changes to the text layer in PDFjs v2.14.305 require the start range to be set manually for correct highlighting behavior
+    const startRange = selection.getRangeAt(0);
+    range.setStart(startRange.startContainer, startRange.startOffset);
+
     const containerEl = findClosestElWithClass(range.endContainer as Element, 'textLayer');
     const startPage = getPageNumber(range.startContainer as Element);
     const endPage = getPageNumber(range.endContainer as Element);


### PR DESCRIPTION
Fixing incorrect text selection/highlighting behavior specifically on Firefox. Tested other browsers as well just to be sure!

<img width="368" alt="Screen Shot 2022-09-22 at 4 16 02 PM" src="https://user-images.githubusercontent.com/95440409/191867447-9c7c072a-edd0-426d-a37a-5829f4b74986.png">

**Before (Firefox):**
<img width="1247" alt="Screen Shot 2022-09-22 at 4 34 51 PM" src="https://user-images.githubusercontent.com/95440409/191869154-7e5c53a5-7783-486e-b18f-96536306666c.png">

**After (Firefox):**
<img width="1246" alt="Screen Shot 2022-09-22 at 3 47 12 PM" src="https://user-images.githubusercontent.com/95440409/191867479-2b9fce0b-11c8-42ad-9f81-13aca9b7f6b5.png">
