### PR TITLE
fix(region): persist staged region annotation on click-away

### DIFF
--- a/src/region/RegionCreation.tsx
+++ b/src/region/RegionCreation.tsx
@@ -33,7 +33,13 @@ export default class RegionCreation extends React.PureComponent<Props, State> {
     state: State = {};
 
     handleAbort = (): void => {
-        const { resetCreator } = this.props;
+        const { resetCreator, staged } = this.props;
+
+        // Click-away (a click too small to start a new region) must not discard an in-progress comment/annotation
+        if (staged) {
+            return;
+        }
+
         resetCreator();
     };
 

--- a/src/region/__tests__/RegionCreation-test.tsx
+++ b/src/region/__tests__/RegionCreation-test.tsx
@@ -45,7 +45,15 @@ describe('RegionCreation', () => {
         });
 
         describe('handleAbort', () => {
-            test('should call resetCreator', () => {
+            test('should not reset creator when a staged region already exists', () => {
+                instance.handleAbort();
+
+                expect(defaults.resetCreator).not.toHaveBeenCalled();
+            });
+
+            test('should call resetCreator when nothing is staged', () => {
+                wrapper = getWrapper({ staged: null });
+                instance = wrapper.instance() as InstanceType<typeof RegionCreation>;
                 instance.handleAbort();
 
                 expect(defaults.resetCreator).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Click-away on a staged region no longer calls `resetCreator()`, so the comment popup stays mounted and an in-progress PopupV2 draft is not lost.
- After investigation, this abort path only exists for region annotations. Highlight and drawing do not treat a normal click as cancel, so they are unchanged.
- Drawing caveat (existing behavior, not changed here): a true click does not discard the annotation, but starting a new drawing does. A long press or a click with a tiny drag can register as a new drawing and clear the in-progress comment.

## Test plan
- [ ] Draw a region, type a comment, click the page → region and comment stay
- [ ] Draw a region, leave the comment empty, click the page → region stays (no empty-dismiss guard in this PR)
- [ ] Click the page before drawing a region → creator still resets
- [ ] Draw a new region after one is staged → previous box is replaced with an empty editor
- [ ] Confirm highlight and drawing click-away still keep the staged annotation
- [ ] Drawing: a true click keeps the comment; a tiny drag that starts a new drawing still replaces it


Made with [Cursor](https://cursor.com)