### PR TITLE
fix(missing-annotations): Fix annotations on zoom issue

### DIFF
--- a/src/document/DocumentAnnotator.ts
+++ b/src/document/DocumentAnnotator.ts
@@ -60,14 +60,21 @@ export default class DocumentAnnotator extends BaseAnnotator {
         const pageReferenceEl = this.getPageReference(pageEl);
         const managers = this.managers.get(pageNumber) || new Set();
         const resinTags = { fileid: fileId, iscurrent: isCurrentFileVersion };
+        let destroyManagers = false;
 
-        // Destroy any managers that were attached to page elements that no longer exist
+        // If a referenced page element doesn't exist, destroy all managers to keep them in sync
         managers.forEach(manager => {
             if (!manager.exists(pageEl)) {
+                destroyManagers = true;
+            }
+            if (destroyManagers) {
                 manager.destroy();
-                managers.delete(manager);
             }
         });
+        if (destroyManagers) {
+            managers.clear();
+            destroyManagers = false;
+        }
 
         // Lazily instantiate managers as pages are added or re-rendered
         if (managers.size === 0) {

--- a/src/document/DocumentAnnotator.ts
+++ b/src/document/DocumentAnnotator.ts
@@ -73,7 +73,6 @@ export default class DocumentAnnotator extends BaseAnnotator {
                 manager.destroy();
             });
             managers.clear();
-            destroyManagers = false;
         }
 
         // Lazily instantiate managers as pages are added or re-rendered

--- a/src/document/DocumentAnnotator.ts
+++ b/src/document/DocumentAnnotator.ts
@@ -67,11 +67,11 @@ export default class DocumentAnnotator extends BaseAnnotator {
             if (!manager.exists(pageEl)) {
                 destroyManagers = true;
             }
-            if (destroyManagers) {
-                manager.destroy();
-            }
         });
         if (destroyManagers) {
+            managers.forEach(manager => {
+                manager.destroy();
+            });
             managers.clear();
             destroyManagers = false;
         }


### PR DESCRIPTION
Due to changes in PDFjs v3.6.172, annotations would dissapear upon zooming in/out on the pdf. This is because the page elements that our annotation managers were referencing would be removed when zooming in/out. The textLayer pdfJS uses would not be removed however, which would make one of our managers not get cleaned up. In order to reinstantiate our managers, we need all managers to be cleaned up. Because of our current logic for adding managers, we need to make sure every manager is cleaned up when at least one manager is cleaned up. Which makes sense since the annotation managers are coupled together and cannot function correctly without the others.

Annotation Drawing mode
![2023-07-19 23 46 18](https://github.com/box/box-annotations/assets/11734293/9a11ca13-565a-47ef-8b70-26d7a13fc097)

Annotation Highlight mode
![2023-07-19 23 52 06](https://github.com/box/box-annotations/assets/11734293/d0c227c7-f145-4620-a66f-835712a4b48d)


