### PR TITLE
fix(popup): Wrap PopupV2 content in TooltipProvider

### DIFF
--- a/src/components/Popups/PopupV2.tsx
+++ b/src/components/Popups/PopupV2.tsx
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { BlueprintModernizationProvider } from '@box/blueprint-web';
+import { BlueprintModernizationProvider, TooltipProvider } from '@box/blueprint-web';
 import {
     MentionContextProvider,
     MessageEditorV2,
@@ -281,34 +281,36 @@ const PopupV2 = ({ annotationId, onSubmit, popupPortalEl, reference }: Props): J
                 role="presentation"
             >
                 <BlueprintModernizationProvider enableModernizedComponents>
-                    <MentionContextProvider value={{
-                        collaborationPopoverProps: {
-                            onSubmit: () => Promise.resolve(),
-                        },
-                    }}>
-                        {annotationId ? (
-                            <ThreadedAnnotationsV2
-                                isAnnotations
-                                isResolved={isResolved}
-                                messages={threadMessages}
-                                onAvatarClick={noop}
-                                onDelete={noop}
-                                onPost={handlePost}
-                                onResolve={handleResolve}
-                                onThreadDelete={handleThreadDelete}
-                                onUnresolve={handleUnresolve}
-                                resolvedAt={resolvedAt}
-                                resolvedBy={resolvedBy}
-                                userSelectorProps={userSelectorProps}
-                            />
-                        ) : (
-                            <MessageEditorV2
-                                isFirstAnnotation
-                                onPost={handlePost}
-                                userSelectorProps={userSelectorProps}
-                            />
-                        )}
-                    </MentionContextProvider>
+                    <TooltipProvider>
+                        <MentionContextProvider value={{
+                            collaborationPopoverProps: {
+                                onSubmit: () => Promise.resolve(),
+                            },
+                        }}>
+                            {annotationId ? (
+                                <ThreadedAnnotationsV2
+                                    isAnnotations
+                                    isResolved={isResolved}
+                                    messages={threadMessages}
+                                    onAvatarClick={noop}
+                                    onDelete={noop}
+                                    onPost={handlePost}
+                                    onResolve={handleResolve}
+                                    onThreadDelete={handleThreadDelete}
+                                    onUnresolve={handleUnresolve}
+                                    resolvedAt={resolvedAt}
+                                    resolvedBy={resolvedBy}
+                                    userSelectorProps={userSelectorProps}
+                                />
+                            ) : (
+                                <MessageEditorV2
+                                    isFirstAnnotation
+                                    onPost={handlePost}
+                                    userSelectorProps={userSelectorProps}
+                                />
+                            )}
+                        </MentionContextProvider>
+                    </TooltipProvider>
                 </BlueprintModernizationProvider>
                 <div data-threaded-annotations-portal />
             </div>

--- a/src/components/Popups/__tests__/PopupV2-test.tsx
+++ b/src/components/Popups/__tests__/PopupV2-test.tsx
@@ -24,6 +24,7 @@ jest.mock('box-ui-elements/es/components/focus-trap/FocusTrap', () => {
 
 jest.mock('@box/blueprint-web', () => ({
     BlueprintModernizationProvider: ({ children }: { children: React.ReactNode }) => children,
+    TooltipProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
 jest.mock('@box/threaded-annotations', () => {


### PR DESCRIPTION
## Summary
- Wraps the `PopupV2` tree in `<TooltipProvider>` so tooltips inside `ThreadedAnnotationsV2` and `MessageEditorV2` render with a valid tooltip context.
- Updates the `@box/blueprint-web` mock in `PopupV2-test.tsx` to export `TooltipProvider`.

## Test plan
- [ ] `yarn test --watchAll=false --testPathPattern="Popups/__tests__/PopupV2"` passes
- [ ] Manually verify tooltips inside the threaded annotation popup render correctly