### PR TITLE
fix(popup): show v2 thread popup on deep-link load

### DIFF
--- a/src/popup/PopupLayer.tsx
+++ b/src/popup/PopupLayer.tsx
@@ -45,6 +45,8 @@ const modeStagedMap: { [M in Mode]?: (staged: CreatorItem | null) => boolean } =
     [Mode.REGION]: isCreatorStagedRegion,
 };
 
+const ACTIVE_TARGET_OBSERVER_TIMEOUT_MS = 10000;
+
 const PopupLayer = (props: Props): JSX.Element | null => {
     const {
         activeAnnotationId,
@@ -98,13 +100,39 @@ const PopupLayer = (props: Props): JSX.Element | null => {
         setReference(referenceId ? document.querySelector(`[data-ba-reference-id="${referenceId}"]`) : null);
     }, [referenceId]);
 
+    // activeAnnotationId can be set (e.g. via deep link) before the target DOM node mounts;
+    // observe until it appears, or give up after ACTIVE_TARGET_OBSERVER_TIMEOUT_MS.
     React.useEffect(() => {
-        if (activeAnnotationId && isThreadedAnnotation) {
-            const el = document.querySelector(`[data-ba-annotation-id="${CSS.escape(activeAnnotationId)}"]`);
-            setActiveReference(el);
-        } else {
+        if (!activeAnnotationId || !isThreadedAnnotation) {
             setActiveReference(null);
+            return noop;
         }
+
+        const selector = `[data-ba-annotation-id="${CSS.escape(activeAnnotationId)}"]`;
+        const existing = document.querySelector(selector);
+        if (existing) {
+            setActiveReference(existing);
+            return noop;
+        }
+
+        setActiveReference(null);
+        const observer = new MutationObserver(() => {
+            const el = document.querySelector(selector);
+            if (el) {
+                setActiveReference(el);
+                observer.disconnect();
+            }
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+
+        const timeoutId = window.setTimeout(() => {
+            observer.disconnect();
+        }, ACTIVE_TARGET_OBSERVER_TIMEOUT_MS);
+
+        return () => {
+            observer.disconnect();
+            window.clearTimeout(timeoutId);
+        };
     }, [activeAnnotationId, isThreadedAnnotation]);
 
     const showCreator = canCreate && canReply && reference && staged;

--- a/src/popup/__tests__/PopupLayer-test.tsx
+++ b/src/popup/__tests__/PopupLayer-test.tsx
@@ -152,6 +152,134 @@ describe('PopupLayer', () => {
             expect(screen.getByTestId('popup-reply')).toBeDefined();
             expect(screen.queryByTestId('popup-v2')).toBeNull();
         });
+
+        describe('active annotation thread', () => {
+            const activeAnnotationId = 'annotation-1';
+
+            const appendTarget = (id: string): HTMLElement => {
+                const target = document.createElement('div');
+                target.setAttribute('data-ba-annotation-id', id);
+                document.body.appendChild(target);
+                return target;
+            };
+
+            test('should register a MutationObserver and resolve once the target element appears in the DOM', async () => {
+                const observeSpy = jest.spyOn(MutationObserver.prototype, 'observe');
+                const disconnectSpy = jest.spyOn(MutationObserver.prototype, 'disconnect');
+
+                renderLayer({
+                    activeAnnotationId,
+                    isThreadedAnnotation: true,
+                    staged: null,
+                    status: CreatorStatus.init,
+                });
+
+                expect(screen.queryByTestId('popup-v2')).toBeNull();
+                expect(observeSpy).toHaveBeenCalledWith(document.body, { childList: true, subtree: true });
+
+                act(() => {
+                    appendTarget(activeAnnotationId);
+                });
+
+                const popup = await screen.findByTestId('popup-v2');
+                expect(popup.getAttribute('data-annotation-id')).toBe(activeAnnotationId);
+                expect(disconnectSpy).toHaveBeenCalled();
+
+                observeSpy.mockRestore();
+                disconnectSpy.mockRestore();
+            });
+
+            test('should disconnect the previous observer when activeAnnotationId changes', () => {
+                const disconnectSpy = jest.spyOn(MutationObserver.prototype, 'disconnect');
+
+                const { rerender } = renderLayer({
+                    activeAnnotationId,
+                    isThreadedAnnotation: true,
+                    staged: null,
+                    status: CreatorStatus.init,
+                });
+
+                const callsBeforeChange = disconnectSpy.mock.calls.length;
+
+                act(() => {
+                    rerender(
+                        <PopupLayer
+                            {...getDefaults()}
+                            activeAnnotationId="annotation-2"
+                            isThreadedAnnotation
+                            staged={null}
+                            status={CreatorStatus.init}
+                        />,
+                    );
+                });
+
+                expect(disconnectSpy.mock.calls.length).toBeGreaterThan(callsBeforeChange);
+
+                disconnectSpy.mockRestore();
+            });
+
+            test('should disconnect the observer on unmount', () => {
+                const disconnectSpy = jest.spyOn(MutationObserver.prototype, 'disconnect');
+
+                const { unmount } = renderLayer({
+                    activeAnnotationId,
+                    isThreadedAnnotation: true,
+                    staged: null,
+                    status: CreatorStatus.init,
+                });
+
+                const callsBeforeUnmount = disconnectSpy.mock.calls.length;
+                act(() => {
+                    unmount();
+                });
+
+                expect(disconnectSpy.mock.calls.length).toBeGreaterThan(callsBeforeUnmount);
+
+                disconnectSpy.mockRestore();
+            });
+
+            test('should not update reference when target appears after unmount', () => {
+                const { unmount } = renderLayer({
+                    activeAnnotationId,
+                    isThreadedAnnotation: true,
+                    staged: null,
+                    status: CreatorStatus.init,
+                });
+
+                act(() => {
+                    unmount();
+                });
+
+                expect(() => {
+                    act(() => {
+                        appendTarget(activeAnnotationId);
+                    });
+                }).not.toThrow();
+            });
+
+            test('should disconnect the observer after the timeout when no target appears', () => {
+                jest.useFakeTimers();
+                const disconnectSpy = jest.spyOn(MutationObserver.prototype, 'disconnect');
+
+                renderLayer({
+                    activeAnnotationId,
+                    isThreadedAnnotation: true,
+                    staged: null,
+                    status: CreatorStatus.init,
+                });
+
+                const callsBeforeTimeout = disconnectSpy.mock.calls.length;
+
+                act(() => {
+                    jest.advanceTimersByTime(10000);
+                });
+
+                expect(disconnectSpy.mock.calls.length).toBeGreaterThan(callsBeforeTimeout);
+
+                disconnectSpy.mockRestore();
+                jest.useRealTimers();
+            });
+        });
     });
 
     describe('popup portal', () => {


### PR DESCRIPTION
## Summary
- Fix: when a URL deep-links to an annotation, the v2 thread popup now opens on initial load instead of requiring the user to reselect the annotation.
- Root cause: `activeAnnotationId` is set in the store from the URL before the per-page target element with `data-ba-annotation-id` mounts in the DOM. The previous one-shot `querySelector` returned `null`, leaving `activeReference` unset.
- Fix: wait for the target element via `MutationObserver`, with a 10s timeout fallback so a missing target does not leak the observer.

## Test plan
- [ ] Reload a file URL that deep-links to a v2 annotation; verify the thread popup appears on initial load.
- [ ] Click an annotation, click off, click back; verify the thread popup still opens correctly.
- [ ] Open a URL with a stale or non-existent annotation id; verify nothing breaks (observer disconnects after timeout).
