### PR TITLE
fix(document): account for page padding in rotation layer sizing

### DIFF
--- a/src/document/DocumentAnnotator.ts
+++ b/src/document/DocumentAnnotator.ts
@@ -24,6 +24,9 @@ import type { ViewMode } from '../store/options/types';
 // Pdf.js textLayer enhancement requires waiting for 300ms (they hardcode this magic number)
 const TEXT_LAYER_ENHANCEMENT = 300;
 
+// Vertical padding on each page element as provided by Preview SDK (see DocumentAnnotator.scss)
+const PAGE_PADDING = 15;
+
 export default class DocumentAnnotator extends BaseAnnotator {
     annotatedEl?: HTMLElement;
 
@@ -200,7 +203,7 @@ export default class DocumentAnnotator extends BaseAnnotator {
 
         // Calculate original (unrotated) page dimensions for annotation layer sizing
         const pageWidth = pageEl.clientWidth;
-        const pageHeight = pageEl.clientHeight;
+        const pageHeight = pageEl.clientHeight - PAGE_PADDING * 2;
         const isOrthogonal = rotation % 180 !== 0;
         const origWidth = isOrthogonal ? pageHeight : pageWidth;
         const origHeight = isOrthogonal ? pageWidth : pageHeight;

--- a/src/document/__tests__/DocumentAnnotator-test.ts
+++ b/src/document/__tests__/DocumentAnnotator-test.ts
@@ -28,6 +28,8 @@ jest.mock('../../region/RegionManager');
 jest.mock('../../boundingBoxHighlight');
 jest.mock('../../utils/scroll');
 
+const PAGE_PADDING = 15;
+
 describe('DocumentAnnotator', () => {
     const container = document.createElement('div');
     const defaults = {
@@ -349,7 +351,7 @@ describe('DocumentAnnotator', () => {
                 left: '50%',
                 top: '50%',
                 transform: 'translate(-50%, -50%) rotate(90deg)',
-                width: '800px',
+                width: `${800 - PAGE_PADDING * 2}px`,
             });
         });
 
@@ -371,7 +373,7 @@ describe('DocumentAnnotator', () => {
                 left: '50%',
                 top: '50%',
                 transform: 'translate(-50%, -50%) rotate(270deg)',
-                width: '800px',
+                width: `${800 - PAGE_PADDING * 2}px`,
             });
         });
 
@@ -389,7 +391,7 @@ describe('DocumentAnnotator', () => {
             annotator.renderPage(pageEl);
 
             expect(mockManager.style).toHaveBeenCalledWith({
-                height: '600px',
+                height: `${600 - PAGE_PADDING * 2}px`,
                 left: '50%',
                 top: '50%',
                 transform: 'translate(-50%, -50%) rotate(180deg)',


### PR DESCRIPTION
**Summary**
- Fixes bug where annotations on PDF's appear in slightly different positions when PDF is rotated
- Solution: subtract the 30px vertical page padding (15px top + 15px bottom from Preview SDK) when computing annotation layer dimensions
- `pageEl.clientHeight` was being used directly, but it includes padding that isn't part of the annotation content area — causing the layer to be oversized and percentage-based annotation coordinates to resolve to slightly wrong pixel positions                                                                                                                                                                                                        
                                                                                                                                                                                                                               
**Test plan**                                                                                                                                                                                                                    
- Draw and save annotations on a PDF at 0° rotation
- Rotate the PDF 90°, 180°, and 270° — verify annotations remain precisely positioned
- Verify annotations near page edges (where offset was most visible) are no longer shifted           