### PR TITLE
feat(annotations): add logic for drawing/region annotation cursor input on rotated files

### DIFF
--- a/src/drawing/DrawingAnnotations.tsx
+++ b/src/drawing/DrawingAnnotations.tsx
@@ -24,6 +24,7 @@ export type Props = {
     location: number;
     redoDrawingPathGroup: () => void;
     resetDrawing: () => void;
+    rotation: number;
     setActiveAnnotationId: (annotationId: string | null) => void;
     setReferenceId: (uuid: string) => void;
     setStaged: (staged: CreatorItemDrawing | null) => void;
@@ -47,6 +48,7 @@ const DrawingAnnotations = (props: Props): JSX.Element => {
         location,
         redoDrawingPathGroup,
         resetDrawing,
+        rotation,
         setActiveAnnotationId,
         setReferenceId,
         setStaged,
@@ -170,6 +172,7 @@ const DrawingAnnotations = (props: Props): JSX.Element => {
                     color={color}
                     onStart={handleStart}
                     onStop={handleStop}
+                    rotation={rotation}
                 />
             )}
 

--- a/src/drawing/DrawingAnnotationsContainer.tsx
+++ b/src/drawing/DrawingAnnotationsContainer.tsx
@@ -18,6 +18,7 @@ import {
     getAnnotationsForLocation,
     getColor,
     getCreatorStatus,
+    getRotation,
     Mode,
     setActiveAnnotationIdAction,
     setReferenceIdAction,
@@ -34,6 +35,7 @@ export type Props = {
     canShowPopupToolbar: boolean;
     drawnPathGroups: Array<PathGroup>;
     isCreating: boolean;
+    rotation: number;
     stashedPathGroups: Array<PathGroup>;
 };
 
@@ -47,6 +49,7 @@ export const mapStateToProps = (state: AppState, { location }: { location: numbe
         canShowPopupToolbar: creatorStatus === CreatorStatus.started,
         drawnPathGroups: getDrawingDrawnPathGroupsForLocation(state, location),
         isCreating: getAnnotationMode(state) === Mode.DRAWING && creatorStatus !== CreatorStatus.pending,
+        rotation: getRotation(state),
         stashedPathGroups: getStashedDrawnPathGroupsForLocation(state, location),
     };
 };

--- a/src/drawing/DrawingCreator.tsx
+++ b/src/drawing/DrawingCreator.tsx
@@ -61,15 +61,18 @@ export default function DrawingCreator({
         }));
     }, [stroke]);
 
-    const getPosition = (x: number, y: number): [number, number] => {
-        const { current: creatorEl } = creatorElRef;
+    const getPosition = React.useCallback(
+        (x: number, y: number): [number, number] => {
+            const { current: creatorEl } = creatorElRef;
 
-        if (!creatorEl) {
-            return [x, y];
-        }
+            if (!creatorEl) {
+                return [x, y];
+            }
 
-        return getElementLocalPosition(x, y, creatorEl, rotation);
-    };
+            return getElementLocalPosition(x, y, creatorEl, rotation);
+        },
+        [rotation],
+    );
 
     // Drawing Lifecycle Callbacks
     const startDraw = (x: number, y: number): void => {

--- a/src/drawing/DrawingCreator.tsx
+++ b/src/drawing/DrawingCreator.tsx
@@ -7,6 +7,7 @@ import DrawingSVG, { DrawingSVGRef } from './DrawingSVG';
 import PointerCapture, { PointerCaptureRef, Status as DrawingStatus } from '../components/PointerCapture';
 import { getDrawingCursor } from './DrawingCursor';
 import { getPathCommands } from './drawingUtil';
+import { rotatePoint } from '../utils/rotate';
 import { PathGroup, Position } from '../@types';
 import './DrawingCreator.scss';
 
@@ -15,6 +16,7 @@ export type Props = {
     color?: string;
     onStart: () => void;
     onStop: (pathGroup: PathGroup) => void;
+    rotation?: number;
     size?: number;
 };
 
@@ -26,6 +28,7 @@ export default function DrawingCreator({
     color = defaultStrokeColor,
     onStart,
     onStop,
+    rotation = 0,
     size = defaultStrokeSize,
 }: Props): JSX.Element {
     const [drawingStatus, setDrawingStatus] = React.useState<DrawingStatus>(DrawingStatus.init);
@@ -45,7 +48,9 @@ export default function DrawingCreator({
             return [];
         }
 
-        const { height, width } = creatorEl.getBoundingClientRect();
+        // Use offsetWidth/offsetHeight to get pre-transform dimensions (local coordinate space)
+        const width = creatorEl.offsetWidth;
+        const height = creatorEl.offsetHeight;
         const { size: minSize } = stroke;
         const MAX_X = width - minSize;
         const MAX_Y = height - minSize;
@@ -63,9 +68,28 @@ export default function DrawingCreator({
             return [x, y];
         }
 
-        // Calculate the new position based on the mouse position less the page offset
-        const { left, top } = creatorEl.getBoundingClientRect();
-        return [x - left, y - top];
+        const rect = creatorEl.getBoundingClientRect();
+
+        if (!rotation) {
+            return [x - rect.left, y - rect.top];
+        }
+
+        // When the annotation layer is CSS-rotated, getBoundingClientRect() returns the
+        // axis-aligned bounding box in screen space, but the element's internal coordinate
+        // system is rotated. We must apply the inverse rotation to convert screen-space
+        // coordinates into the element's local coordinate system.
+        const centerX = rect.left + rect.width / 2;
+        const centerY = rect.top + rect.height / 2;
+
+        // Get mouse position relative to element center (in screen space)
+        const relX = x - centerX;
+        const relY = y - centerY;
+
+        // Apply inverse rotation to transform into local coordinate space
+        const local = rotatePoint({ x: relX, y: relY }, -rotation);
+
+        // Convert from center-relative to top-left-relative using pre-transform dimensions
+        return [local.x + creatorEl.offsetWidth / 2, local.y + creatorEl.offsetHeight / 2];
     };
 
     // Drawing Lifecycle Callbacks
@@ -111,6 +135,7 @@ export default function DrawingCreator({
                 onStart();
             }
         },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [drawingStatus, onStart, setDrawingStatus],
     );
 

--- a/src/drawing/DrawingCreator.tsx
+++ b/src/drawing/DrawingCreator.tsx
@@ -61,22 +61,9 @@ export default function DrawingCreator({
         }));
     }, [stroke]);
 
-    const getPosition = React.useCallback(
-        (x: number, y: number): [number, number] => {
-            const { current: creatorEl } = creatorElRef;
-
-            if (!creatorEl) {
-                return [x, y];
-            }
-
-            return getElementLocalPosition(x, y, creatorEl, rotation);
-        },
-        [rotation],
-    );
-
     // Drawing Lifecycle Callbacks
     const startDraw = (x: number, y: number): void => {
-        const [x1, y1] = getPosition(x, y);
+        const [x1, y1] = getElementLocalPosition(x, y, creatorElRef.current, rotation);
 
         setDrawingStatus(DrawingStatus.dragging);
 
@@ -106,7 +93,7 @@ export default function DrawingCreator({
 
     const updateDraw = React.useCallback(
         (x: number, y: number): void => {
-            const [x2, y2] = getPosition(x, y);
+            const [x2, y2] = getElementLocalPosition(x, y, creatorElRef.current, rotation);
             const { current: points } = capturedPointsRef;
 
             points.push({ x: x2, y: y2 });
@@ -117,7 +104,7 @@ export default function DrawingCreator({
                 onStart();
             }
         },
-        [drawingStatus, getPosition, onStart, setDrawingStatus],
+        [drawingStatus, onStart, rotation, setDrawingStatus],
     );
 
     // Event Handlers

--- a/src/drawing/DrawingCreator.tsx
+++ b/src/drawing/DrawingCreator.tsx
@@ -7,7 +7,7 @@ import DrawingSVG, { DrawingSVGRef } from './DrawingSVG';
 import PointerCapture, { PointerCaptureRef, Status as DrawingStatus } from '../components/PointerCapture';
 import { getDrawingCursor } from './DrawingCursor';
 import { getPathCommands } from './drawingUtil';
-import { rotatePoint } from '../utils/rotate';
+import { getElementLocalPosition } from '../utils/rotate';
 import { PathGroup, Position } from '../@types';
 import './DrawingCreator.scss';
 
@@ -48,7 +48,7 @@ export default function DrawingCreator({
             return [];
         }
 
-        // Use offsetWidth/offsetHeight to get pre-transform dimensions (local coordinate space)
+        // Get the element's dimensions (before any rotation is applied)
         const width = creatorEl.offsetWidth;
         const height = creatorEl.offsetHeight;
         const { size: minSize } = stroke;
@@ -68,28 +68,7 @@ export default function DrawingCreator({
             return [x, y];
         }
 
-        const rect = creatorEl.getBoundingClientRect();
-
-        if (!rotation) {
-            return [x - rect.left, y - rect.top];
-        }
-
-        // When the annotation layer is CSS-rotated, getBoundingClientRect() returns the
-        // axis-aligned bounding box in screen space, but the element's internal coordinate
-        // system is rotated. We must apply the inverse rotation to convert screen-space
-        // coordinates into the element's local coordinate system.
-        const centerX = rect.left + rect.width / 2;
-        const centerY = rect.top + rect.height / 2;
-
-        // Get mouse position relative to element center (in screen space)
-        const relX = x - centerX;
-        const relY = y - centerY;
-
-        // Apply inverse rotation to transform into local coordinate space
-        const local = rotatePoint({ x: relX, y: relY }, -rotation);
-
-        // Convert from center-relative to top-left-relative using pre-transform dimensions
-        return [local.x + creatorEl.offsetWidth / 2, local.y + creatorEl.offsetHeight / 2];
+        return getElementLocalPosition(x, y, creatorEl, rotation);
     };
 
     // Drawing Lifecycle Callbacks
@@ -135,7 +114,6 @@ export default function DrawingCreator({
                 onStart();
             }
         },
-        // eslint-disable-next-line react-hooks/exhaustive-deps
         [drawingStatus, onStart, setDrawingStatus],
     );
 

--- a/src/drawing/DrawingCreator.tsx
+++ b/src/drawing/DrawingCreator.tsx
@@ -114,7 +114,7 @@ export default function DrawingCreator({
                 onStart();
             }
         },
-        [drawingStatus, onStart, setDrawingStatus],
+        [drawingStatus, getPosition, onStart, setDrawingStatus],
     );
 
     // Event Handlers

--- a/src/drawing/__tests__/DrawingAnnotations-test.tsx
+++ b/src/drawing/__tests__/DrawingAnnotations-test.tsx
@@ -40,6 +40,7 @@ describe('DrawingAnnotations', () => {
         location: 0,
         redoDrawingPathGroup: jest.fn(),
         resetDrawing: jest.fn(),
+        rotation: 0,
         setActiveAnnotationId: jest.fn(),
         setReferenceId: jest.fn(),
         setStaged: jest.fn(),

--- a/src/drawing/__tests__/DrawingCreator-test.tsx
+++ b/src/drawing/__tests__/DrawingCreator-test.tsx
@@ -32,6 +32,8 @@ describe('DrawingCreator', () => {
         jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => setTimeout(cb, 100)); // 10 fps;
         jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(() => getDOMRect());
         jest.spyOn(Element.prototype, 'setAttribute');
+        Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, get: () => 100 });
+        Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => 100 });
     });
 
     const simulateDrawStart = (wrapper: ReactWrapper<PointerCaptureProps, NonNullable<unknown>>, clientX = 10, clientY = 10): void => {

--- a/src/drawing/__tests__/DrawingCreator-test.tsx
+++ b/src/drawing/__tests__/DrawingCreator-test.tsx
@@ -25,6 +25,9 @@ describe('DrawingCreator', () => {
     const getWrapper = (props?: Partial<Props>): ReactWrapper<PointerCaptureProps, NonNullable<unknown>> =>
         mount(<DrawingCreator {...getDefaults()} {...props} />);
 
+    let origOffsetWidth: PropertyDescriptor | undefined;
+    let origOffsetHeight: PropertyDescriptor | undefined;
+
     beforeEach(() => {
         jest.useFakeTimers();
 
@@ -32,8 +35,16 @@ describe('DrawingCreator', () => {
         jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => setTimeout(cb, 100)); // 10 fps;
         jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(() => getDOMRect());
         jest.spyOn(Element.prototype, 'setAttribute');
+
+        origOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
+        origOffsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
         Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, get: () => 100 });
         Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => 100 });
+    });
+
+    afterEach(() => {
+        if (origOffsetWidth) Object.defineProperty(HTMLElement.prototype, 'offsetWidth', origOffsetWidth);
+        if (origOffsetHeight) Object.defineProperty(HTMLElement.prototype, 'offsetHeight', origOffsetHeight);
     });
 
     const simulateDrawStart = (wrapper: ReactWrapper<PointerCaptureProps, NonNullable<unknown>>, clientX = 10, clientY = 10): void => {

--- a/src/region/RegionCreation.tsx
+++ b/src/region/RegionCreation.tsx
@@ -9,9 +9,9 @@ import { getVideoCurrentTimeInMilliseconds } from '../utils/useVideoTiming';
 
 type Props = {
     isCreating: boolean;
-    isRotated: boolean;
     location: number;
     resetCreator: () => void;
+    rotation: number;
     setReferenceId: (uuid: string) => void;
     setStaged: (staged: CreatorItemRegion | null) => void;
     setStatus: (status: CreatorStatus) => void;
@@ -27,7 +27,7 @@ type State = {
 export default class RegionCreation extends React.PureComponent<Props, State> {
     static defaultProps = {
         isCreating: false,
-        isRotated: false,
+        rotation: 0,
     };
 
     state: State = {};
@@ -57,11 +57,7 @@ export default class RegionCreation extends React.PureComponent<Props, State> {
     };
 
     render(): JSX.Element | null {
-        const { isCreating, isRotated, staged } = this.props;
-
-        if (isRotated) {
-            return null;
-        }
+        const { isCreating, rotation, staged } = this.props;
 
         return (
             <>
@@ -71,6 +67,7 @@ export default class RegionCreation extends React.PureComponent<Props, State> {
                         onAbort={this.handleAbort}
                         onStart={this.handleStart}
                         onStop={this.handleStop}
+                        rotation={rotation}
                     />
                 )}
 

--- a/src/region/RegionCreationContainer.tsx
+++ b/src/region/RegionCreationContainer.tsx
@@ -19,7 +19,7 @@ import withProviders from '../common/withProviders';
 
 export type Props = {
     isCreating: boolean;
-    isRotated: boolean;
+    rotation: number;
     staged: CreatorItemRegion | null;
 };
 
@@ -28,7 +28,7 @@ export const mapStateToProps = (state: AppState, { location }: { location: numbe
 
     return {
         isCreating: getAnnotationMode(state) === Mode.REGION && getCreatorStatus(state) !== CreatorStatus.pending,
-        isRotated: !!getRotation(state),
+        rotation: getRotation(state),
         staged: isCreatorStagedRegion(staged) ? staged : null,
     };
 };

--- a/src/region/RegionCreator.tsx
+++ b/src/region/RegionCreator.tsx
@@ -4,7 +4,7 @@ import PointerCapture, { Status as DrawingStatus } from '../components/PointerCa
 import PopupCursor from '../components/Popups/PopupCursor';
 import RegionRect, { RegionRectRef } from './RegionRect';
 import useAutoScroll from '../common/useAutoScroll';
-import { rotatePoint } from '../utils/rotate';
+import { getElementLocalPosition } from '../utils/rotate';
 import { Rect } from '../@types';
 import { styleShape } from './regionUtil';
 import './RegionCreator.scss';
@@ -44,25 +44,7 @@ export default function RegionCreator({ className, onAbort, onStart, onStop, rot
             return [x, y];
         }
 
-        const rect = creatorEl.getBoundingClientRect();
-
-        if (!rotation) {
-            return [x - rect.left, y - rect.top];
-        }
-
-        // When the annotation layer is CSS-rotated, getBoundingClientRect() returns the
-        // axis-aligned bounding box in screen space, but the element's internal coordinate
-        // system is rotated. We must apply the inverse rotation to convert screen-space
-        // coordinates into the element's local coordinate system.
-        const centerX = rect.left + rect.width / 2;
-        const centerY = rect.top + rect.height / 2;
-
-        const relX = x - centerX;
-        const relY = y - centerY;
-
-        const local = rotatePoint({ x: relX, y: relY }, -rotation);
-
-        return [local.x + creatorEl.offsetWidth / 2, local.y + creatorEl.offsetHeight / 2];
+        return getElementLocalPosition(x, y, creatorEl, rotation);
     };
     const getShape = (): Rect | null => {
         const { current: creatorEl } = creatorElRef;
@@ -75,7 +57,7 @@ export default function RegionCreator({ className, onAbort, onStart, onStop, rot
             return null;
         }
 
-        // Use offsetWidth/offsetHeight to get pre-transform dimensions (local coordinate space)
+        // Get the element's dimensions (before any rotation is applied)
         const width = creatorEl.offsetWidth;
         const height = creatorEl.offsetHeight;
         const MAX_HEIGHT = height - MIN_SIZE;
@@ -158,7 +140,6 @@ export default function RegionCreator({ className, onAbort, onStart, onStop, rot
                 onStart();
             }
         },
-        // eslint-disable-next-line react-hooks/exhaustive-deps
         [drawingStatus, onStart, setDrawingStatus],
     );
 

--- a/src/region/RegionCreator.tsx
+++ b/src/region/RegionCreator.tsx
@@ -36,19 +36,6 @@ export default function RegionCreator({ className, onAbort, onStart, onStop, rot
     const regionRectRef = React.useRef<RegionRectRef>(null);
     const renderHandleRef = React.useRef<number | null>(null);
 
-    // Drawing Helpers
-    const getPosition = React.useCallback(
-        (x: number, y: number): [number, number] => {
-            const { current: creatorEl } = creatorElRef;
-
-            if (!creatorEl) {
-                return [x, y];
-            }
-
-            return getElementLocalPosition(x, y, creatorEl, rotation);
-        },
-        [rotation],
-    );
     const getShape = (): Rect | null => {
         const { current: creatorEl } = creatorElRef;
         const { current: x1 } = positionX1Ref;
@@ -93,7 +80,7 @@ export default function RegionCreator({ className, onAbort, onStart, onStop, rot
 
     // Drawing Lifecycle Callbacks
     const startDraw = (x: number, y: number): void => {
-        const [x1, y1] = getPosition(x, y);
+        const [x1, y1] = getElementLocalPosition(x, y, creatorElRef.current, rotation);
 
         setDrawingStatus(DrawingStatus.dragging);
 
@@ -124,7 +111,7 @@ export default function RegionCreator({ className, onAbort, onStart, onStop, rot
 
     const updateDraw = React.useCallback(
         (x: number, y: number): void => {
-            const [x2, y2] = getPosition(x, y);
+            const [x2, y2] = getElementLocalPosition(x, y, creatorElRef.current, rotation);
             const { current: x1 } = positionX1Ref;
             const { current: y1 } = positionY1Ref;
             const { current: prevX2 } = positionX2Ref;
@@ -143,7 +130,7 @@ export default function RegionCreator({ className, onAbort, onStart, onStop, rot
                 onStart();
             }
         },
-        [drawingStatus, getPosition, onStart, setDrawingStatus],
+        [drawingStatus, onStart, rotation, setDrawingStatus],
     );
 
     // Event Handlers

--- a/src/region/RegionCreator.tsx
+++ b/src/region/RegionCreator.tsx
@@ -140,7 +140,7 @@ export default function RegionCreator({ className, onAbort, onStart, onStop, rot
                 onStart();
             }
         },
-        [drawingStatus, onStart, setDrawingStatus],
+        [drawingStatus, getPosition, onStart, setDrawingStatus],
     );
 
     // Event Handlers

--- a/src/region/RegionCreator.tsx
+++ b/src/region/RegionCreator.tsx
@@ -37,15 +37,18 @@ export default function RegionCreator({ className, onAbort, onStart, onStop, rot
     const renderHandleRef = React.useRef<number | null>(null);
 
     // Drawing Helpers
-    const getPosition = (x: number, y: number): [number, number] => {
-        const { current: creatorEl } = creatorElRef;
+    const getPosition = React.useCallback(
+        (x: number, y: number): [number, number] => {
+            const { current: creatorEl } = creatorElRef;
 
-        if (!creatorEl) {
-            return [x, y];
-        }
+            if (!creatorEl) {
+                return [x, y];
+            }
 
-        return getElementLocalPosition(x, y, creatorEl, rotation);
-    };
+            return getElementLocalPosition(x, y, creatorEl, rotation);
+        },
+        [rotation],
+    );
     const getShape = (): Rect | null => {
         const { current: creatorEl } = creatorElRef;
         const { current: x1 } = positionX1Ref;

--- a/src/region/RegionCreator.tsx
+++ b/src/region/RegionCreator.tsx
@@ -4,6 +4,7 @@ import PointerCapture, { Status as DrawingStatus } from '../components/PointerCa
 import PopupCursor from '../components/Popups/PopupCursor';
 import RegionRect, { RegionRectRef } from './RegionRect';
 import useAutoScroll from '../common/useAutoScroll';
+import { rotatePoint } from '../utils/rotate';
 import { Rect } from '../@types';
 import { styleShape } from './regionUtil';
 import './RegionCreator.scss';
@@ -13,6 +14,7 @@ type Props = {
     onAbort: () => void;
     onStart: () => void;
     onStop: (shape: Rect) => void;
+    rotation?: number;
 };
 
 const MIN_X = 0; // Minimum region x position must be positive
@@ -22,7 +24,7 @@ const MIN_SIZE = 10; // Minimum region size must be large enough to be clickable
 const isValid = (x1: number, y1: number, x2: number, y2: number): boolean =>
     Math.abs(x2 - x1) >= MIN_SIZE || Math.abs(y2 - y1) >= MIN_SIZE;
 
-export default function RegionCreator({ className, onAbort, onStart, onStop }: Props): JSX.Element {
+export default function RegionCreator({ className, onAbort, onStart, onStop, rotation = 0 }: Props): JSX.Element {
     const [drawingStatus, setDrawingStatus] = React.useState<DrawingStatus>(DrawingStatus.init);
     const [isHovering, setIsHovering] = React.useState<boolean>(false);
     const creatorElRef = React.useRef<HTMLDivElement>(null);
@@ -42,9 +44,25 @@ export default function RegionCreator({ className, onAbort, onStart, onStop }: P
             return [x, y];
         }
 
-        // Calculate the new position based on the mouse position less the page offset
-        const { left, top } = creatorEl.getBoundingClientRect();
-        return [x - left, y - top];
+        const rect = creatorEl.getBoundingClientRect();
+
+        if (!rotation) {
+            return [x - rect.left, y - rect.top];
+        }
+
+        // When the annotation layer is CSS-rotated, getBoundingClientRect() returns the
+        // axis-aligned bounding box in screen space, but the element's internal coordinate
+        // system is rotated. We must apply the inverse rotation to convert screen-space
+        // coordinates into the element's local coordinate system.
+        const centerX = rect.left + rect.width / 2;
+        const centerY = rect.top + rect.height / 2;
+
+        const relX = x - centerX;
+        const relY = y - centerY;
+
+        const local = rotatePoint({ x: relX, y: relY }, -rotation);
+
+        return [local.x + creatorEl.offsetWidth / 2, local.y + creatorEl.offsetHeight / 2];
     };
     const getShape = (): Rect | null => {
         const { current: creatorEl } = creatorElRef;
@@ -57,7 +75,9 @@ export default function RegionCreator({ className, onAbort, onStart, onStop }: P
             return null;
         }
 
-        const { height, width } = creatorEl.getBoundingClientRect();
+        // Use offsetWidth/offsetHeight to get pre-transform dimensions (local coordinate space)
+        const width = creatorEl.offsetWidth;
+        const height = creatorEl.offsetHeight;
         const MAX_HEIGHT = height - MIN_SIZE;
         const MAX_WIDTH = width - MIN_SIZE;
         const MAX_X = Math.max(0, width - MIN_X);
@@ -138,6 +158,7 @@ export default function RegionCreator({ className, onAbort, onStart, onStop }: P
                 onStart();
             }
         },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [drawingStatus, onStart, setDrawingStatus],
     );
 

--- a/src/region/__tests__/RegionCreation-test.tsx
+++ b/src/region/__tests__/RegionCreation-test.tsx
@@ -136,15 +136,15 @@ describe('RegionCreation', () => {
             expect(wrapper.exists(RegionRect)).toBe(false);
         });
 
-        test('should not render creation components if file is rotated', () => {
+        test('should render creation components when file is rotated', () => {
             const wrapper = getWrapper({
                 isCreating: true,
-                isRotated: true,
-                staged: {},
+                rotation: -90,
+                staged: getStaged(),
             });
 
-            expect(wrapper.exists(RegionCreator)).toBe(false);
-            expect(wrapper.exists(RegionRect)).toBe(false);
+            expect(wrapper.exists(RegionCreator)).toBe(true);
+            expect(wrapper.exists(RegionRect)).toBe(true);
         });
     });
 });

--- a/src/region/__tests__/RegionCreationContainer-test.tsx
+++ b/src/region/__tests__/RegionCreationContainer-test.tsx
@@ -70,20 +70,17 @@ describe('RegionCreationContainer', () => {
         );
 
         test.each`
-            rotation     | isRotated
-            ${null}      | ${false}
-            ${undefined} | ${false}
-            ${0}         | ${false}
-            ${90}        | ${true}
-            ${360}       | ${true}
-            ${-360}      | ${true}
-            ${-90}       | ${true}
-            ${-0}        | ${false}
-        `('should set the isRotated prop based on the rotation angle value', ({ isRotated, rotation }) => {
+            rotation
+            ${0}
+            ${90}
+            ${-90}
+            ${-180}
+            ${-270}
+        `('should pass rotation=$rotation to the underlying component', ({ rotation }) => {
             const store = createStore({ options: { rotation } });
             const wrapper = getWrapper({ store });
 
-            expect(wrapper.find(RegionCreation).prop('isRotated')).toEqual(isRotated);
+            expect(wrapper.find(RegionCreation).prop('rotation')).toEqual(rotation);
         });
     });
 });

--- a/src/region/__tests__/RegionCreationContainer-test.tsx
+++ b/src/region/__tests__/RegionCreationContainer-test.tsx
@@ -70,17 +70,22 @@ describe('RegionCreationContainer', () => {
         );
 
         test.each`
-            rotation
-            ${0}
-            ${90}
-            ${-90}
-            ${-180}
-            ${-270}
-        `('should pass rotation=$rotation to the underlying component', ({ rotation }) => {
+            rotation     | expected
+            ${null}      | ${null}
+            ${undefined} | ${0}
+            ${0}         | ${0}
+            ${-0}        | ${-0}
+            ${90}        | ${90}
+            ${-90}       | ${-90}
+            ${-180}      | ${-180}
+            ${-270}      | ${-270}
+            ${360}       | ${360}
+            ${-360}      | ${-360}
+        `('should pass rotation=$rotation as $expected to the underlying component', ({ rotation, expected }) => {
             const store = createStore({ options: { rotation } });
             const wrapper = getWrapper({ store });
 
-            expect(wrapper.find(RegionCreation).prop('rotation')).toEqual(rotation);
+            expect(wrapper.find(RegionCreation).prop('rotation')).toEqual(expected);
         });
     });
 });

--- a/src/region/__tests__/RegionCreator-test.tsx
+++ b/src/region/__tests__/RegionCreator-test.tsx
@@ -34,6 +34,9 @@ describe('RegionCreator', () => {
     // Render helpers
     const getWrapper = (props = {}): ReactWrapper => mount(<RegionCreator {...defaults} {...props} />);
 
+    let origOffsetWidth: PropertyDescriptor | undefined;
+    let origOffsetHeight: PropertyDescriptor | undefined;
+
     beforeEach(() => {
         jest.useFakeTimers();
 
@@ -42,8 +45,16 @@ describe('RegionCreator', () => {
         jest.spyOn(document, 'removeEventListener');
         jest.spyOn(window, 'cancelAnimationFrame');
         jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => setTimeout(cb, 100)); // 10 fps
+
+        origOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
+        origOffsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
         Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, get: () => 1000 });
         Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => 1000 });
+    });
+
+    afterEach(() => {
+        if (origOffsetWidth) Object.defineProperty(HTMLElement.prototype, 'offsetWidth', origOffsetWidth);
+        if (origOffsetHeight) Object.defineProperty(HTMLElement.prototype, 'offsetHeight', origOffsetHeight);
     });
 
     describe('mouse events', () => {

--- a/src/region/__tests__/RegionCreator-test.tsx
+++ b/src/region/__tests__/RegionCreator-test.tsx
@@ -42,6 +42,8 @@ describe('RegionCreator', () => {
         jest.spyOn(document, 'removeEventListener');
         jest.spyOn(window, 'cancelAnimationFrame');
         jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => setTimeout(cb, 100)); // 10 fps
+        Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, get: () => 1000 });
+        Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => 1000 });
     });
 
     describe('mouse events', () => {

--- a/src/utils/__tests__/rotate-test.ts
+++ b/src/utils/__tests__/rotate-test.ts
@@ -1,4 +1,4 @@
-import { getPoints, getRotatedShape, selectTransformationPoint } from '../../utils/rotate';
+import { getElementLocalPosition, getPoints, getRotatedShape, selectTransformationPoint } from '../../utils/rotate';
 
 describe('rotate', () => {
     const parseValue = (value: number): number => parseFloat(value.toFixed(3));
@@ -32,6 +32,53 @@ describe('rotate', () => {
                 expect(selectTransformationPoint(shape, rotation)).toEqual(expectedPoint);
             },
         );
+    });
+
+    describe('getElementLocalPosition()', () => {
+        const createElement = (width: number, height: number, rect: Partial<DOMRect> = {}) => {
+            const el = document.createElement('div');
+            Object.defineProperty(el, 'offsetWidth', { get: () => width });
+            Object.defineProperty(el, 'offsetHeight', { get: () => height });
+            jest.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+                left: 0,
+                top: 0,
+                right: width,
+                bottom: height,
+                width,
+                height,
+                x: 0,
+                y: 0,
+                toJSON: jest.fn(),
+                ...rect,
+            });
+            return el;
+        };
+
+        test.each`
+            rotation | clientX | clientY | rectWidth | rectHeight | expectedX | expectedY
+            ${0}     | ${75}   | ${55}   | ${100}    | ${100}     | ${75}     | ${55}
+            ${-90}   | ${0}    | ${0}    | ${100}    | ${100}     | ${100}    | ${0}
+            ${-180}  | ${25}   | ${25}   | ${100}    | ${100}     | ${75}     | ${75}
+            ${-270}  | ${75}   | ${25}   | ${100}    | ${100}     | ${25}     | ${25}
+        `(
+            'should map window coords ($clientX, $clientY) to element-local coords ($expectedX, $expectedY) at rotation=$rotation',
+            ({ rotation, clientX, clientY, rectWidth, rectHeight, expectedX, expectedY }) => {
+                const el = createElement(100, 100, { left: 0, top: 0, width: rectWidth, height: rectHeight });
+                const [x, y] = getElementLocalPosition(clientX, clientY, el, rotation);
+
+                expect(Math.round(x)).toBe(expectedX);
+                expect(Math.round(y)).toBe(expectedY);
+            },
+        );
+
+        test('should account for element screen offset', () => {
+            const el = createElement(100, 100, { left: 100, top: 200, width: 100, height: 100 });
+            // Click at center of element on screen → maps to center regardless of rotation
+            const [x, y] = getElementLocalPosition(150, 250, el, -90);
+
+            expect(Math.round(x)).toBe(50);
+            expect(Math.round(y)).toBe(50);
+        });
     });
 
     describe('getRotatedShape()', () => {

--- a/src/utils/__tests__/rotate-test.ts
+++ b/src/utils/__tests__/rotate-test.ts
@@ -79,6 +79,13 @@ describe('rotate', () => {
             expect(Math.round(x)).toBe(50);
             expect(Math.round(y)).toBe(50);
         });
+
+        test('should return raw coordinates when element is null', () => {
+            const [x, y] = getElementLocalPosition(123, 456, null, -90);
+
+            expect(x).toBe(123);
+            expect(y).toBe(456);
+        });
     });
 
     describe('getRotatedShape()', () => {

--- a/src/utils/__tests__/rotate-test.ts
+++ b/src/utils/__tests__/rotate-test.ts
@@ -35,7 +35,7 @@ describe('rotate', () => {
     });
 
     describe('getElementLocalPosition()', () => {
-        const createElement = (width: number, height: number, rect: Partial<DOMRect> = {}) => {
+        const createElement = (width: number, height: number, rect: Partial<DOMRect> = {}): HTMLElement => {
             const el = document.createElement('div');
             Object.defineProperty(el, 'offsetWidth', { get: () => width });
             Object.defineProperty(el, 'offsetHeight', { get: () => height });

--- a/src/utils/rotate.ts
+++ b/src/utils/rotate.ts
@@ -136,16 +136,22 @@ export function getRotatedPosition({ x, y }: Position, rotation: number): Positi
  *
  * When an element has a CSS rotation, its internal axes are rotated with it.
  * This function maps window coordinates to element-local coordinates.
- * 
+ *
+ * If element is null, returns the raw coordinates as a passthrough.
+ *
  * Assumes transform-origin: center (the CSS default), which matches how
  * box-content-preview applies rotation to annotation layers.
  */
 export function getElementLocalPosition(
     clientX: number,
     clientY: number,
-    element: HTMLElement,
+    element: HTMLElement | null,
     rotation: number,
 ): [number, number] {
+    if (!element) {
+        return [clientX, clientY];
+    }
+
     const rect = element.getBoundingClientRect();
 
     if (!rotation) {

--- a/src/utils/rotate.ts
+++ b/src/utils/rotate.ts
@@ -129,3 +129,37 @@ export function getRotatedPosition({ x, y }: Position, rotation: number): Positi
     const { x: rotatedX, y: rotatedY } = getRotatedShape({ height: 0, width: 0, x, y }, rotation);
     return { x: rotatedX, y: rotatedY };
 }
+
+/**
+ * Converts a mouse position (in browser window coordinates) to a position relative to
+ * a CSS-rotated element's own top-left corner.
+ *
+ * When an element has a CSS rotation, its internal axes are rotated with it.
+ * This function maps window coordinates to element-local coordinates.
+ */
+export function getElementLocalPosition(
+    clientX: number,
+    clientY: number,
+    element: HTMLElement,
+    rotation: number,
+): [number, number] {
+    const rect = element.getBoundingClientRect();
+
+    if (!rotation) {
+        return [clientX - rect.left, clientY - rect.top];
+    }
+
+    // 1. Find the element's center (rotation doesn't move the center)
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+
+    // 2. Get the mouse position relative to the center (in browser window coordinates)
+    const relX = clientX - centerX;
+    const relY = clientY - centerY;
+
+    // 3. Apply inverse rotation to obtain the mouse position from center in element-local coordinates
+    const local = rotatePoint({ x: relX, y: relY }, -rotation);
+
+    // 4. Convert coordinates from center-relative to top-left-relative
+    return [local.x + element.offsetWidth / 2, local.y + element.offsetHeight / 2];
+}

--- a/src/utils/rotate.ts
+++ b/src/utils/rotate.ts
@@ -136,6 +136,9 @@ export function getRotatedPosition({ x, y }: Position, rotation: number): Positi
  *
  * When an element has a CSS rotation, its internal axes are rotated with it.
  * This function maps window coordinates to element-local coordinates.
+ * 
+ * Assumes transform-origin: center (the CSS default), which matches how
+ * box-content-preview applies rotation to annotation layers.
  */
 export function getElementLocalPosition(
     clientX: number,


### PR DESCRIPTION
## Summary
Adds support for live annotation drawing on rotated pages/images. This is in preparation for enabling annotation creation on rotated PDFs and images, where the annotation controls were previously hidden. Without this change, simply re-enabling annotation creation controls in the rotated state would cause the live drawing input to be offset from the user’s cursor.

This PR:
  - Correctly maps window/browser mouse coordinates to annotation layer's local coordinate system, ensuring that live drawing/region input is correct when files are rotated
  - Uses `offsetWidth`/`offsetHeight` (pre-transform dimensions) for percentage instead of `getBoundingClientRect()` which returns post-transform axis-aligned bounding box dimensions
  -  Removes the `isRotated` guard that blocked region annotation creation on rotated files

For further clarity, here is the live pointer capture flow when drawing annotations:
1. Mouse events provide clientX/clientY coordinates in screen space.
2. `getPosition` applies the inverse rotation transform to convert window/browser coordinates into the annotation layer’s local coordinate space.
3. `getPoints`/`getShape` normalize those local-space pixel coordinates into percentages using the annotation layer’s pre-transform (unrotated) `offsetWidth`/`offsetHeight`.

## Test plan
- [ ] Rotate a PDF 90°, 180°, 270° counterclockwise and verify drawing annotations follow the cursor
- [ ] Rotate an image 90°, 180°, 270° and verify region annotations follow the cursor
- [ ] Verify annotations on unrotated (0°) files still work correctly
- [ ] Verify stored annotations remain anchored to content when rotation changes