### PR TITLE
chore(deps): Bump @box/threaded-annotations to 1.89.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
         "@babel/preset-react": "^7.25.9",
         "@babel/preset-typescript": "^7.25.9",
         "@box/frontend": "^10.0.0",
-        "@box/blueprint-web": "^14.30.0",
-        "@box/blueprint-web-assets": "^4.117.2",
-        "@box/collaboration-popover": "^1.62.3",
+        "@box/blueprint-web": "^14.31.0",
+        "@box/blueprint-web-assets": "^4.118.3",
+        "@box/collaboration-popover": "^1.62.9",
         "@box/languages": "^1.1.0",
-        "@box/readable-time": "^1.41.3",
-        "@box/threaded-annotations": "^1.89.1",
-        "@box/user-selector": "^1.76.3",
+        "@box/readable-time": "^1.41.9",
+        "@box/threaded-annotations": "^1.89.8",
+        "@box/user-selector": "^1.76.9",
         "@cfaester/enzyme-adapter-react-18": "^0.8.0",
         "@commitlint/cli": "^8.3.5",
         "@commitlint/config-conventional": "^8.2.0",
@@ -128,12 +128,12 @@
         "worker-farm": "^1.7.0"
     },
     "peerDependencies": {
-        "@box/blueprint-web": "^14.30.0",
-        "@box/blueprint-web-assets": "^4.117.2",
-        "@box/collaboration-popover": "^1.62.3",
-        "@box/readable-time": "^1.41.3",
-        "@box/threaded-annotations": "^1.89.1",
-        "@box/user-selector": "^1.76.3"
+        "@box/blueprint-web": "^14.31.0",
+        "@box/blueprint-web-assets": "^4.118.3",
+        "@box/collaboration-popover": "^1.62.9",
+        "@box/readable-time": "^1.41.9",
+        "@box/threaded-annotations": "^1.89.8",
+        "@box/user-selector": "^1.76.9"
     },
     "scripts": {
         "build": "yarn setup && yarn build:prod:dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1027,19 +1027,19 @@
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
 
-"@box/blueprint-web-assets@^4.117.2":
-  version "4.117.2"
-  resolved "https://registry.yarnpkg.com/@box/blueprint-web-assets/-/blueprint-web-assets-4.117.2.tgz#f3793b0ca111baa67eec5f6d1d12e7db8b505c75"
-  integrity sha512-9PbdGk8R6qkhdcYSRRtTuynSKPfOT0MxEPP256u2IWYv/y4Nmp5HB9dyGJKbOLKLSJsf88Fo3tfHKEYeFZKKfg==
+"@box/blueprint-web-assets@^4.118.3":
+  version "4.118.3"
+  resolved "https://registry.yarnpkg.com/@box/blueprint-web-assets/-/blueprint-web-assets-4.118.3.tgz#871a03d6bae643edb536b0342a2759fefd0720a8"
+  integrity sha512-MFHdbb0NGsDIiq/jy/7ao8muCMVPIf6Gn07ehNMejVpQNy5l5xmFU1WudkXnEPXefZiyUUAoL80EJz6WLRNikQ==
 
-"@box/blueprint-web@^14.30.0":
-  version "14.30.0"
-  resolved "https://registry.yarnpkg.com/@box/blueprint-web/-/blueprint-web-14.30.0.tgz#c0dac3b29e6dcd3b6a827387eadea78113639bef"
-  integrity sha512-x0gJPInCmPxPn/hvdKcH0+3i/SDIC97hhnnnXKthryq3VTgWDz0alexcsPvfubmLlszmMuaIuVeihekYpwFlHg==
+"@box/blueprint-web@^14.31.0":
+  version "14.31.0"
+  resolved "https://registry.yarnpkg.com/@box/blueprint-web/-/blueprint-web-14.31.0.tgz#5018921d1783020a60d6d6fb6f0953355278c80f"
+  integrity sha512-5teFWpzqpaeQxERp0Wmb97f+j1vfnJCkvfqQ/HdZTrW/mCJtU8lAwSsQ5vt1k4fpfGVhz6RoU+LN8CZDozj6yg==
   dependencies:
     "@ariakit/react" "0.4.21"
     "@ariakit/react-core" "0.4.21"
-    "@box/blueprint-web-assets" "^4.117.2"
+    "@box/blueprint-web-assets" "^4.118.3"
     "@internationalized/date" "^3.12.0"
     "@radix-ui/react-accordion" "1.1.2"
     "@radix-ui/react-checkbox" "1.0.4"
@@ -1068,10 +1068,10 @@
     react-aria-components "1.16.0"
     type-fest "^3.2.0"
 
-"@box/collaboration-popover@^1.62.3":
-  version "1.62.3"
-  resolved "https://registry.yarnpkg.com/@box/collaboration-popover/-/collaboration-popover-1.62.3.tgz#b1cea34df5df771373af57ad0a27dc85a830a3e6"
-  integrity sha512-eu71Hra6p4QPwaVjQbvR36oLbyukIGSt+nEVvSQzM3pnL+KwD05JJEn2OFnzrPaQUQgUV0bhYzBRFvOADzLS4w==
+"@box/collaboration-popover@^1.62.9":
+  version "1.62.9"
+  resolved "https://registry.yarnpkg.com/@box/collaboration-popover/-/collaboration-popover-1.62.9.tgz#e523086ea3f65418249f43830a97f6b63f9ad49f"
+  integrity sha512-UHPG2RlYpOsGY8YPEO1fBkFEqC0Gi4LXp5SMUVL6A0nu7bTUUvlkPDnr/H9fyqLNrpgdH6EWxTo1nTWlErhf5g==
 
 "@box/frontend@^10.0.0":
   version "10.0.0"
@@ -1087,15 +1087,15 @@
   resolved "https://registry.yarnpkg.com/@box/languages/-/languages-1.1.0.tgz#58bef2d4166d344aa316919e5dc09c7149ab801f"
   integrity sha512-nGP1D5mNPwKajbl6i0NERXvHzK56HNjrRnkJlhbVl62IlpgCJtayEpRPWWAbSAC4NFyku03KieavaaXnWalx+A==
 
-"@box/readable-time@^1.41.3":
-  version "1.41.3"
-  resolved "https://registry.yarnpkg.com/@box/readable-time/-/readable-time-1.41.3.tgz#423d19e3bb97b08f233a3a1543586dc619b953ff"
-  integrity sha512-6igs7l8gxXcG8f3fQ+uSl+KE+d3Z+rFU2oyWITw7WoswzQn0w3shezKa27vLT/7Rxa22yxzzkJXUEPZ/j7gIHw==
+"@box/readable-time@^1.41.9":
+  version "1.41.9"
+  resolved "https://registry.yarnpkg.com/@box/readable-time/-/readable-time-1.41.9.tgz#738b809481eab7766d7fa1dae28f51f8f9bd64a8"
+  integrity sha512-HnVVil64/epkEUjPL1LPC9p3akT6wGhWpST/xg1F2htISPzN3m4WptNWHVMSJvGHJzsUhsHu3BbN0DTRu2OfmA==
 
-"@box/threaded-annotations@^1.89.1":
-  version "1.89.1"
-  resolved "https://registry.yarnpkg.com/@box/threaded-annotations/-/threaded-annotations-1.89.1.tgz#c777560d04150fa4c4039fbeef11edcd59fb2c47"
-  integrity sha512-vqWhinWEriUjzw1iqVA6/PYN8FI2RBDWaOqIzS5qRgLldr/prwbyjTLGnORvYWPQ0Hsx+1dXjuR2KjCh6pFZBA==
+"@box/threaded-annotations@^1.89.8":
+  version "1.89.8"
+  resolved "https://registry.yarnpkg.com/@box/threaded-annotations/-/threaded-annotations-1.89.8.tgz#bd53181595b3ea0b6cc090c1141e9fd34ed8bd09"
+  integrity sha512-jiIn86tO1dxs17/4EQd0twsp3u/ivRJrqHKY/Dmi8FL5VQp2hbH5JLhoBaJj/aeh8u0Wrl34xvzuKJZEmZOWLg==
   dependencies:
     "@tanstack/react-virtual" "^3.10.8"
     "@tiptap/core" "2.0.2"
@@ -1109,10 +1109,10 @@
     "@tiptap/suggestion" "2.0.2"
     uuid "^9.0.1"
 
-"@box/user-selector@^1.76.3":
-  version "1.76.3"
-  resolved "https://registry.yarnpkg.com/@box/user-selector/-/user-selector-1.76.3.tgz#9c8d63c00e6be4fb47fe7072b293ace4bd410fca"
-  integrity sha512-rwLQeF4WqDc2JXptv/ALCe5w1Mw26/8eNssRofqPI400D0KrZXBTmf8ykQ5rk00quNbaKp0GLHT7gSiGIiokFA==
+"@box/user-selector@^1.76.9":
+  version "1.76.9"
+  resolved "https://registry.yarnpkg.com/@box/user-selector/-/user-selector-1.76.9.tgz#6ebcd88d4b1d8373de8c965f780cb6a4b8ab4a7c"
+  integrity sha512-aDs9l/ISHXEuA8qspODgZKabzZwGPv6/MaXcu3CnkQLtz2BXgJnLdn+cjRyFBaNJhYM3w3lp33KAVvHhI5xC2Q==
 
 "@cfaester/enzyme-adapter-react-18@^0.8.0":
   version "0.8.0"


### PR DESCRIPTION
## Summary
- Bump `@box/threaded-annotations` from 1.89.1 to 1.89.8
- Bump required peer dependencies: `@box/blueprint-web` to ^14.31.0, `@box/blueprint-web-assets` to ^4.118.3, `@box/collaboration-popover` to ^1.62.9, `@box/readable-time` to ^1.41.9, `@box/user-selector` to ^1.76.9

## Test plan
- [ ] Verify yarn install succeeds and lockfile is clean
- [ ] Verify annotations editor renders and posts/edits successfully
- [ ] Verify reply, edit, copy link, resolve/unresolve flows still work
