### PR TITLE
chore(deps): Bump @box/threaded-annotations to 1.91.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
         "@babel/preset-react": "^7.25.9",
         "@babel/preset-typescript": "^7.25.9",
         "@box/frontend": "^10.0.0",
-        "@box/blueprint-web": "^14.31.0",
-        "@box/blueprint-web-assets": "^4.118.3",
-        "@box/collaboration-popover": "^1.62.9",
+        "@box/blueprint-web": "^14.33.0",
+        "@box/blueprint-web-assets": "^4.119.4",
+        "@box/collaboration-popover": "^1.62.19",
         "@box/languages": "^1.1.0",
-        "@box/readable-time": "^1.41.9",
-        "@box/threaded-annotations": "^1.89.8",
-        "@box/user-selector": "^1.76.9",
+        "@box/readable-time": "^1.41.19",
+        "@box/threaded-annotations": "^1.91.8",
+        "@box/user-selector": "^1.76.19",
         "@cfaester/enzyme-adapter-react-18": "^0.8.0",
         "@commitlint/cli": "^8.3.5",
         "@commitlint/config-conventional": "^8.2.0",
@@ -128,12 +128,12 @@
         "worker-farm": "^1.7.0"
     },
     "peerDependencies": {
-        "@box/blueprint-web": "^14.31.0",
-        "@box/blueprint-web-assets": "^4.118.3",
-        "@box/collaboration-popover": "^1.62.9",
-        "@box/readable-time": "^1.41.9",
-        "@box/threaded-annotations": "^1.89.8",
-        "@box/user-selector": "^1.76.9"
+        "@box/blueprint-web": "^14.33.0",
+        "@box/blueprint-web-assets": "^4.119.4",
+        "@box/collaboration-popover": "^1.62.19",
+        "@box/readable-time": "^1.41.19",
+        "@box/threaded-annotations": "^1.91.8",
+        "@box/user-selector": "^1.76.19"
     },
     "scripts": {
         "build": "yarn setup && yarn build:prod:dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1027,19 +1027,19 @@
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
 
-"@box/blueprint-web-assets@^4.118.3":
-  version "4.118.3"
-  resolved "https://registry.yarnpkg.com/@box/blueprint-web-assets/-/blueprint-web-assets-4.118.3.tgz#871a03d6bae643edb536b0342a2759fefd0720a8"
-  integrity sha512-MFHdbb0NGsDIiq/jy/7ao8muCMVPIf6Gn07ehNMejVpQNy5l5xmFU1WudkXnEPXefZiyUUAoL80EJz6WLRNikQ==
+"@box/blueprint-web-assets@^4.119.4":
+  version "4.119.4"
+  resolved "https://registry.yarnpkg.com/@box/blueprint-web-assets/-/blueprint-web-assets-4.119.4.tgz#0f4664458465ee38731cd0ffb93c183250d1c993"
+  integrity sha512-cD/DIjRq6XDrRwCN81+igvseGH1ZxsIHcOdKPl5uZYFPAbAZ6eILnWipm2B8puJ1jnInL561xCqFG1O4MND5Rg==
 
-"@box/blueprint-web@^14.31.0":
-  version "14.31.0"
-  resolved "https://registry.yarnpkg.com/@box/blueprint-web/-/blueprint-web-14.31.0.tgz#5018921d1783020a60d6d6fb6f0953355278c80f"
-  integrity sha512-5teFWpzqpaeQxERp0Wmb97f+j1vfnJCkvfqQ/HdZTrW/mCJtU8lAwSsQ5vt1k4fpfGVhz6RoU+LN8CZDozj6yg==
+"@box/blueprint-web@^14.33.0":
+  version "14.33.0"
+  resolved "https://registry.yarnpkg.com/@box/blueprint-web/-/blueprint-web-14.33.0.tgz#5c71da4ae90957759693a45bd82e20ca7bbdfa99"
+  integrity sha512-IUqrtN20EdYyk8PgdLlLkxdCbSKZ6YERvMVey5N+hyXEa5/l8CrFmkFm91vvI1Xbu9jVFEpP2acfzQlFtB82mw==
   dependencies:
     "@ariakit/react" "0.4.21"
     "@ariakit/react-core" "0.4.21"
-    "@box/blueprint-web-assets" "^4.118.3"
+    "@box/blueprint-web-assets" "^4.119.4"
     "@internationalized/date" "^3.12.0"
     "@radix-ui/react-accordion" "1.1.2"
     "@radix-ui/react-checkbox" "1.0.4"
@@ -1068,10 +1068,10 @@
     react-aria-components "1.16.0"
     type-fest "^3.2.0"
 
-"@box/collaboration-popover@^1.62.9":
-  version "1.62.9"
-  resolved "https://registry.yarnpkg.com/@box/collaboration-popover/-/collaboration-popover-1.62.9.tgz#e523086ea3f65418249f43830a97f6b63f9ad49f"
-  integrity sha512-UHPG2RlYpOsGY8YPEO1fBkFEqC0Gi4LXp5SMUVL6A0nu7bTUUvlkPDnr/H9fyqLNrpgdH6EWxTo1nTWlErhf5g==
+"@box/collaboration-popover@^1.62.19":
+  version "1.62.19"
+  resolved "https://registry.yarnpkg.com/@box/collaboration-popover/-/collaboration-popover-1.62.19.tgz#996a89357cb509dfba019048edee280650788705"
+  integrity sha512-g1jmHOrL1/HtzYoHt+6OLyQ+b3rQ75tzFCg/3Jz2+v76dC23Z1mCqecMie3oLxoCr6SpMh9N+AVS3e8UJukjAw==
 
 "@box/frontend@^10.0.0":
   version "10.0.0"
@@ -1087,15 +1087,15 @@
   resolved "https://registry.yarnpkg.com/@box/languages/-/languages-1.1.0.tgz#58bef2d4166d344aa316919e5dc09c7149ab801f"
   integrity sha512-nGP1D5mNPwKajbl6i0NERXvHzK56HNjrRnkJlhbVl62IlpgCJtayEpRPWWAbSAC4NFyku03KieavaaXnWalx+A==
 
-"@box/readable-time@^1.41.9":
-  version "1.41.9"
-  resolved "https://registry.yarnpkg.com/@box/readable-time/-/readable-time-1.41.9.tgz#738b809481eab7766d7fa1dae28f51f8f9bd64a8"
-  integrity sha512-HnVVil64/epkEUjPL1LPC9p3akT6wGhWpST/xg1F2htISPzN3m4WptNWHVMSJvGHJzsUhsHu3BbN0DTRu2OfmA==
+"@box/readable-time@^1.41.19":
+  version "1.41.19"
+  resolved "https://registry.yarnpkg.com/@box/readable-time/-/readable-time-1.41.19.tgz#06b3663322bc2b35ea243aeb72a7b8b5dc21a821"
+  integrity sha512-65xHwJvg21UmxUCzuCF2JTahwzAbVKR+moVQQ6jt0PzlxnDQk0iIIxPW9JubFJCy08e20OL3lZMpxyTlDqwykg==
 
-"@box/threaded-annotations@^1.89.8":
-  version "1.89.8"
-  resolved "https://registry.yarnpkg.com/@box/threaded-annotations/-/threaded-annotations-1.89.8.tgz#bd53181595b3ea0b6cc090c1141e9fd34ed8bd09"
-  integrity sha512-jiIn86tO1dxs17/4EQd0twsp3u/ivRJrqHKY/Dmi8FL5VQp2hbH5JLhoBaJj/aeh8u0Wrl34xvzuKJZEmZOWLg==
+"@box/threaded-annotations@^1.91.8":
+  version "1.91.8"
+  resolved "https://registry.yarnpkg.com/@box/threaded-annotations/-/threaded-annotations-1.91.8.tgz#b061571103c6a5881f77e3fedbbdda6389e793b4"
+  integrity sha512-FK8flIZ5js9xn64jfD0fJlGUt/yCdPgM7yGDn6yzuklECpfN8Qwo9xvVMQtkJzrpYVycIjc5qwi3/cO/MPucNw==
   dependencies:
     "@tanstack/react-virtual" "^3.10.8"
     "@tiptap/core" "2.0.2"
@@ -1109,10 +1109,10 @@
     "@tiptap/suggestion" "2.0.2"
     uuid "^9.0.1"
 
-"@box/user-selector@^1.76.9":
-  version "1.76.9"
-  resolved "https://registry.yarnpkg.com/@box/user-selector/-/user-selector-1.76.9.tgz#6ebcd88d4b1d8373de8c965f780cb6a4b8ab4a7c"
-  integrity sha512-aDs9l/ISHXEuA8qspODgZKabzZwGPv6/MaXcu3CnkQLtz2BXgJnLdn+cjRyFBaNJhYM3w3lp33KAVvHhI5xC2Q==
+"@box/user-selector@^1.76.19":
+  version "1.76.19"
+  resolved "https://registry.yarnpkg.com/@box/user-selector/-/user-selector-1.76.19.tgz#1ce73d2e3014e862a1ddac2b352073fb6fe60e83"
+  integrity sha512-ZoLS42ojbr4qhYz417nH8Pzn++0YKsp6uiG5ygjxGjEGXezQ6zO8Au/2vJ9AneVX4bbk/kyjRy2cktMHsqRSBA==
 
 "@cfaester/enzyme-adapter-react-18@^0.8.0":
   version "0.8.0"


### PR DESCRIPTION
## Summary
- Bump `@box/threaded-annotations` from `^1.89.8` to `^1.91.8`
- Bump peer requirements to satisfy the new version: `@box/blueprint-web` to `^14.33.0`, `@box/blueprint-web-assets` to `^4.119.4`, `@box/collaboration-popover` to `^1.62.19`, `@box/readable-time` to `^1.41.19`, `@box/user-selector` to `^1.76.19`
- Updates apply to both `dependencies` and `peerDependencies`; `yarn.lock` deduped

## Test plan
- [ ] CI passes
- [ ] Storybook smoke test on annotations
