### PR TITLE
fix(drawing): render PopupDrawingToolbar inline without portal

### DIFF
--- a/src/drawing/DrawingAnnotations.tsx
+++ b/src/drawing/DrawingAnnotations.tsx
@@ -179,8 +179,8 @@ const DrawingAnnotations = (props: Props): JSX.Element => {
                 />
             )}
 
-            {isCreating && hasPathGroups && drawingSVGGroup && canShowPopupToolbar && popupPortalEl &&
-                ReactDOM.createPortal(
+            {isCreating && hasPathGroups && drawingSVGGroup && canShowPopupToolbar && (() => {
+                const toolbar = (
                     <PopupDrawingToolbar
                         ref={popupDrawingToolbarRef}
                         canComment={hasDrawnPathGroups}
@@ -192,9 +192,10 @@ const DrawingAnnotations = (props: Props): JSX.Element => {
                         onReply={handleReply}
                         onUndo={handleUndo}
                         reference={drawingSVGGroup}
-                    />,
-                    popupPortalEl,
-                )}
+                    />
+                );
+                return popupPortalEl ? ReactDOM.createPortal(toolbar, popupPortalEl) : toolbar;
+            })()}
         </>
     );
 };

--- a/src/drawing/__tests__/DrawingAnnotations-test.tsx
+++ b/src/drawing/__tests__/DrawingAnnotations-test.tsx
@@ -337,7 +337,7 @@ describe('DrawingAnnotations', () => {
             document.body.removeChild(popupPortalEl);
         });
 
-        test('should not render PopupDrawingToolbar when popupPortalEl is missing', () => {
+        test('should render PopupDrawingToolbar inline when popupPortalEl is missing', () => {
             const wrapper = getWrapper({
                 canShowPopupToolbar: true,
                 drawnPathGroups: pathGroups,
@@ -345,7 +345,7 @@ describe('DrawingAnnotations', () => {
                 popupPortalEl: null,
             });
 
-            expect(wrapper.find(PopupDrawingToolbar).exists()).toBe(false);
+            expect(wrapper.find(PopupDrawingToolbar).exists()).toBe(true);
         });
     });
 


### PR DESCRIPTION
**Summary**
- The drawing popup toolbar (Add Comment button, undo/redo/trash icons) was not appearing for video annotations
- `popupPortalEl` is only needed to keep the toolbar upright on rotated documents/images — videos don't have rotation, so the portal isn't necessary (this portal element was introduced in https://github.com/box/box-annotations/pull/749)
- Added an inline fallback: when `popupPortalEl` is absent, the toolbar renders directly instead of not rendering at all

**Test plan**
- [ ] Unit tests pass (including updated portal test)
- [ ] Verify drawing toolbar appears on video annotations
- [ ] Verify drawing toolbar still works on documents and images (portal path)
