### PR TITLE
style(popup): enable pointer events on PopupV2 inside the portal

### DIFF
--- a/src/common/BaseAnnotator.scss
+++ b/src/common/BaseAnnotator.scss
@@ -34,7 +34,8 @@
     z-index: 10;
     pointer-events: none;
 
-    .ba-Popup {
+    .ba-Popup,
+    .ba-PopupV2 {
         z-index: 150;
         pointer-events: auto;
     }


### PR DESCRIPTION
## Summary
`.ba-PopupPortal` sets `pointer-events: none` and only re-enables them on `.ba-Popup` (v1). PopupV2 uses `.ba-PopupV2`, so hover and clicks fell through the popup to the highlight text layer underneath, which made the cursor render as the highlight cursor and made it hard to click Reply or Save inside the thread popup.

Fix: include `.ba-PopupV2` in the same selector that re-enables `pointer-events: auto` inside `.ba-PopupPortal`.

## Test plan
- [ ] Open a doc with the threaded annotations v2 popup enabled
- [ ] Hover over an existing thread popup, confirm the cursor is the default arrow (not the highlight text cursor)
- [ ] Click Reply and Save buttons inside the popup, confirm clicks register on the first try
- [ ] Confirm v1 popups still behave correctly (regression check)
