### PR TITLE
fix(mentions): suppress invite popover after selecting a mention

### DIFF
--- a/src/components/Popups/PopupV2.tsx
+++ b/src/components/Popups/PopupV2.tsx
@@ -342,6 +342,8 @@ const PopupV2 = ({ annotationId, onSubmit, popupPortalEl, reference }: Props): J
                             collaborationPopoverProps: {
                                 onSubmit: () => Promise.resolve(),
                             },
+                            // Mentions are restricted to file collaborators; the invite popover is intentionally never shown.
+                            fetchCollaboratorState: async () => true,
                         }}>
                             {annotationId ? (
                                 <ThreadedAnnotationsV2

--- a/src/components/Popups/__tests__/PopupV2-test.tsx
+++ b/src/components/Popups/__tests__/PopupV2-test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import { useDispatch, useSelector } from 'react-redux';
-import type { ThreadedAnnotationsPropsV2 } from '@box/threaded-annotations';
+import type { MentionContextData, ThreadedAnnotationsPropsV2 } from '@box/threaded-annotations';
 import AnnotationCallbacksContext from '../../../common/AnnotationCallbacksContext';
 import PopupV2, { Props } from '../PopupV2';
 import {
@@ -34,13 +34,16 @@ jest.mock('@box/blueprint-web', () => ({
     TooltipProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
+let lastMentionContextValue: MentionContextData = {};
 let lastThreadedAnnotationsProps: Partial<ThreadedAnnotationsPropsV2> = {};
 
 jest.mock('@box/threaded-annotations', () => {
     const ReactMock = jest.requireActual('react');
     return {
-        MentionContextProvider: ({ children }: { children: React.ReactNode }) =>
-            ReactMock.createElement('div', { 'data-testid': 'mention-context' }, children),
+        MentionContextProvider: ({ children, value }: { children: React.ReactNode; value: MentionContextData }) => {
+            lastMentionContextValue = value;
+            return ReactMock.createElement('div', { 'data-testid': 'mention-context' }, children);
+        },
         MessageEditorV2: (props: Record<string, unknown>) =>
             ReactMock.createElement('div', {
                 'data-testid': 'message-editor-v2',
@@ -149,6 +152,7 @@ describe('PopupV2', () => {
     };
 
     beforeEach(() => {
+        lastMentionContextValue = {};
         lastThreadedAnnotationsProps = {};
         mockUseDispatch.mockReturnValue(mockDispatch);
         mockFetch.mockResolvedValue({
@@ -198,6 +202,21 @@ describe('PopupV2', () => {
 
             const popup = screen.getByRole('presentation');
             expect(popup).toHaveAttribute('data-resin-component', 'popupReplyV2');
+        });
+
+        // Mention contacts are file collaborators, so fetchCollaboratorState must resolve true
+        // or threaded-annotations opens the non-collaborator invite popover after every mention
+        test('should provide fetchCollaboratorState resolving true so the invite popover never opens', async () => {
+            render(<PopupV2 {...defaults} />);
+
+            const user = {
+                id: 100,
+                email: 'test@box.com',
+                name: 'Test User',
+                type: 'user' as const,
+                value: 'test@box.com',
+            };
+            await expect(lastMentionContextValue.fetchCollaboratorState?.(user)).resolves.toBe(true);
         });
     });
 


### PR DESCRIPTION
## Summary

Fixes a bug where selecting a user from the @-mention dropdown in the threaded annotations v2 comment editor caused a small popover to immediately reappear, showing just the selected user.

That popover is the collaboration ("invite non-collaborator") popover from `@box/threaded-annotations`, not the mention typeahead. After a mention is selected, `useMentionUserSelection` checks `(await fetchCollaboratorState?.(user)) ?? false` and opens the popover for any user it considers a non-collaborator. This library did not provide `fetchCollaboratorState` in its `MentionContextProvider` value, so the check evaluated to false for every user and the popover opened after every mention.

Mention contacts here are fetched from the file collaborators API (`fetchCollaboratorsAction`), so every selectable user is already a collaborator and the invite popover should never be shown from this surface. The fix provides `fetchCollaboratorState: async () => true` in the mention context.

This also affects clicking an already-rendered mention in existing comments: those clicks now show the plain user card rather than an invite popover, which matches the intent that this surface does not offer inviting non-collaborators.

## Changes

- `src/components/Popups/PopupV2.tsx`: add `fetchCollaboratorState: async () => true` to the `MentionContextProvider` value.
- `src/components/Popups/__tests__/PopupV2-test.tsx`: the mocked provider now captures its `value` prop, and a new test asserts `fetchCollaboratorState(user)` resolves true so the invite popover cannot silently regress.

## Testing

- All 1060 unit tests across 117 suites pass; `tsc` and eslint clean
- Verified in a consuming application against a dev environment: selecting a mention inserts it with no popover, and clicking an existing mention shows the plain user card
