### PR TITLE
fix(e2etest): Increase timeout to 30 minutes for e2e

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
           script: yarn test
         - name: 'E2E Tests'
           if: fork = false # Note: We can only run E2E tests on canonical due to security concerns
-          script: yarn test:e2e
+          script: travis_wait 30 yarn test:e2e
 notifications:
     email:
         recipients:


### PR DESCRIPTION
e2e tests have been failing due to a timeout with 10 minutes without content written to the console ([docs](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received)). This PR increases the timeout to 30 minutes to give more time for tests to finish running.