### PR TITLE
chore(fonts): update Lato fonts to point to 1.0.17

### DIFF
--- a/src/common/BaseAnnotator.scss
+++ b/src/common/BaseAnnotator.scss
@@ -1,17 +1,4 @@
-@font-face {
-    font-weight: normal;
-    font-family: 'Lato';
-    font-style: normal;
-    src: local('Lato Regular'), local('Lato-Regular'), url('https://cdn01.boxcdn.net/fonts/1.0.2/lato/Lato-Regular.woff2') format('woff2'), url('https://cdn01.boxcdn.net/fonts/1.0.2/lato/Lato-Regular.woff') format('woff');
-}
-
-@font-face {
-    font-weight: bold;
-    font-family: 'Lato';
-    font-style: normal;
-    src: local('Lato Bold'), local('Lato-Bold'), url('https://cdn01.boxcdn.net/fonts/1.0.2/lato/Lato-Bold.woff2') format('woff2'), url('https://cdn01.boxcdn.net/fonts/1.0.2/lato/Lato-Bold.woff') format('woff');
-}
-
+@import '~box-ui-elements/es/elements/common/fonts';
 @import '~box-ui-elements/es/styles/variables';
 
 .ba {


### PR DESCRIPTION
BUIE PR: https://github.com/box/box-ui-elements/pull/3499

The fonts files itself haven't changed.

Changing it to have parity with internal Box changes. This will cause the 1.0.2 fonts to not be downloaded, in favor of existing 1.0.17.