### PR TITLE
fix(build): emit ESM bundle so consumers can tree-shake externals

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 import './dist/annotations.css';
-import './dist/annotations.js';
+import BoxAnnotations from './dist/annotations.js';
 
 export default BoxAnnotations;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "Box Annotations",
     "author": "Box (https://www.box.com/)",
     "license": "SEE LICENSE IN LICENSE",
+    "sideEffects": ["./dist/annotations.js", "**/*.css", "**/*.scss"],
     "repository": {
         "type": "git",
         "url": "git@github.com:box/box-annotations.git"

--- a/scripts/webpack.config.js
+++ b/scripts/webpack.config.js
@@ -10,6 +10,27 @@ const { BannerPlugin } = require('webpack');
 const license = require('./license');
 const commonConfig = require('./webpack.common.config');
 
+// Provided by the consuming application at runtime; kept out of the bundle to
+// avoid duplicating code the host app already ships. The react family must
+// stay commonjs: module externals are assumed to be spec ESM at build time,
+// which strips Babel's _interopRequireDefault checks from bundled CJS code;
+// consumers that provide CJS react then crash on namespace.default access.
+const commonjsExternals = ['react', 'react-dom', 'react-intl', 'react-redux'];
+// These ship ESM, so they are externalized as module imports, which lets the
+// consumer's bundler tree-shake their unused exports. '@tiptap' matches the
+// whole scope.
+const moduleExternals = [
+    '@box/blueprint-web',
+    '@box/blueprint-web-assets',
+    '@box/collaboration-popover',
+    '@box/combobox-with-api',
+    '@box/readable-time',
+    '@box/threaded-annotations',
+    '@box/user-selector',
+    '@tiptap',
+];
+const matchesPackage = (request, name) => request === name || request.startsWith(`${name}/`);
+
 const isDev = process.env.NODE_ENV === 'dev';
 const isLinked = process.env.IS_LINKED === '1';
 const isRelease = process.env.NODE_ENV === 'production';
@@ -30,25 +51,27 @@ const config = Object.assign(commonConfig(), {
         annotations: ['./src/BoxAnnotations.ts'],
     },
     externals: [
-        // @box/threaded-annotations and its transitive dependencies are provided
-        // by the consuming application (EUA) at runtime. Marking them as externals
-        // avoids duplicating code that is already bundled by the host app.
-        /^react(\/.*)?$/,
-        /^react-dom(\/.*)?$/,
-        /^react-intl(\/.*)?$/,
-        /^react-redux(\/.*)?$/,
-        /^@box\/threaded-annotations/,
-        /^@box\/blueprint-web/,
-        /^@box\/blueprint-web-assets/,
-        /^@box\/collaboration-popover/,
-        /^@box\/readable-time/,
-        /^@box\/user-selector/,
-        /^@box\/combobox-with-api/,
-        /^@tiptap\//,
+        ({ request }, callback) => {
+            if (!request) {
+                return callback();
+            }
+            if (commonjsExternals.some(name => matchesPackage(request, name))) {
+                return callback(null, `commonjs ${request}`);
+            }
+            if (moduleExternals.some(name => matchesPackage(request, name))) {
+                return callback(null, `module ${request}`);
+            }
+            return callback();
+        },
     ],
-    externalsType: 'commonjs',
+    experiments: {
+        outputModule: true,
+    },
     output: {
         filename: '[name].js',
+        library: {
+            type: 'module',
+        },
         path: path.resolve('dist'),
     },
     resolve: {
@@ -90,10 +113,7 @@ if (isDev) {
 
 if (isRelease && language === 'en-US') {
     config.optimization = {
-        minimizer: [
-            '...',
-            new CssMinimizerPlugin(),
-        ],
+        minimizer: ['...', new CssMinimizerPlugin()],
     };
 
     // Add license message to top of code


### PR DESCRIPTION
## Summary

Switches the webpack build to emit an ES module bundle so that consumer bundlers can tree-shake the `@box/*` packages this library declares as externals.

Since #743 the published bundle loaded its externals via `require()` calls. A consuming bundler treats `require("@box/blueprint-web")` as opaque namespace access and marks the entire package barrel as used, so unrelated Blueprint components (Table, Calendar, GridList, and others) were retained in consumer bundles even though this library uses only two Blueprint exports.

## Changes

- **`scripts/webpack.config.js`**: emit ESM output (`experiments.outputModule`, `output.library.type: 'module'`) with per-request external types:
  - `@box/*` and `@tiptap/*` packages are externalized as `module`, so the bundle contains named ESM imports (`import { BlueprintModernizationProvider, TooltipProvider } from '@box/blueprint-web'`) that downstream bundlers can tree-shake.
  - react, react-dom, react-intl, and react-redux stay `commonjs`. With `module` externals webpack assumes the external is spec ESM at build time and compiles away Babel's `__esModule` interop from bundled CJS code (e.g. react-tether); consumers that provide a CJS-shaped react then crash on `namespace.default` access during module evaluation, which leaves `globalThis.BoxAnnotations` unassigned.
- **`index.js`**: import the default export from `dist/annotations.js` directly. The bundle now has a real `export default`; previously the entry re-exported an undeclared identifier resolved from the global at runtime.
- **`package.json`**: add `sideEffects`. `./dist/annotations.js` is listed because it assigns `globalThis.BoxAnnotations`, which is how existing consumers access the library; without the entry a consumer bundler could prune the import.

## Testing

- `tsc` and eslint pass
- All 1059 unit tests across 117 suites pass
- Production and development webpack builds compile
- Verified in a consuming application against a dev environment: the annotations bundle loads and evaluates, annotation creation, popup reply, delete, and resolve flows work, and the consumer build resolves Blueprint to individual module files rather than the package barrel

## Notes

- Loading `dist/annotations.js` via a classic script tag is not supported by the ESM output. That path has been broken since #743 (the bundle contained bare `require()` calls that no browser script context could satisfy); bundler consumption is unaffected.
