### PR TITLE
fix(popup): portal annotation popup toolbar and reply so it stays upright on rotate

### DIFF
--- a/src/common/BaseAnnotator.scss
+++ b/src/common/BaseAnnotator.scss
@@ -28,3 +28,14 @@
 .ba-Layer--popup {
     z-index: 4;
 }
+
+.ba-PopupPortal {
+    position: relative;
+    z-index: 10;
+    pointer-events: none;
+
+    .ba-Popup {
+        z-index: 150;
+        pointer-events: auto;
+    }
+}

--- a/src/common/DeselectListener.tsx
+++ b/src/common/DeselectListener.tsx
@@ -8,7 +8,7 @@ export default function DeselectListener(): null {
     React.useEffect(() => {
         const handleMouseDown = (event: MouseEvent): void => {
             // Popup is portaled outside .ba-Layer; native mousedown still bubbles here.
-            if ((event.target as Element | null)?.closest?.('.ba-PopupV2')) return;
+            if ((event.target as Element | null)?.closest?.('.ba-PopupV2, .ba-Popup')) return;
             dispatch(setActiveAnnotationIdAction(null));
         };
 

--- a/src/components/Popups/PopupDrawingToolbar.tsx
+++ b/src/components/Popups/PopupDrawingToolbar.tsx
@@ -34,12 +34,6 @@ export type Props = {
 const options: Partial<Options> = {
     modifiers: [
         {
-            name: 'eventListeners',
-            options: {
-                scroll: false,
-            },
-        },
-        {
             name: 'offset',
             options: {
                 offset: ({ popper }: { popper: Rect }) => [-popper.width / 2, 8],

--- a/src/components/Popups/PopupDrawingToolbar.tsx
+++ b/src/components/Popups/PopupDrawingToolbar.tsx
@@ -42,7 +42,6 @@ const options: Partial<Options> = {
         {
             name: 'preventOverflow',
             options: {
-                altAxis: true,
                 padding: 50,
             },
         },

--- a/src/document/DocumentAnnotator.ts
+++ b/src/document/DocumentAnnotator.ts
@@ -105,7 +105,6 @@ export default class DocumentAnnotator extends BaseAnnotator {
             managers.add(new PopupManager({ location: pageNumber, popupPortalEl: this.popupPortalEl, referenceEl: pageReferenceEl, resinTags }));
             managers.add(new DrawingManager({ location: pageNumber, popupPortalEl: this.popupPortalEl, referenceEl: pageReferenceEl, resinTags }));
 
-
             const textLayer = pageEl.querySelector('.textLayer') as HTMLElement;
 
             if (textLayer) {

--- a/src/document/DocumentAnnotator.ts
+++ b/src/document/DocumentAnnotator.ts
@@ -103,7 +103,8 @@ export default class DocumentAnnotator extends BaseAnnotator {
 
             // Annotations mode
             managers.add(new PopupManager({ location: pageNumber, popupPortalEl: this.popupPortalEl, referenceEl: pageReferenceEl, resinTags }));
-            managers.add(new DrawingManager({ location: pageNumber, referenceEl: pageReferenceEl, resinTags }));
+            managers.add(new DrawingManager({ location: pageNumber, popupPortalEl: this.popupPortalEl, referenceEl: pageReferenceEl, resinTags }));
+
 
             const textLayer = pageEl.querySelector('.textLayer') as HTMLElement;
 

--- a/src/drawing/DrawingAnnotations.tsx
+++ b/src/drawing/DrawingAnnotations.tsx
@@ -179,8 +179,8 @@ const DrawingAnnotations = (props: Props): JSX.Element => {
                 />
             )}
 
-            {isCreating && hasPathGroups && drawingSVGGroup && canShowPopupToolbar && (() => {
-                const toolbar = (
+            {isCreating && hasPathGroups && drawingSVGGroup && canShowPopupToolbar && popupPortalEl &&
+                ReactDOM.createPortal(
                     <PopupDrawingToolbar
                         ref={popupDrawingToolbarRef}
                         canComment={hasDrawnPathGroups}
@@ -192,10 +192,9 @@ const DrawingAnnotations = (props: Props): JSX.Element => {
                         onReply={handleReply}
                         onUndo={handleUndo}
                         reference={drawingSVGGroup}
-                    />
-                );
-                return popupPortalEl ? ReactDOM.createPortal(toolbar, popupPortalEl) : toolbar;
-            })()}
+                    />,
+                    popupPortalEl,
+                )}
         </>
     );
 };

--- a/src/drawing/DrawingAnnotations.tsx
+++ b/src/drawing/DrawingAnnotations.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import DecoratedDrawingPath from './DecoratedDrawingPath';
 import DrawingList from './DrawingList';
@@ -22,6 +23,7 @@ export type Props = {
     drawnPathGroups: Array<PathGroup>;
     isCreating: boolean;
     location: number;
+    popupPortalEl?: HTMLElement | null;
     redoDrawingPathGroup: () => void;
     resetDrawing: () => void;
     rotation: number;
@@ -46,6 +48,7 @@ const DrawingAnnotations = (props: Props): JSX.Element => {
         drawnPathGroups,
         isCreating,
         location,
+        popupPortalEl,
         redoDrawingPathGroup,
         resetDrawing,
         rotation,
@@ -176,20 +179,23 @@ const DrawingAnnotations = (props: Props): JSX.Element => {
                 />
             )}
 
-            {isCreating && hasPathGroups && drawingSVGGroup && canShowPopupToolbar && (
-                <PopupDrawingToolbar
-                    ref={popupDrawingToolbarRef}
-                    canComment={hasDrawnPathGroups}
-                    canRedo={hasStashedPathGroups}
-                    canUndo={hasDrawnPathGroups}
-                    className={classNames('ba-DrawingAnnotations-toolbar', { 'ba-is-drawing': isDrawing })}
-                    onDelete={handleDelete}
-                    onRedo={handleRedo}
-                    onReply={handleReply}
-                    onUndo={handleUndo}
-                    reference={drawingSVGGroup}
-                />
-            )}
+            {isCreating && hasPathGroups && drawingSVGGroup && canShowPopupToolbar && (() => {
+                const toolbar = (
+                    <PopupDrawingToolbar
+                        ref={popupDrawingToolbarRef}
+                        canComment={hasDrawnPathGroups}
+                        canRedo={hasStashedPathGroups}
+                        canUndo={hasDrawnPathGroups}
+                        className={classNames('ba-DrawingAnnotations-toolbar', { 'ba-is-drawing': isDrawing })}
+                        onDelete={handleDelete}
+                        onRedo={handleRedo}
+                        onReply={handleReply}
+                        onUndo={handleUndo}
+                        reference={drawingSVGGroup}
+                    />
+                );
+                return popupPortalEl ? ReactDOM.createPortal(toolbar, popupPortalEl) : toolbar;
+            })()}
         </>
     );
 };

--- a/src/drawing/DrawingManager.tsx
+++ b/src/drawing/DrawingManager.tsx
@@ -1,9 +1,20 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
-import BaseManager, { Props } from '../common/BaseManager';
+import BaseManager, { Options as BaseOptions, Props } from '../common/BaseManager';
 import DrawingAnnotationsContainer from './DrawingAnnotationsContainer';
 
+export type Options = BaseOptions & {
+    popupPortalEl?: HTMLElement | null;
+};
+
 export default class DrawingListManager extends BaseManager {
+    popupPortalEl?: HTMLElement | null;
+
+    constructor({ popupPortalEl, ...options }: Options) {
+        super(options);
+        this.popupPortalEl = popupPortalEl;
+    }
+
     decorate(): void {
         this.reactEl.classList.add('ba-Layer--drawing');
         this.reactEl.dataset.testid = 'ba-Layer--drawing';
@@ -14,6 +25,6 @@ export default class DrawingListManager extends BaseManager {
             this.root = ReactDOM.createRoot(this.reactEl);
         }
 
-        this.root.render(<DrawingAnnotationsContainer referenceEl={this.referenceEl} targetType={this.targetType} location={this.location} {...props} />);
+        this.root.render(<DrawingAnnotationsContainer referenceEl={this.referenceEl} targetType={this.targetType} location={this.location} popupPortalEl={this.popupPortalEl} {...props} />);
     }
 }

--- a/src/drawing/__tests__/DrawingAnnotations-test.tsx
+++ b/src/drawing/__tests__/DrawingAnnotations-test.tsx
@@ -38,6 +38,7 @@ describe('DrawingAnnotations', () => {
         drawnPathGroups: [],
         isCreating: false,
         location: 0,
+        popupPortalEl: document.createElement('div'),
         redoDrawingPathGroup: jest.fn(),
         resetDrawing: jest.fn(),
         rotation: 0,
@@ -317,6 +318,35 @@ describe('DrawingAnnotations', () => {
                 expect(wrapper.find(PopupDrawingToolbar).prop('canUndo')).toBe(canUndo);
             },
         );
+    });
+
+    describe('popup portal', () => {
+        test('should render PopupDrawingToolbar into popupPortalEl', () => {
+            const popupPortalEl = document.createElement('div');
+            document.body.appendChild(popupPortalEl);
+
+            getWrapper({
+                canShowPopupToolbar: true,
+                drawnPathGroups: pathGroups,
+                isCreating: true,
+                popupPortalEl,
+            });
+
+            expect(popupPortalEl.querySelector('.ba-PopupDrawingToolbar')).toBeTruthy();
+
+            document.body.removeChild(popupPortalEl);
+        });
+
+        test('should not render PopupDrawingToolbar when popupPortalEl is missing', () => {
+            const wrapper = getWrapper({
+                canShowPopupToolbar: true,
+                drawnPathGroups: pathGroups,
+                isCreating: true,
+                popupPortalEl: null,
+            });
+
+            expect(wrapper.find(PopupDrawingToolbar).exists()).toBe(false);
+        });
     });
 
     // Use shared video annotation tests

--- a/src/image/ImageAnnotator.ts
+++ b/src/image/ImageAnnotator.ts
@@ -74,7 +74,8 @@ export default class ImageAnnotator extends BaseAnnotator {
             }
 
             this.managers.add(new PopupManager({ popupPortalEl: this.popupPortalEl, referenceEl, resinTags }));
-            this.managers.add(new DrawingManager({ referenceEl, resinTags }));
+            this.managers.add(new DrawingManager({ popupPortalEl: this.popupPortalEl, referenceEl, resinTags }));
+
             this.managers.add(new RegionManager({ referenceEl, resinTags }));
             this.managers.add(new RegionCreationManager({ referenceEl, resinTags }));
         }

--- a/src/image/ImageAnnotator.ts
+++ b/src/image/ImageAnnotator.ts
@@ -75,7 +75,6 @@ export default class ImageAnnotator extends BaseAnnotator {
 
             this.managers.add(new PopupManager({ popupPortalEl: this.popupPortalEl, referenceEl, resinTags }));
             this.managers.add(new DrawingManager({ popupPortalEl: this.popupPortalEl, referenceEl, resinTags }));
-
             this.managers.add(new RegionManager({ referenceEl, resinTags }));
             this.managers.add(new RegionCreationManager({ referenceEl, resinTags }));
         }

--- a/src/popup/PopupLayer.tsx
+++ b/src/popup/PopupLayer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import noop from 'lodash/noop';
 import PopupReply from '../components/Popups/PopupReply';
 import PopupV2 from '../components/Popups/PopupV2';
@@ -121,7 +122,7 @@ const PopupLayer = (props: Props): JSX.Element | null => {
     }
 
     if (showCreator) {
-        return (
+        const replyPopup = (
             <div className="ba-PopupLayer-popup">
                 <PopupReply
                     isPending={isPending}
@@ -133,6 +134,7 @@ const PopupLayer = (props: Props): JSX.Element | null => {
                 />
             </div>
         );
+        return popupPortalEl ? ReactDOM.createPortal(replyPopup, popupPortalEl) : replyPopup;
     }
 
     if (isThreadedAnnotation && activeAnnotationId && activeReference) {

--- a/src/popup/PopupLayer.tsx
+++ b/src/popup/PopupLayer.tsx
@@ -122,7 +122,8 @@ const PopupLayer = (props: Props): JSX.Element | null => {
     }
 
     if (showCreator) {
-        const replyPopup = (
+        if (!popupPortalEl) return null;
+        return ReactDOM.createPortal(
             <div className="ba-PopupLayer-popup">
                 <PopupReply
                     isPending={isPending}
@@ -132,9 +133,9 @@ const PopupLayer = (props: Props): JSX.Element | null => {
                     reference={reference}
                     value={message}
                 />
-            </div>
+            </div>,
+            popupPortalEl,
         );
-        return popupPortalEl ? ReactDOM.createPortal(replyPopup, popupPortalEl) : replyPopup;
     }
 
     if (isThreadedAnnotation && activeAnnotationId && activeReference) {

--- a/src/popup/__tests__/PopupLayer-test.tsx
+++ b/src/popup/__tests__/PopupLayer-test.tsx
@@ -56,6 +56,7 @@ describe('PopupLayer', () => {
     });
 
     const referenceId = '123';
+    const popupPortalEl = document.createElement('div');
     const getDefaults = (): Props => ({
         activeAnnotationId: null,
         createDrawing: jest.fn(),
@@ -65,6 +66,7 @@ describe('PopupLayer', () => {
         location: 1,
         message: '',
         mode: Mode.HIGHLIGHT,
+        popupPortalEl,
         referenceId: '123',
         resetCreator: jest.fn(),
         setMessage: jest.fn(),
@@ -75,6 +77,7 @@ describe('PopupLayer', () => {
 
     beforeEach(() => {
         document.body.innerHTML = `<div data-ba-reference-id="${referenceId}"></div>`;
+        document.body.appendChild(popupPortalEl);
         mockOnCancel = undefined;
         mockOnChange = undefined;
         mockOnSubmit = undefined;
@@ -148,6 +151,20 @@ describe('PopupLayer', () => {
             renderLayer();
             expect(screen.getByTestId('popup-reply')).toBeDefined();
             expect(screen.queryByTestId('popup-v2')).toBeNull();
+        });
+    });
+
+    describe('popup portal', () => {
+        test('should render PopupReply into popupPortalEl', () => {
+            renderLayer();
+
+            expect(popupPortalEl.querySelector('[data-testid="popup-reply"]')).toBeTruthy();
+        });
+
+        test('should render nothing when popupPortalEl is missing', () => {
+            renderLayer({ popupPortalEl: null });
+
+            expect(screen.queryByTestId('popup-reply')).toBeNull();
         });
     });
 


### PR DESCRIPTION
## Summary
- Portal `PopupDrawingToolbar` and `PopupReply` to the `popupPortalEl` container (outside the rotating `.ba-Layer`) so they remain upright when the page is rotated, matching the existing `PopupV2` approach
- Fix `PopupDrawingToolbar` Popper.js options so the toolbar correctly follows its annotation on scroll and doesn't stick to the viewport edge
- Prevent `DeselectListener` from deselecting annotations when clicking portaled popup elements

## Details
When the page is rotated, annotation layers receive `transform: rotate(Xdeg)`, causing all children to rotate. `PopupV2` already solved this via portaling, but `PopupDrawingToolbar` and `PopupReply` still rotated with their layers.

**Portaling changes:**
- Pass popupPortalEl through DrawingManager → DrawingAnnotationsContainer → DrawingAnnotations for both DocumentAnnotator and ImageAnnotator
- Wrap PopupDrawingToolbar and PopupReply in ReactDOM.createPortal() targeting popupPortalEl
- Return null if popupPortalEl is unavailable (no fallback to inline rendering)

**Stacking context fix:**
- Add position: relative; z-index: 10; pointer-events: none to .ba-PopupPortal so portaled popups render above the drawing layer's full-page click overlay
- Set pointer-events: auto on .ba-Popup children so they receive clicks

**Popper.js behavioral fixes:**
- Remove scroll: false from eventListeners modifier — now that the toolbar is outside the scroll container, Popper must actively reposition on scroll
- Remove altAxis: true from preventOverflow — this was clamping the toolbar to the viewport edge vertically instead of letting it scroll away with the annotation

**Deselect fix:**
- Add .ba-Popup to the DeselectListener closest-check so clicks on portaled popups don't trigger annotation deselection

## Test plan
- [ ] Unit tests pass (160 tests across 9 suites)
- [ ] Rotate a PDF 90/180/270°, enter drawing mode, draw a shape — toolbar stays upright and positioned near the drawing
- [ ] Click "Add Comment" — reply popup stays upright
- [ ] Scroll while toolbar is visible — toolbar follows the annotation and disappears off-screen with it
- [ ] Test the same on images (not just PDFs)
- [ ] Click outside a popup — annotation correctly deselects
- [ ] Click popup buttons (undo/redo/delete/Add Comment) — all register correctly

