### PR TITLE
fix(popup): Portal thread popup to body so it stays upright on rotate

### DIFF
--- a/src/common/BaseAnnotator.scss
+++ b/src/common/BaseAnnotator.scss
@@ -7,7 +7,8 @@
     @import '~box-ui-elements/es/styles/common/buttons';
 
     &.is-hidden {
-        .ba-Layer {
+        .ba-Layer,
+        .ba-PopupPortal {
             display: none;
         }
     }

--- a/src/common/BaseAnnotator.ts
+++ b/src/common/BaseAnnotator.ts
@@ -49,6 +49,7 @@ export type Options = {
 
 export const CSS_CONTAINER_CLASS = 'ba';
 export const CSS_LOADED_CLASS = 'ba-annotations-loaded';
+export const CSS_POPUP_PORTAL_CLASS = 'ba-PopupPortal';
 export const ANNOTATION_CLASSES: { [M in store.Mode]?: string } = {
     [store.Mode.HIGHLIGHT]: 'ba-is-create--highlight',
     [store.Mode.REGION]: 'ba-is-create--region',
@@ -58,6 +59,8 @@ export default class BaseAnnotator extends EventEmitter {
     annotatedEl?: HTMLElement | null;
 
     containerEl?: HTMLElement | null;
+
+    popupPortalEl?: HTMLElement | null;
 
     container: Container;
 
@@ -132,6 +135,11 @@ export default class BaseAnnotator extends EventEmitter {
             this.containerEl.classList.remove(CSS_CONTAINER_CLASS);
         }
 
+        if (this.popupPortalEl) {
+            this.popupPortalEl.remove();
+            this.popupPortalEl = null;
+        }
+
         if (this.annotatedEl) {
             this.annotatedEl.classList.remove(CSS_LOADED_CLASS);
         }
@@ -165,6 +173,12 @@ export default class BaseAnnotator extends EventEmitter {
         // Add classes to the parent elements to support CSS scoping
         this.annotatedEl.classList.add(CSS_LOADED_CLASS);
         this.containerEl.classList.add(CSS_CONTAINER_CLASS);
+
+        if (!this.popupPortalEl) {
+            this.popupPortalEl = this.containerEl.ownerDocument.createElement('div');
+            this.popupPortalEl.classList.add(CSS_POPUP_PORTAL_CLASS);
+            this.containerEl.appendChild(this.popupPortalEl);
+        }
 
         // Defer to the child class to render annotations
         this.render();

--- a/src/common/DeselectListener.tsx
+++ b/src/common/DeselectListener.tsx
@@ -6,7 +6,9 @@ export default function DeselectListener(): null {
     const dispatch = useDispatch();
 
     React.useEffect(() => {
-        const handleMouseDown = (): void => {
+        const handleMouseDown = (event: MouseEvent): void => {
+            // Popup is portaled to body, so its clicks reach this listener.
+            if ((event.target as Element | null)?.closest?.('.ba-PopupV2')) return;
             dispatch(setActiveAnnotationIdAction(null));
         };
 

--- a/src/common/DeselectListener.tsx
+++ b/src/common/DeselectListener.tsx
@@ -7,7 +7,7 @@ export default function DeselectListener(): null {
 
     React.useEffect(() => {
         const handleMouseDown = (event: MouseEvent): void => {
-            // Popup is portaled to body, so its clicks reach this listener.
+            // Popup is portaled outside .ba-Layer; native mousedown still bubbles here.
             if ((event.target as Element | null)?.closest?.('.ba-PopupV2')) return;
             dispatch(setActiveAnnotationIdAction(null));
         };

--- a/src/common/__tests__/DeselectListener-test.tsx
+++ b/src/common/__tests__/DeselectListener-test.tsx
@@ -25,4 +25,20 @@ describe('DeselectListener', () => {
         expect(document.addEventListener).toHaveBeenCalledWith('mousedown', expect.any(Function));
         expect(setActiveAnnotationIdAction).toHaveBeenCalledWith(null);
     });
+
+    test('should not deselect when mousedown originates inside a portaled popup', () => {
+        getWrapper();
+
+        const popup = document.createElement('div');
+        popup.className = 'ba-PopupV2';
+        const inner = document.createElement('button');
+        popup.appendChild(inner);
+        document.body.appendChild(popup);
+
+        inner.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+        expect(setActiveAnnotationIdAction).not.toHaveBeenCalled();
+
+        document.body.removeChild(popup);
+    });
 });

--- a/src/components/Popups/PopupV2.scss
+++ b/src/components/Popups/PopupV2.scss
@@ -1,6 +1,14 @@
 .ba-PopupV2 {
-    z-index: 1;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 150;
     width: 348px;
+}
+
+// Popup is portaled to body, so mirror the annotator's .is-hidden state here.
+body:has(.ba.is-hidden) .ba-PopupV2 {
+    display: none;
 }
 
 // Specificity must beat .ba selectors from box-ui-elements globals

--- a/src/components/Popups/PopupV2.scss
+++ b/src/components/Popups/PopupV2.scss
@@ -11,9 +11,9 @@ body:has(.ba.is-hidden) .ba-PopupV2 {
     display: none;
 }
 
-// Specificity must beat .ba selectors from box-ui-elements globals
-// (forms, buttons, links) that cascade into threaded-annotations components.
-.ba .ba-PopupV2 {
+// Specificity must beat box-ui-elements globals (forms, buttons, links) that
+// cascade into threaded-annotations components.
+.ba-PopupV2.ba-PopupV2 {
     div[contenteditable='true'],
     div[contenteditable='true']:hover,
     div[contenteditable='true']:focus {

--- a/src/components/Popups/PopupV2.scss
+++ b/src/components/Popups/PopupV2.scss
@@ -6,14 +6,9 @@
     width: 348px;
 }
 
-// Popup is portaled to body, so mirror the annotator's .is-hidden state here.
-body:has(.ba.is-hidden) .ba-PopupV2 {
-    display: none;
-}
-
-// Specificity must beat box-ui-elements globals (forms, buttons, links) that
-// cascade into threaded-annotations components.
-.ba-PopupV2.ba-PopupV2 {
+// Specificity must beat .ba selectors from box-ui-elements globals
+// (forms, buttons, links) that cascade into threaded-annotations components.
+.ba .ba-PopupV2 {
     div[contenteditable='true'],
     div[contenteditable='true']:hover,
     div[contenteditable='true']:focus {

--- a/src/components/Popups/PopupV2.tsx
+++ b/src/components/Popups/PopupV2.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
 import noop from 'lodash/noop';
-import { useDispatch, useSelector } from 'react-redux';
+import React from 'react';
+import ReactDOM from 'react-dom';
 import { useIntl } from 'react-intl';
+import { useDispatch, useSelector } from 'react-redux';
+
 import { BlueprintModernizationProvider } from '@box/blueprint-web';
 import {
     MentionContextProvider,
@@ -74,7 +76,7 @@ const fetchAvatarBlob = async (apiHost: string, token: string, userId: string): 
     }
 };
 
-const PopupV2 = ({ annotationId, onSubmit, reference }: Props): JSX.Element => {
+const PopupV2 = ({ annotationId, onSubmit, reference }: Props): JSX.Element | null => {
     const intl = useIntl();
     const dispatch = useDispatch<AppThunkDispatch>();
     const popupRef = React.useRef<HTMLDivElement>(null);
@@ -260,7 +262,9 @@ const PopupV2 = ({ annotationId, onSubmit, reference }: Props): JSX.Element => {
         [annotationId, dispatch],
     );
 
-    return (
+    if (typeof document === 'undefined') return null;
+
+    return ReactDOM.createPortal(
         <FocusTrap>
             <div
                 ref={popupRef}
@@ -307,7 +311,8 @@ const PopupV2 = ({ annotationId, onSubmit, reference }: Props): JSX.Element => {
                 </BlueprintModernizationProvider>
                 <div data-threaded-annotations-portal />
             </div>
-        </FocusTrap>
+        </FocusTrap>,
+        document.body,
     );
 };
 

--- a/src/components/Popups/PopupV2.tsx
+++ b/src/components/Popups/PopupV2.tsx
@@ -37,6 +37,7 @@ import './PopupV2.scss';
 export type Props = {
     annotationId?: string;
     onSubmit: (text: string) => void;
+    popupPortalEl?: HTMLElement | null;
     reference: PopupReference;
 };
 
@@ -76,7 +77,7 @@ const fetchAvatarBlob = async (apiHost: string, token: string, userId: string): 
     }
 };
 
-const PopupV2 = ({ annotationId, onSubmit, reference }: Props): JSX.Element | null => {
+const PopupV2 = ({ annotationId, onSubmit, popupPortalEl, reference }: Props): JSX.Element | null => {
     const intl = useIntl();
     const dispatch = useDispatch<AppThunkDispatch>();
     const popupRef = React.useRef<HTMLDivElement>(null);
@@ -262,7 +263,7 @@ const PopupV2 = ({ annotationId, onSubmit, reference }: Props): JSX.Element | nu
         [annotationId, dispatch],
     );
 
-    if (typeof document === 'undefined') return null;
+    if (!popupPortalEl) return null;
 
     return ReactDOM.createPortal(
         <FocusTrap>
@@ -312,7 +313,7 @@ const PopupV2 = ({ annotationId, onSubmit, reference }: Props): JSX.Element | nu
                 <div data-threaded-annotations-portal />
             </div>
         </FocusTrap>,
-        document.body,
+        popupPortalEl,
     );
 };
 

--- a/src/components/Popups/__tests__/PopupV2-test.tsx
+++ b/src/components/Popups/__tests__/PopupV2-test.tsx
@@ -246,4 +246,14 @@ describe('PopupV2', () => {
         const portal = screen.getByRole('presentation').querySelector('[data-threaded-annotations-portal]');
         expect(portal).not.toBeNull();
     });
+
+    test('should render popup into document.body via portal', () => {
+        mockSelectorValues(undefined);
+        const { container } = render(
+            <PopupV2 onSubmit={jest.fn()} reference={document.createElement('div')} />,
+        );
+
+        expect(container.querySelector('.ba-PopupV2')).toBeNull();
+        expect(document.body.querySelector('.ba-PopupV2')).toBeVisible();
+    });
 });

--- a/src/components/Popups/__tests__/PopupV2-test.tsx
+++ b/src/components/Popups/__tests__/PopupV2-test.tsx
@@ -129,9 +129,16 @@ describe('PopupV2', () => {
         jest.clearAllMocks();
     });
 
+    const makePortalEl = (): HTMLElement => {
+        const el = document.createElement('div');
+        document.body.appendChild(el);
+        return el;
+    };
+
     describe('create mode (no annotationId)', () => {
         const defaults: Props = {
             onSubmit: jest.fn(),
+            popupPortalEl: makePortalEl(),
             reference: document.createElement('div'),
         };
 
@@ -166,6 +173,7 @@ describe('PopupV2', () => {
         const defaults: Props = {
             annotationId: 'annotation-1',
             onSubmit: jest.fn(),
+            popupPortalEl: makePortalEl(),
             reference: document.createElement('div'),
         };
 
@@ -234,26 +242,37 @@ describe('PopupV2', () => {
 
     test('should set aria-label on popup container', () => {
         mockSelectorValues(undefined);
-        render(<PopupV2 onSubmit={jest.fn()} reference={document.createElement('div')} />);
+        render(<PopupV2 onSubmit={jest.fn()} popupPortalEl={makePortalEl()} reference={document.createElement('div')} />);
 
         expect(screen.getByRole('presentation')).toHaveAttribute('aria-label', 'Comment');
     });
 
     test('should render portal container for threaded-annotations popovers', () => {
         mockSelectorValues(undefined);
-        render(<PopupV2 onSubmit={jest.fn()} reference={document.createElement('div')} />);
+        render(<PopupV2 onSubmit={jest.fn()} popupPortalEl={makePortalEl()} reference={document.createElement('div')} />);
 
         const portal = screen.getByRole('presentation').querySelector('[data-threaded-annotations-portal]');
         expect(portal).not.toBeNull();
     });
 
-    test('should render popup into document.body via portal', () => {
+    test('should render popup into popupPortalEl, not the render container', () => {
+        mockSelectorValues(undefined);
+        const portalEl = makePortalEl();
+        const { container } = render(
+            <PopupV2 onSubmit={jest.fn()} popupPortalEl={portalEl} reference={document.createElement('div')} />,
+        );
+
+        expect(container.querySelector('.ba-PopupV2')).toBeNull();
+        expect(portalEl.querySelector('.ba-PopupV2')).toBeVisible();
+    });
+
+    test('should render nothing when popupPortalEl is missing', () => {
         mockSelectorValues(undefined);
         const { container } = render(
             <PopupV2 onSubmit={jest.fn()} reference={document.createElement('div')} />,
         );
 
         expect(container.querySelector('.ba-PopupV2')).toBeNull();
-        expect(document.body.querySelector('.ba-PopupV2')).toBeVisible();
+        expect(document.body.querySelector('.ba-PopupV2')).toBeNull();
     });
 });

--- a/src/document/DocumentAnnotator.ts
+++ b/src/document/DocumentAnnotator.ts
@@ -99,7 +99,7 @@ export default class DocumentAnnotator extends BaseAnnotator {
             }
 
             // Annotations mode
-            managers.add(new PopupManager({ location: pageNumber, referenceEl: pageReferenceEl, resinTags }));
+            managers.add(new PopupManager({ location: pageNumber, popupPortalEl: this.popupPortalEl, referenceEl: pageReferenceEl, resinTags }));
             managers.add(new DrawingManager({ location: pageNumber, referenceEl: pageReferenceEl, resinTags }));
 
             const textLayer = pageEl.querySelector('.textLayer') as HTMLElement;

--- a/src/image/ImageAnnotator.ts
+++ b/src/image/ImageAnnotator.ts
@@ -73,7 +73,7 @@ export default class ImageAnnotator extends BaseAnnotator {
                 return this.managers;
             }
 
-            this.managers.add(new PopupManager({ referenceEl, resinTags }));
+            this.managers.add(new PopupManager({ popupPortalEl: this.popupPortalEl, referenceEl, resinTags }));
             this.managers.add(new DrawingManager({ referenceEl, resinTags }));
             this.managers.add(new RegionManager({ referenceEl, resinTags }));
             this.managers.add(new RegionCreationManager({ referenceEl, resinTags }));

--- a/src/media/MediaAnnotator.ts
+++ b/src/media/MediaAnnotator.ts
@@ -46,7 +46,7 @@ export default class MediaAnnotator extends BaseAnnotator {
 
 
     addManagers(referenceEl: HTMLVideoElement, resinTags: { fileid: string|null; iscurrent: boolean }): void {
-        this.managers.add(new PopupManager({ location: MEDIA_LOCATION_INDEX, referenceEl, resinTags, targetType: TARGET_TYPE.FRAME }));
+        this.managers.add(new PopupManager({ location: MEDIA_LOCATION_INDEX, popupPortalEl: this.popupPortalEl, referenceEl, resinTags, targetType: TARGET_TYPE.FRAME }));
         this.managers.add(new DrawingManager({ location: MEDIA_LOCATION_INDEX, referenceEl, resinTags, targetType: TARGET_TYPE.FRAME }));
         this.managers.add(new RegionManager({ location: MEDIA_LOCATION_INDEX, referenceEl, resinTags, targetType: TARGET_TYPE.FRAME }));
         this.managers.add(new RegionCreationManager({ location: MEDIA_LOCATION_INDEX, referenceEl, resinTags, targetType: TARGET_TYPE.FRAME }));

--- a/src/popup/PopupContainer.tsx
+++ b/src/popup/PopupContainer.tsx
@@ -20,6 +20,13 @@ import { isFeatureEnabled } from '../store/options';
 import { createDrawingAction } from '../drawing/actions';
 import { createHighlightAction } from '../highlight/actions';
 import { createRegionAction } from '../region';
+import { TARGET_TYPE } from '../constants';
+
+export type OwnProps = {
+    location: number;
+    popupPortalEl?: HTMLElement | null;
+    targetType?: TARGET_TYPE;
+};
 
 export type Props = {
     activeAnnotationId: string | null;
@@ -32,7 +39,7 @@ export type Props = {
     status: CreatorStatus;
 };
 
-export const mapStateToProps = (state: AppState, { location }: { location: number }): Props => {
+export const mapStateToProps = (state: AppState, { location }: OwnProps): Props => {
     return {
         activeAnnotationId: getActiveAnnotationId(state),
         isPromoting: getIsPromoting(state),

--- a/src/popup/PopupLayer.tsx
+++ b/src/popup/PopupLayer.tsx
@@ -29,6 +29,7 @@ export type Props = {
     location: number;
     message: string;
     mode: Mode;
+    popupPortalEl?: HTMLElement | null;
     referenceId: string | null;
     resetCreator: () => void;
     setMessage: (message: string) => void;
@@ -53,6 +54,7 @@ const PopupLayer = (props: Props): JSX.Element | null => {
         isThreadedAnnotation = false,
         message,
         mode,
+        popupPortalEl,
         referenceId,
         resetCreator,
         setMessage,
@@ -111,6 +113,7 @@ const PopupLayer = (props: Props): JSX.Element | null => {
             <div className="ba-PopupLayer-popup">
                 <PopupV2
                     onSubmit={handleSubmit}
+                    popupPortalEl={popupPortalEl}
                     reference={reference}
                 />
             </div>
@@ -138,6 +141,7 @@ const PopupLayer = (props: Props): JSX.Element | null => {
                 <PopupV2
                     annotationId={activeAnnotationId}
                     onSubmit={handleSubmit}
+                    popupPortalEl={popupPortalEl}
                     reference={activeReference}
                 />
             </div>

--- a/src/popup/PopupManager.tsx
+++ b/src/popup/PopupManager.tsx
@@ -1,9 +1,20 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
-import BaseManager, { Props } from '../common/BaseManager';
+import BaseManager, { Options as BaseOptions, Props } from '../common/BaseManager';
 import PopupContainer from './PopupContainer';
 
+export type Options = BaseOptions & {
+    popupPortalEl?: HTMLElement | null;
+};
+
 export default class PopupManager extends BaseManager {
+    popupPortalEl?: HTMLElement | null;
+
+    constructor({ popupPortalEl, ...options }: Options) {
+        super(options);
+        this.popupPortalEl = popupPortalEl;
+    }
+
     decorate(): void {
         this.reactEl.classList.add('ba-Layer--popup');
         this.reactEl.dataset.testid = 'ba-Layer--popup';
@@ -13,7 +24,14 @@ export default class PopupManager extends BaseManager {
         if (!this.root) {
             this.root = ReactDOM.createRoot(this.reactEl);
         }
-       
-        this.root.render(<PopupContainer location={this.location}  {...props} targetType={this.targetType} />);
+
+        this.root.render(
+            <PopupContainer
+                location={this.location}
+                {...props}
+                popupPortalEl={this.popupPortalEl}
+                targetType={this.targetType}
+            />,
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Portal `PopupV2` to `document.body` via `ReactDOM.createPortal` so the thread popup no longer inherits the rotation transform the annotation layer applies to its managers.
- Update `DeselectListener` to skip `mousedown` events whose target is inside `.ba-PopupV2`, since the portaled popup now reaches the document-level listener directly.
- Add `body:has(.ba.is-hidden) .ba-PopupV2 { display: none }` so the portaled popup hides when the annotator is hidden.

## Test Plan
- [ ] Open an image annotation, rotate the page through 90/180/270/-90, confirm the thread popup stays upright and anchored to the marker.
- [ ] Click the reply editor, mention menu, resolve/delete buttons inside the popup; thread stays open.
- [ ] Click outside the popup on the image; thread closes.
- [ ] Toggle annotator visibility; popup hides with the rest of the annotator UI.