### PR TITLE
fix(popup): map edited timestamp to threaded-annotations updatedAt

### DIFF
--- a/src/adapters/__tests__/threadedAnnotationsAdapters-test.ts
+++ b/src/adapters/__tests__/threadedAnnotationsAdapters-test.ts
@@ -194,6 +194,22 @@ describe('threadedAnnotationsAdapters', () => {
             expect(result[0].permissions.canEdit).toBe(true);
         });
 
+        test.each([
+            ['identical timestamps', '2026-01-01T00:00:00Z', undefined],
+            ['equivalent ISO formats with fractional precision', '2026-01-01T00:00:00.000Z', undefined],
+            ['unparseable modified_at', 'not-a-date', undefined],
+            ['edited later', '2026-02-01T00:00:00Z', new Date('2026-02-01T00:00:00Z').getTime()],
+        ])('should map updatedAt for %s', (_label, modifiedAt, expected) => {
+            const annotation: Annotation = {
+                ...baseAnnotation,
+                description: { message: 'Root' } as unknown as Reply,
+                modified_at: modifiedAt,
+            };
+            const result = annotationToMessages(annotation);
+
+            expect(result[0].updatedAt).toBe(expected);
+        });
+
         test('should include description and replies in order', () => {
             const annotation: Annotation = {
                 ...baseAnnotation,
@@ -217,7 +233,6 @@ describe('threadedAnnotationsAdapters', () => {
             expect(result[0].author.name).toBe('User');
             expect(result[1].author.name).toBe('Other');
         });
-
     });
 
     describe('collaboratorToUserContact', () => {

--- a/src/adapters/threadedAnnotationsAdapters.ts
+++ b/src/adapters/threadedAnnotationsAdapters.ts
@@ -89,6 +89,19 @@ export const replyToTextMessage = (reply: Reply): TextMessageTypeV2 => ({
     },
 });
 
+/**
+ * Returns the edit timestamp consumers use to render an edited indicator.
+ * Compares parsed instants, not raw strings, so equivalent ISO formats
+ * (Z vs +00:00, fractional precision) are treated as unedited.
+ */
+const toUpdatedAt = (createdAt: string, modifiedAt: string): number | undefined => {
+    const modifiedMs = new Date(modifiedAt).getTime();
+    if (Number.isNaN(modifiedMs)) return undefined;
+    const createdMs = new Date(createdAt).getTime();
+    if (modifiedMs === createdMs) return undefined;
+    return modifiedMs;
+};
+
 // The root message shares the annotation's author and permissions; description
 // comes back sparse ({ message } only) from the list endpoint.
 const descriptionToTextMessage = (annotation: Annotation): TextMessageTypeV2 => ({
@@ -106,6 +119,7 @@ const descriptionToTextMessage = (annotation: Annotation): TextMessageTypeV2 => 
         canReply: annotation.permissions?.can_reply ?? false,
         canResolve: annotation.permissions?.can_resolve ?? false,
     },
+    updatedAt: toUpdatedAt(annotation.created_at, annotation.modified_at),
 });
 
 /**


### PR DESCRIPTION
## Summary
The threaded-annotations v2 thread component shows an edited indicator on a message when its `updatedAt` is set to a timestamp newer than `createdAt`. The box-annotations adapter was not populating `updatedAt`, so even after the user edited an annotation in PopupV2, the thread never rendered the indicator.

This change maps `Annotation.modified_at` to the root message `updatedAt` when it differs from `created_at`. Replies are unaffected because the API model has no `modified_at` on `Reply` and the adapter forces `canEdit: false` for replies.

## Implementation notes
- Compares parsed instants (`getTime()`) rather than raw ISO strings, so equivalent normalizations (`Z` vs `+00:00`, fractional precision) are treated as unedited.
- Falls back to `undefined` for unparseable `modified_at`. The consumer simply hides the indicator in that case rather than crashing the popup; the field is optional in the public type.

## Test plan
- [ ] Open an annotation in the threaded popup, edit the root message, save, and confirm the edited indicator renders
- [ ] Reload the file with the edited annotation already on disk and confirm the indicator still renders on the root message
- [ ] Confirm an unedited annotation does not render the indicator
- [ ] Confirm replies do not render the indicator (they have no editable timestamp in the model)
