### PR TITLE
chore(deps): Bump @box/threaded-annotations to 1.93.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
         "@babel/preset-react": "^7.25.9",
         "@babel/preset-typescript": "^7.25.9",
         "@box/frontend": "^10.0.0",
-        "@box/blueprint-web": "^14.33.0",
-        "@box/blueprint-web-assets": "^4.119.4",
-        "@box/collaboration-popover": "^1.62.19",
+        "@box/blueprint-web": "^14.38.0",
+        "@box/blueprint-web-assets": "^4.120.5",
+        "@box/collaboration-popover": "^1.62.27",
         "@box/languages": "^1.1.0",
-        "@box/readable-time": "^1.41.19",
-        "@box/threaded-annotations": "^1.91.8",
-        "@box/user-selector": "^1.76.19",
+        "@box/readable-time": "^1.41.27",
+        "@box/threaded-annotations": "^1.93.2",
+        "@box/user-selector": "^1.76.27",
         "@cfaester/enzyme-adapter-react-18": "^0.8.0",
         "@commitlint/cli": "^8.3.5",
         "@commitlint/config-conventional": "^8.2.0",
@@ -128,12 +128,12 @@
         "worker-farm": "^1.7.0"
     },
     "peerDependencies": {
-        "@box/blueprint-web": "^14.33.0",
-        "@box/blueprint-web-assets": "^4.119.4",
-        "@box/collaboration-popover": "^1.62.19",
-        "@box/readable-time": "^1.41.19",
-        "@box/threaded-annotations": "^1.91.8",
-        "@box/user-selector": "^1.76.19"
+        "@box/blueprint-web": "^14.38.0",
+        "@box/blueprint-web-assets": "^4.120.5",
+        "@box/collaboration-popover": "^1.62.27",
+        "@box/readable-time": "^1.41.27",
+        "@box/threaded-annotations": "^1.93.2",
+        "@box/user-selector": "^1.76.27"
     },
     "scripts": {
         "build": "yarn setup && yarn build:prod:dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1027,19 +1027,19 @@
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
 
-"@box/blueprint-web-assets@^4.119.4":
-  version "4.119.4"
-  resolved "https://registry.yarnpkg.com/@box/blueprint-web-assets/-/blueprint-web-assets-4.119.4.tgz#0f4664458465ee38731cd0ffb93c183250d1c993"
-  integrity sha512-cD/DIjRq6XDrRwCN81+igvseGH1ZxsIHcOdKPl5uZYFPAbAZ6eILnWipm2B8puJ1jnInL561xCqFG1O4MND5Rg==
+"@box/blueprint-web-assets@^4.120.5":
+  version "4.120.5"
+  resolved "https://registry.yarnpkg.com/@box/blueprint-web-assets/-/blueprint-web-assets-4.120.5.tgz#f115d2b6a16d7a25665c25be262e3d7fbab0a7e6"
+  integrity sha512-YNWm11ek2lSyrVWlJPeV4SU7jcKmjUw39w+ejsa+f7f7Ae8qGX3Je9r3yc7vj2e142ALRpOLnHNxFV8YA7+KiA==
 
-"@box/blueprint-web@^14.33.0":
-  version "14.33.0"
-  resolved "https://registry.yarnpkg.com/@box/blueprint-web/-/blueprint-web-14.33.0.tgz#5c71da4ae90957759693a45bd82e20ca7bbdfa99"
-  integrity sha512-IUqrtN20EdYyk8PgdLlLkxdCbSKZ6YERvMVey5N+hyXEa5/l8CrFmkFm91vvI1Xbu9jVFEpP2acfzQlFtB82mw==
+"@box/blueprint-web@^14.38.0":
+  version "14.38.0"
+  resolved "https://registry.yarnpkg.com/@box/blueprint-web/-/blueprint-web-14.38.0.tgz#4e61ccdba8cda57806ef81dc184856b68f165db6"
+  integrity sha512-EFEo7DjIcfxxEmbEfF98uYxbjFUgFTTSuSHpvY9gHgbaPphSH9073rMa1QLb4C/KCh2Ia5AG2m0NSRJeRxd/9Q==
   dependencies:
     "@ariakit/react" "0.4.21"
     "@ariakit/react-core" "0.4.21"
-    "@box/blueprint-web-assets" "^4.119.4"
+    "@box/blueprint-web-assets" "^4.120.5"
     "@internationalized/date" "^3.12.0"
     "@radix-ui/react-accordion" "1.1.2"
     "@radix-ui/react-checkbox" "1.0.4"
@@ -1068,10 +1068,10 @@
     react-aria-components "1.16.0"
     type-fest "^3.2.0"
 
-"@box/collaboration-popover@^1.62.19":
-  version "1.62.19"
-  resolved "https://registry.yarnpkg.com/@box/collaboration-popover/-/collaboration-popover-1.62.19.tgz#996a89357cb509dfba019048edee280650788705"
-  integrity sha512-g1jmHOrL1/HtzYoHt+6OLyQ+b3rQ75tzFCg/3Jz2+v76dC23Z1mCqecMie3oLxoCr6SpMh9N+AVS3e8UJukjAw==
+"@box/collaboration-popover@^1.62.27":
+  version "1.62.27"
+  resolved "https://registry.yarnpkg.com/@box/collaboration-popover/-/collaboration-popover-1.62.27.tgz#26765e84b4ab1280a87fe3b24765edc11d0fa33c"
+  integrity sha512-H6cJc8PwVL+jKKyL5s62uD02QverLQa/cUEW7T/uSJC/vjNdnQ/Vx0l+B6j+ihNj6j6cV3lUyrsjVBVhp7fWyQ==
 
 "@box/frontend@^10.0.0":
   version "10.0.0"
@@ -1087,15 +1087,15 @@
   resolved "https://registry.yarnpkg.com/@box/languages/-/languages-1.1.0.tgz#58bef2d4166d344aa316919e5dc09c7149ab801f"
   integrity sha512-nGP1D5mNPwKajbl6i0NERXvHzK56HNjrRnkJlhbVl62IlpgCJtayEpRPWWAbSAC4NFyku03KieavaaXnWalx+A==
 
-"@box/readable-time@^1.41.19":
-  version "1.41.19"
-  resolved "https://registry.yarnpkg.com/@box/readable-time/-/readable-time-1.41.19.tgz#06b3663322bc2b35ea243aeb72a7b8b5dc21a821"
-  integrity sha512-65xHwJvg21UmxUCzuCF2JTahwzAbVKR+moVQQ6jt0PzlxnDQk0iIIxPW9JubFJCy08e20OL3lZMpxyTlDqwykg==
+"@box/readable-time@^1.41.27":
+  version "1.41.27"
+  resolved "https://registry.yarnpkg.com/@box/readable-time/-/readable-time-1.41.27.tgz#2a7fc352fa9717caaaccc00a2559299411117ba9"
+  integrity sha512-10CuMCBGPDGCh5Va26RVyqIPvqmA7tZ1Q0CUO65o3NvnTEiDmPW15o9TCUtZy98jm32CISYhyIsspXVMoYpoRg==
 
-"@box/threaded-annotations@^1.91.8":
-  version "1.91.8"
-  resolved "https://registry.yarnpkg.com/@box/threaded-annotations/-/threaded-annotations-1.91.8.tgz#b061571103c6a5881f77e3fedbbdda6389e793b4"
-  integrity sha512-FK8flIZ5js9xn64jfD0fJlGUt/yCdPgM7yGDn6yzuklECpfN8Qwo9xvVMQtkJzrpYVycIjc5qwi3/cO/MPucNw==
+"@box/threaded-annotations@^1.93.2":
+  version "1.93.2"
+  resolved "https://registry.yarnpkg.com/@box/threaded-annotations/-/threaded-annotations-1.93.2.tgz#95985b4eedd872b40cb401d833b21f8101dbbe94"
+  integrity sha512-86VLTlox7D/hGkNsfZNUJf9q92vcCluXaNSxhk1qHVfNbVh/VySzz6JqnBSN3Czqq2m+MM4lHg0FMMRY0PMcmQ==
   dependencies:
     "@tanstack/react-virtual" "^3.10.8"
     "@tiptap/core" "2.0.2"
@@ -1109,10 +1109,10 @@
     "@tiptap/suggestion" "2.0.2"
     uuid "^9.0.1"
 
-"@box/user-selector@^1.76.19":
-  version "1.76.19"
-  resolved "https://registry.yarnpkg.com/@box/user-selector/-/user-selector-1.76.19.tgz#1ce73d2e3014e862a1ddac2b352073fb6fe60e83"
-  integrity sha512-ZoLS42ojbr4qhYz417nH8Pzn++0YKsp6uiG5ygjxGjEGXezQ6zO8Au/2vJ9AneVX4bbk/kyjRy2cktMHsqRSBA==
+"@box/user-selector@^1.76.27":
+  version "1.76.27"
+  resolved "https://registry.yarnpkg.com/@box/user-selector/-/user-selector-1.76.27.tgz#948852854174b1514db7de6d085ef882e5e5171b"
+  integrity sha512-cKgXX1y78+GKNh058R+I25dwOCsLdIMtyxlMeZhdiGkJV3yVki9MQAll1TBTsD+qWQDVk+o5L8pyfqJ2RSwFKA==
 
 "@cfaester/enzyme-adapter-react-18@^0.8.0":
   version "0.8.0"


### PR DESCRIPTION
## Summary
- Bump `@box/threaded-annotations` from `^1.91.8` to `^1.93.2`
- Bump peer requirements to satisfy the new version: `@box/blueprint-web` to `^14.38.0`, `@box/blueprint-web-assets` to `^4.120.5`, `@box/collaboration-popover` to `^1.62.27`, `@box/readable-time` to `^1.41.27`, `@box/user-selector` to `^1.76.27`
- Updates apply to both `dependencies` and `peerDependencies`; `yarn.lock` deduped

## Test plan
- [ ] CI passes
- [ ] Storybook smoke test on annotations
