### PR TITLE
feat(popup-v2): Hide wrapping markdown when flag off

### DIFF
--- a/src/adapters/__tests__/stripWrappingMarkdown-test.ts
+++ b/src/adapters/__tests__/stripWrappingMarkdown-test.ts
@@ -1,0 +1,38 @@
+import { stripWrappingMarkdown } from '../stripWrappingMarkdown';
+
+describe('stripWrappingMarkdown', () => {
+    test('returns empty input unchanged', () => {
+        expect(stripWrappingMarkdown('')).toBe('');
+    });
+
+    test('strips bold, italic, and underline wraps', () => {
+        expect(stripWrappingMarkdown('**bold**')).toBe('bold');
+        expect(stripWrappingMarkdown('_italic_')).toBe('italic');
+        expect(stripWrappingMarkdown('*italic*')).toBe('italic');
+        expect(stripWrappingMarkdown('++under++')).toBe('under');
+        expect(stripWrappingMarkdown('__bold__')).toBe('bold');
+    });
+
+    test('strips stacked wraps', () => {
+        expect(stripWrappingMarkdown('++**_stacked_**++')).toBe('stacked');
+    });
+
+    test('preserves mention tokens and strips wraps around adjacent text', () => {
+        expect(stripWrappingMarkdown('@[7340978551:Jose Gaston] ++pie++')).toBe('@[7340978551:Jose Gaston] pie');
+        expect(stripWrappingMarkdown('**@[7340978551:Jose Gaston]**')).toBe('@[7340978551:Jose Gaston]');
+    });
+
+    test('leaves list markers unchanged', () => {
+        expect(stripWrappingMarkdown('- @[7340978551:Jose Gaston] dogs')).toBe('- @[7340978551:Jose Gaston] dogs');
+        expect(stripWrappingMarkdown('1. numbered')).toBe('1. numbered');
+    });
+
+    test('leaves plain text and newlines unchanged', () => {
+        expect(stripWrappingMarkdown('Hello world')).toBe('Hello world');
+        expect(stripWrappingMarkdown('Line 1\nLine 2')).toBe('Line 1\nLine 2');
+    });
+
+    test('leaves unclosed underline literal', () => {
+        expect(stripWrappingMarkdown('++unclosed')).toBe('++unclosed');
+    });
+});

--- a/src/adapters/__tests__/threadedAnnotationsAdapters-test.ts
+++ b/src/adapters/__tests__/threadedAnnotationsAdapters-test.ts
@@ -201,6 +201,30 @@ describe('threadedAnnotationsAdapters', () => {
             });
         });
 
+        test('should strip wrapping markdown when isRichTextEnabled is false', () => {
+            const reply: Reply = { ...mockReply, message: '**bold**' };
+
+            const result = replyToTextMessage(reply);
+
+            expect(parseMessageMarkdown).not.toHaveBeenCalled();
+            expect(result.message.content[0].content).toEqual([{ type: 'text', text: 'bold' }]);
+        });
+
+        test('should leave list markers when stripping wraps with isRichTextEnabled false', () => {
+            const reply: Reply = { ...mockReply, message: '- @[10:Alice] dogs' };
+
+            const result = replyToTextMessage(reply);
+
+            expect(result.message.content[0].content).toEqual([
+                { type: 'text', text: '- ' },
+                {
+                    type: 'mention',
+                    attrs: { authorId: '', mentionId: '10', mentionedUserId: '10', mentionedUserName: 'Alice' },
+                },
+                { type: 'text', text: ' dogs' },
+            ]);
+        });
+
         test('should leave updatedAt undefined when reply has no modified_at', () => {
             const result = replyToTextMessage(mockReply);
 

--- a/src/adapters/stripWrappingMarkdown.ts
+++ b/src/adapters/stripWrappingMarkdown.ts
@@ -1,0 +1,60 @@
+/**
+ * Strips wrapping rich-text markdown delimiters for flag-off read paths.
+ * Handles **bold**, __bold__, _italic_, *italic*, and ++underline++ only.
+ * List markers (- , 1.) are intentionally left unchanged.
+ */
+
+const MENTION_PATTERN = /@\[([^:\]]+):([^\]]+)\]/g;
+
+const MENTION_PLACEHOLDER_PREFIX = '\u0000mention:';
+const MENTION_PLACEHOLDER_SUFFIX = '\u0000';
+
+const WRAP_DELIMITERS = ['++', '**', '__', '_', '*'] as const;
+
+const protectMentions = (text: string): { protectedText: string; mentions: string[] } => {
+    const mentions: string[] = [];
+    const protectedText = text.replace(MENTION_PATTERN, mention => {
+        mentions.push(mention);
+        return `${MENTION_PLACEHOLDER_PREFIX}${mentions.length - 1}${MENTION_PLACEHOLDER_SUFFIX}`;
+    });
+
+    return { protectedText, mentions };
+};
+
+const restoreMentions = (text: string, mentions: string[]): string =>
+    text.replace(
+        new RegExp(`${MENTION_PLACEHOLDER_PREFIX}(\\d+)${MENTION_PLACEHOLDER_SUFFIX}`, 'g'),
+        (_, index) => mentions[Number(index)] ?? '',
+    );
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const unwrapDelimiter = (text: string, delimiter: string): string => {
+    const escaped = escapeRegExp(delimiter);
+    return text.replace(new RegExp(`${escaped}([\\s\\S]*?)${escaped}`, 'g'), '$1');
+};
+
+const stripProtectedText = (text: string): string => {
+    let result = text;
+    let previous: string;
+
+    do {
+        previous = result;
+        for (const delimiter of WRAP_DELIMITERS) {
+            result = unwrapDelimiter(result, delimiter);
+        }
+    } while (result !== previous);
+
+    return result;
+};
+
+export const stripWrappingMarkdown = (text: string): string => {
+    if (!text) {
+        return text;
+    }
+
+    const { protectedText, mentions } = protectMentions(text);
+    const stripped = stripProtectedText(protectedText);
+
+    return restoreMentions(stripped, mentions);
+};

--- a/src/adapters/threadedAnnotationsAdapters.ts
+++ b/src/adapters/threadedAnnotationsAdapters.ts
@@ -9,6 +9,8 @@ import { parseMessageMarkdown } from '@box/threaded-annotations';
 
 import type { Annotation, Collaborator, Reply, UserMini } from '../@types';
 
+import { stripWrappingMarkdown } from './stripWrappingMarkdown';
+
 const MENTION_REGEX = /@\[(\d+):([^\]]+)\]/g;
 
 /**
@@ -77,7 +79,9 @@ export const deserializeMentionMarkup = (text: string): DocumentNodeV2 => {
 };
 
 const toDocumentNode = (text: string, isRichTextEnabled = false): DocumentNodeV2 =>
-    isRichTextEnabled ? (parseMessageMarkdown(text) as DocumentNodeV2) : deserializeMentionMarkup(text);
+    isRichTextEnabled
+        ? (parseMessageMarkdown(text) as DocumentNodeV2)
+        : deserializeMentionMarkup(stripWrappingMarkdown(text));
 
 /**
  * Returns the edit timestamp consumers use to render an edited indicator.


### PR DESCRIPTION
### Description

When `isRichTextEnabled` is false, `toDocumentNode` now unwraps wrapping markdown (`**`, `__`, `*`, `_`, `++`) before `deserializeMentionMarkup`, so the annotation popup shows the inner text instead of the marks.

When the flag is on, messages still go through `parseMessageMarkdown`. Mentions (`@[id:name]`) stay intact. List prefixes (`- `, `1.`) are not stripped. Composer serialize is unchanged.

Quirk: unmatched leftover marks stay visible — this is unwrap, not a markdown parser.
