### PR TITLE
feat(annotations): support highlight/text annotations on rotated docs

### DIFF
--- a/src/document/DocumentAnnotator.ts
+++ b/src/document/DocumentAnnotator.ts
@@ -118,7 +118,7 @@ export default class DocumentAnnotator extends BaseAnnotator {
                 );
             }
 
-            managers.add(new HighlightManager({ location: pageNumber, referenceEl: pageReferenceEl, resinTags }));
+            managers.add(new HighlightManager({ location: pageNumber, popupPortalEl: this.popupPortalEl, referenceEl: pageReferenceEl, resinTags }));
             managers.add(new RegionManager({ location: pageNumber, referenceEl: pageReferenceEl, resinTags }));
 
             const canvasLayerEl = pageEl.querySelector<HTMLElement>('.canvasWrapper');

--- a/src/document/docUtil.ts
+++ b/src/document/docUtil.ts
@@ -1,4 +1,5 @@
 type Selection = {
+    containerEl: HTMLElement;
     containerRect: DOMRect;
     hasError?: boolean;
     location: number;
@@ -61,5 +62,5 @@ export function getSelection(): Selection | null {
         location = getPageNumber(selection.focusNode as Element) ?? endPage;
     }
 
-    return { containerRect: containerEl.getBoundingClientRect(), hasError, location, range };
+    return { containerEl: containerEl as HTMLElement, containerRect: containerEl.getBoundingClientRect(), hasError, location, range };
 }

--- a/src/highlight/HighlightAnnotations.tsx
+++ b/src/highlight/HighlightAnnotations.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import ReactDOM from 'react-dom';
 import HighlightCanvas from './HighlightCanvas';
 import HighlightList from './HighlightList';
 import HighlightSvg from './HighlightSvg';
@@ -20,6 +21,8 @@ type Props = {
     isPromoting: boolean;
     isSelecting: boolean;
     location: number;
+    popupPortalEl?: HTMLElement | null;
+    rotation: number;
     selection: SelectionItem | null;
     setActiveAnnotationId: (annotationId: string | null) => void;
     setIsPromoting: (isPromoting: boolean) => void;
@@ -38,6 +41,8 @@ const HighlightAnnotations = (props: Props): JSX.Element => {
         isPending = false,
         isPromoting = false,
         isSelecting = false,
+        popupPortalEl,
+        rotation,
         selection,
         setActiveAnnotationId,
         setIsPromoting,
@@ -121,22 +126,30 @@ const HighlightAnnotations = (props: Props): JSX.Element => {
             )}
 
             {/* Layer 3a: Annotations promoter to promote selection to staged */}
-            {!isCreating && selection && !selection.hasError && (
-                <div className="ba-HighlightAnnotations-popup">
-                    <PopupHighlight
-                        onCancel={handleCancel}
-                        onSubmit={handlePromote}
-                        shape={getBoundingRect(selection.rects)}
-                    />
-                </div>
-            )}
+            {!isCreating && selection && !selection.hasError && (() => {
+                const popupShape = selection.popupRect || getBoundingRect(selection.rects);
+                const popup = (
+                    <div className="ba-HighlightAnnotations-popup">
+                        <PopupHighlight
+                            onCancel={handleCancel}
+                            onSubmit={handlePromote}
+                            shape={popupShape}
+                        />
+                    </div>
+                );
+                return rotation && popupPortalEl ? ReactDOM.createPortal(popup, popupPortalEl) : popup;
+            })()}
 
             {/* Layer 3b: Highlight error popup */}
-            {selection && selection.hasError && (
-                <div className="ba-HighlightAnnotations-popup">
-                    <PopupHighlightError onCancel={handleCancel} shape={getBoundingRect(selection.rects)} />
-                </div>
-            )}
+            {selection && selection.hasError && (() => {
+                const popupShape = selection.popupRect || getBoundingRect(selection.rects);
+                const popup = (
+                    <div className="ba-HighlightAnnotations-popup">
+                        <PopupHighlightError onCancel={handleCancel} shape={popupShape} />
+                    </div>
+                );
+                return rotation && popupPortalEl ? ReactDOM.createPortal(popup, popupPortalEl) : popup;
+            })()}
         </>
     );
 };

--- a/src/highlight/HighlightContainer.tsx
+++ b/src/highlight/HighlightContainer.tsx
@@ -13,6 +13,7 @@ import {
     getCreatorStatus,
     getIsPromoting,
     getIsSelecting,
+    getRotation,
     getSelectionForLocation,
     isCreatorStagedHighlight,
     Mode,
@@ -33,6 +34,7 @@ export type Props = {
     isPending: boolean;
     isPromoting: boolean;
     isSelecting: boolean;
+    rotation: number;
     selection: SelectionItem | null;
     staged: CreatorItemHighlight | null;
 };
@@ -47,6 +49,7 @@ export const mapStateToProps = (state: AppState, { location }: { location: numbe
         isPending: getCreatorStatus(state) === CreatorStatus.pending,
         isPromoting: getIsPromoting(state),
         isSelecting: getIsSelecting(state),
+        rotation: getRotation(state),
         selection: getSelectionForLocation(state, location),
         staged: isCreatorStagedHighlight(staged) ? staged : null,
     };

--- a/src/highlight/HighlightCreatorManager.ts
+++ b/src/highlight/HighlightCreatorManager.ts
@@ -1,6 +1,7 @@
 import {
     AppStore,
     getIsSelecting,
+    getRotation,
     SelectionArg as Selection,
     setIsSelectingAction,
     setSelectionAction,
@@ -41,18 +42,18 @@ export default class HighlightCreatorManager implements Manager {
         this.store.dispatch(setSelectionAction(null));
 
         this.referenceEl.addEventListener('mousedown', this.handleMouseDown);
-        this.referenceEl.addEventListener('mouseup', this.handleMouseUp);
+        document.addEventListener('mouseup', this.handleMouseUp);
     }
 
-    style(styles: Partial<CSSStyleDeclaration>): CSSStyleDeclaration {
-        return Object.assign(this.referenceEl.style, styles);
+    style(): CSSStyleDeclaration {
+        return this.referenceEl.style;
     }
 
     destroy(): void {
         clearTimeout(this.selectionChangeTimer);
 
         this.referenceEl.removeEventListener('mousedown', this.handleMouseDown);
-        this.referenceEl.removeEventListener('mouseup', this.handleMouseUp);
+        document.removeEventListener('mouseup', this.handleMouseUp);
     }
 
     handleMouseDown = ({ buttons }: MouseEvent): void => {
@@ -72,7 +73,9 @@ export default class HighlightCreatorManager implements Manager {
         }
 
         this.selectionChangeTimer = window.setTimeout(() => {
-            this.store.dispatch(setSelectionAction(this.getSelection()));
+            const selection = this.getSelection();
+            const rotation = getRotation(this.store.getState());
+            this.store.dispatch(setSelectionAction(selection ? { ...selection, rotation } : null));
             this.store.dispatch(setIsSelectingAction(false));
         }, this.selectionChangeDelay);
     };

--- a/src/highlight/HighlightListener.ts
+++ b/src/highlight/HighlightListener.ts
@@ -1,5 +1,5 @@
 import debounce from 'lodash/debounce';
-import { AppStore, getIsSelecting, SelectionArg as Selection, setSelectionAction } from '../store';
+import { AppStore, getIsSelecting, getRotation, SelectionArg as Selection, setSelectionAction } from '../store';
 
 export type Options = {
     getSelection: () => Selection | null;
@@ -30,7 +30,9 @@ export default class HighlightListener {
             return;
         }
 
-        this.store.dispatch(setSelectionAction(this.getSelection()));
+        const selection = this.getSelection();
+        const rotation = getRotation(this.store.getState());
+        this.store.dispatch(setSelectionAction(selection ? { ...selection, rotation } : null));
     };
 
     debounceHandleSelectionChange = debounce(this.handleSelectionChange, SELECTION_CHANGE_DEBOUNCE);

--- a/src/highlight/HighlightManager.tsx
+++ b/src/highlight/HighlightManager.tsx
@@ -1,9 +1,20 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
-import BaseManager, { Props } from '../common/BaseManager';
+import BaseManager, { Options as BaseOptions, Props } from '../common/BaseManager';
 import HighlightContainer from './HighlightContainer';
 
+export type Options = BaseOptions & {
+    popupPortalEl?: HTMLElement | null;
+};
+
 export default class HighlightManager extends BaseManager {
+    popupPortalEl?: HTMLElement | null;
+
+    constructor({ popupPortalEl, ...options }: Options) {
+        super(options);
+        this.popupPortalEl = popupPortalEl;
+    }
+
     decorate(): void {
         this.reactEl.classList.add('ba-Layer--highlight');
         this.reactEl.dataset.testid = 'ba-Layer--highlight';
@@ -14,6 +25,6 @@ export default class HighlightManager extends BaseManager {
             this.root = ReactDOM.createRoot(this.reactEl);
         }
 
-        this.root.render(<HighlightContainer location={this.location} {...props} />);
+        this.root.render(<HighlightContainer location={this.location} popupPortalEl={this.popupPortalEl} {...props} />);
     }
 }

--- a/src/highlight/__tests__/HighlightAnnotations-test.tsx
+++ b/src/highlight/__tests__/HighlightAnnotations-test.tsx
@@ -26,6 +26,8 @@ describe('HighlightAnnotations', () => {
         isPromoting: false,
         isSelecting: false,
         location: 1,
+        popupPortalEl: null as HTMLElement | null,
+        rotation: 0,
         selection: null,
         setActiveAnnotationId: jest.fn(),
         setIsPromoting: jest.fn(),
@@ -222,6 +224,71 @@ describe('HighlightAnnotations', () => {
                 });
                 expect(defaults.setStatus).toHaveBeenCalledWith(CreatorStatus.staged);
             });
+        });
+    });
+
+    describe('popup portal (rotation)', () => {
+        let popupPortalEl: HTMLElement;
+
+        beforeEach(() => {
+            popupPortalEl = document.createElement('div');
+            document.body.appendChild(popupPortalEl);
+        });
+
+        afterEach(() => {
+            document.body.removeChild(popupPortalEl);
+        });
+
+        test('should portal PopupHighlight into popupPortalEl when rotated', () => {
+            getWrapper({
+                rotation: -90,
+                popupPortalEl,
+                selection: selectionMock,
+            });
+
+            expect(popupPortalEl.querySelector('.ba-HighlightAnnotations-popup')).toBeTruthy();
+        });
+
+        test('should portal PopupHighlightError into popupPortalEl when rotated', () => {
+            getWrapper({
+                rotation: -90,
+                popupPortalEl,
+                selection: { ...selectionMock, hasError: true },
+            });
+
+            expect(popupPortalEl.querySelector('.ba-HighlightAnnotations-popup')).toBeTruthy();
+        });
+
+        test('should render PopupHighlight inline when rotation is 0', () => {
+            const wrapper = getWrapper({
+                rotation: 0,
+                popupPortalEl,
+                selection: selectionMock,
+            });
+
+            expect(wrapper.exists(PopupHighlight)).toBe(true);
+            expect(popupPortalEl.querySelector('.ba-HighlightAnnotations-popup')).toBeNull();
+        });
+
+        test('should render PopupHighlight inline when popupPortalEl is not provided', () => {
+            const wrapper = getWrapper({
+                rotation: -90,
+                popupPortalEl: null,
+                selection: selectionMock,
+            });
+
+            expect(wrapper.exists(PopupHighlight)).toBe(true);
+        });
+
+        test('should use popupRect for popup positioning when available', () => {
+            const popupRect = { x: 50, y: 60, width: 200, height: 30 };
+            getWrapper({
+                rotation: -90,
+                popupPortalEl,
+                selection: { ...selectionMock, popupRect },
+            });
+
+            expect(popupPortalEl.querySelector('.ba-HighlightAnnotations-popup')).toBeTruthy();
         });
     });
 });

--- a/src/highlight/__tests__/HighlightCreatorManager-test.ts
+++ b/src/highlight/__tests__/HighlightCreatorManager-test.ts
@@ -46,12 +46,13 @@ describe('HighlightCreatorManager', () => {
             wrapper.selectionChangeTimer = 1;
 
             jest.spyOn(mockReferenceEl, 'removeEventListener');
+            jest.spyOn(document, 'removeEventListener');
 
             wrapper.destroy();
 
             expect(clearTimeout).toHaveBeenCalledWith(1);
             expect(mockReferenceEl.removeEventListener).toHaveBeenCalledWith('mousedown', wrapper.handleMouseDown);
-            expect(mockReferenceEl.removeEventListener).toHaveBeenCalledWith('mouseup', wrapper.handleMouseUp);
+            expect(document.removeEventListener).toHaveBeenCalledWith('mouseup', wrapper.handleMouseUp);
         });
     });
 
@@ -71,12 +72,13 @@ describe('HighlightCreatorManager', () => {
             wrapper.referenceEl = mockReferenceEl;
 
             jest.spyOn(mockReferenceEl, 'addEventListener');
+            jest.spyOn(document, 'addEventListener');
 
             wrapper.render();
 
             expect(defaults.store.dispatch).toHaveBeenCalled();
             expect(mockReferenceEl.addEventListener).toHaveBeenCalledWith('mousedown', wrapper.handleMouseDown);
-            expect(mockReferenceEl.addEventListener).toHaveBeenCalledWith('mouseup', wrapper.handleMouseUp);
+            expect(document.addEventListener).toHaveBeenCalledWith('mouseup', wrapper.handleMouseUp);
         });
     });
 

--- a/src/store/__mocks__/index.ts
+++ b/src/store/__mocks__/index.ts
@@ -16,6 +16,7 @@ module.exports = {
     getIsInitialized: jest.fn().mockReturnValue(false),
     getIsPromoting: jest.fn().mockReturnValue(false),
     getIsSelecting: jest.fn().mockReturnValue(false),
+    getRotation: jest.fn().mockReturnValue(0),
     getSelectionForLocation: jest.fn(),
     isCreatorStagedHighlight,
     isCreatorStagedRegion,

--- a/src/store/highlight/__mocks__/data.ts
+++ b/src/store/highlight/__mocks__/data.ts
@@ -30,3 +30,23 @@ export const mockRange: Range = ({
     getClientRects: () => [mockDOMRect],
     startContainer: mockTextNode,
 } as unknown) as Range;
+
+// Simulates an 800x600 element rotated -90deg (appears as 600x800 on screen)
+export const mockRotatedContainerEl = (() => {
+    const el = document.createElement('div');
+    Object.defineProperty(el, 'offsetWidth', { value: 800, configurable: true });
+    Object.defineProperty(el, 'offsetHeight', { value: 600, configurable: true });
+    return el;
+})();
+
+export const mockRotatedContainerRect: DOMRect = {
+    left: 100,
+    top: 50,
+    width: 600,
+    height: 800,
+    right: 700,
+    bottom: 850,
+    x: 100,
+    y: 50,
+    toJSON: jest.fn(),
+};

--- a/src/store/highlight/__mocks__/highlightState.ts
+++ b/src/store/highlight/__mocks__/highlightState.ts
@@ -18,4 +18,27 @@ export default {
             },
         ],
     },
+    rotatedSelection: {
+        containerRect: {
+            height: 600,
+            width: 800,
+            x: 0,
+            y: 0,
+        },
+        location: 1,
+        popupRect: {
+            height: 100,
+            width: 100,
+            x: 200,
+            y: 200,
+        },
+        rects: [
+            {
+                height: 100,
+                width: 100,
+                x: 550,
+                y: 100,
+            },
+        ],
+    },
 };

--- a/src/store/highlight/__tests__/actions-test.ts
+++ b/src/store/highlight/__tests__/actions-test.ts
@@ -72,9 +72,9 @@ describe('store/highlight/actions', () => {
                 expect(rect.width).toBeCloseTo(state.rotatedSelection.rects[0].width);
                 expect(rect.height).toBeCloseTo(state.rotatedSelection.rects[0].height);
 
-                expect(result.payload.containerRect).toEqual(state.rotatedSelection.containerRect);
-                expect(result.payload.popupRect).toEqual(state.rotatedSelection.popupRect);
-                expect(result.payload.location).toEqual(state.rotatedSelection.location);
+                expect(result.payload!.containerRect).toEqual(state.rotatedSelection.containerRect);
+                expect(result.payload!.popupRect).toEqual(state.rotatedSelection.popupRect);
+                expect(result.payload!.location).toEqual(state.rotatedSelection.location);
             });
 
             test('should prepare correct argument when rotation is 0', () => {

--- a/src/store/highlight/__tests__/actions-test.ts
+++ b/src/store/highlight/__tests__/actions-test.ts
@@ -1,5 +1,5 @@
 import state from '../__mocks__/highlightState';
-import { mockContainerRect, mockDOMRect, mockRange } from '../__mocks__/data';
+import { mockContainerRect, mockDOMRect, mockRange, mockRotatedContainerEl, mockRotatedContainerRect } from '../__mocks__/data';
 import { setSelectionAction } from '../actions';
 
 describe('store/highlight/actions', () => {
@@ -41,6 +41,66 @@ describe('store/highlight/actions', () => {
             expect(setSelectionAction(newArg)).toEqual({
                 payload: state.selection,
                 type: 'SET_SELECTION',
+            });
+        });
+
+        test('should return null payload when arg is null', () => {
+            expect(setSelectionAction(null)).toEqual({
+                payload: null,
+                type: 'SET_SELECTION',
+            });
+        });
+
+        describe('with rotation', () => {
+            beforeEach(() => {
+                jest.spyOn(mockRotatedContainerEl, 'getBoundingClientRect').mockReturnValue(mockRotatedContainerRect);
+            });
+
+            test('should prepare correct argument when rotated', () => {
+                const rotatedArg = {
+                    ...arg,
+                    containerEl: mockRotatedContainerEl,
+                    rotation: -90,
+                };
+
+                const result = setSelectionAction(rotatedArg);
+
+                // we use toBeCloseTo for rects due to floating-point tolerance from trig calculations
+                const rect = result.payload!.rects[0];
+                expect(rect.x).toBeCloseTo(state.rotatedSelection.rects[0].x);
+                expect(rect.y).toBeCloseTo(state.rotatedSelection.rects[0].y);
+                expect(rect.width).toBeCloseTo(state.rotatedSelection.rects[0].width);
+                expect(rect.height).toBeCloseTo(state.rotatedSelection.rects[0].height);
+
+                expect(result.payload.containerRect).toEqual(state.rotatedSelection.containerRect);
+                expect(result.payload.popupRect).toEqual(state.rotatedSelection.popupRect);
+                expect(result.payload.location).toEqual(state.rotatedSelection.location);
+            });
+
+            test('should prepare correct argument when rotation is 0', () => {
+                const noRotationArg = {
+                    ...arg,
+                    containerEl: mockRotatedContainerEl,
+                    rotation: 0,
+                };
+
+                expect(setSelectionAction(noRotationArg)).toEqual({
+                    payload: state.selection,
+                    type: 'SET_SELECTION',
+                });
+            });
+
+            test('should prepare correct argument when containerEl is null', () => {
+                const noContainerArg = {
+                    ...arg,
+                    containerEl: null,
+                    rotation: -90,
+                };
+
+                expect(setSelectionAction(noContainerArg)).toEqual({
+                    payload: state.selection,
+                    type: 'SET_SELECTION',
+                });
             });
         });
     });

--- a/src/store/highlight/actions.ts
+++ b/src/store/highlight/actions.ts
@@ -1,13 +1,16 @@
 import { createAction } from '@reduxjs/toolkit';
-import { combineRects } from '../../highlight/highlightUtil';
+import { combineRects, getBoundingRect } from '../../highlight/highlightUtil';
+import { getElementLocalPosition } from '../../utils/rotate';
 import { SelectionItem } from './types';
 import { Shape } from '../../@types';
 
 export type SelectionArg = {
+    containerEl?: HTMLElement | null;
     containerRect: DOMRect;
     hasError?: boolean;
     location: number;
     range: Range;
+    rotation?: number;
 };
 
 type Payload = {
@@ -83,7 +86,7 @@ export const setSelectionAction = createAction(
             };
         }
 
-        const { containerRect, hasError, location, range } = arg;
+        const { containerEl, containerRect, hasError, location, range, rotation } = arg;
 
         let rects = Array.from(range.getClientRects());
         // getClientRects on IE/Edge might return 0 rects
@@ -91,12 +94,38 @@ export const setSelectionAction = createAction(
             rects = getClientRects(range);
         }
 
+        const screenShapes = rects.map(getShape);
+
+        if (rotation && containerEl) {
+            // Convert screen rects to element-local coordinates
+            const localRects = screenShapes.map(shape => {
+                const [lx1, ly1] = getElementLocalPosition(shape.x, shape.y, containerEl, rotation);
+                const [lx2, ly2] = getElementLocalPosition(shape.x + shape.width, shape.y + shape.height, containerEl, rotation);
+                return {
+                    x: Math.min(lx1, lx2),
+                    y: Math.min(ly1, ly2),
+                    width: Math.abs(lx2 - lx1),
+                    height: Math.abs(ly2 - ly1),
+                };
+            });
+
+            return {
+                payload: {
+                    containerRect: { x: 0, y: 0, width: containerEl.offsetWidth, height: containerEl.offsetHeight },
+                    hasError,
+                    location,
+                    popupRect: getBoundingRect(screenShapes),
+                    rects: combineRects(localRects),
+                },
+            };
+        }
+
         return {
             payload: {
                 containerRect: getShape(containerRect),
                 hasError,
                 location,
-                rects: combineRects(rects.map(getShape)),
+                rects: combineRects(screenShapes),
             },
         };
     },

--- a/src/store/highlight/types.ts
+++ b/src/store/highlight/types.ts
@@ -10,5 +10,6 @@ export type SelectionItem = {
     containerRect: Shape;
     hasError?: boolean;
     location: number;
+    popupRect?: Shape;
     rects: Array<Shape>;
 };


### PR DESCRIPTION
**Summary**                                                                                                                                                                                                         
  - Adds rotation support to highlight annotations by converting screen-coordinate selection rects to element-local coordinates, matching the approach already used by drawing/region annotations
  - Portals the highlight promoter popup (`PopupHighlight`) and error popup (`PopupHighlightError`) out of the rotated annotation layer so they remain upright and correctly positioned on screen
  - Passes `containerEl` (the textLayer element) through the selection flow so that setSelectionAction can use it with `getElementLocalPosition()` to convert screen coordinates to element-local coordinates. Previously only     
  `containerRect` (the DOMRect) was passed, which doesn't provide the element reference needed to account for CSS rotation transforms.                                                                                         
  - Fixes a bug where overdragging past text (selecting an entire line and dragging slightly beyond) would silently fail on rotated documents because the `mouseup` event never reached the textLayer

 **Test plan**
  - Run npm test — all 965 tests pass
  - Open a PDF, rotate -90°, select partial text → popup appears correctly positioned and upright
  - Rotate -90°, select an entire line (overdrag past end of text) → popup still appears
  - Click the promoter popup → highlight is staged at the correct position within the rotated layer
  - Save the highlight → persists correctly and renders properly at 0°, -90°, -180°, -270°
  - Verify non-rotated highlight behavior is unchanged (no regressions)
