### PR TITLE
feat(annotations): pass rich-text flag on fetch GET

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -59,6 +59,7 @@ export interface AnnotationsAPI {
         limit?: number,
         shouldFetchAll?: boolean,
         shouldFetchReplies?: boolean,
+        shouldEnableRichText?: boolean,
     ): Promise<void>;
 
     updateAnnotation(

--- a/src/store/annotations/__tests__/actions-test.ts
+++ b/src/store/annotations/__tests__/actions-test.ts
@@ -67,6 +67,39 @@ describe('store/annotations/actions', () => {
             expect(result.meta).toMatchObject({ aborted: true });
             expect(result.payload).toBe(undefined);
         });
+
+        test('should pass isRichTextEnabled into getAnnotations', async () => {
+            const getAnnotations = jest.fn((fileId, fileVersionId, permissions, resolve) =>
+                resolve({ entries: [], limit: 1000, next_marker: null }),
+            );
+            (api.getAnnotationsAPI as jest.Mock).mockReturnValueOnce({
+                getAnnotations,
+                destroy: jest.fn(),
+            });
+            getState.mockReturnValue({
+                ...baseState,
+                options: {
+                    ...baseState.options,
+                    features: { isRichTextEnabled: true },
+                },
+            });
+
+            await fetchAnnotationsAction()(dispatch, getState, { api });
+
+            expect(getAnnotations).toHaveBeenCalledWith(
+                '12345',
+                '67890',
+                baseState.options.permissions,
+                expect.any(Function),
+                expect.any(Function),
+                1000,
+                false,
+                false,
+                true,
+            );
+
+            getState.mockReturnValue(baseState);
+        });
     });
 
     describe('updateReplyAction', () => {

--- a/src/store/annotations/actions.ts
+++ b/src/store/annotations/actions.ts
@@ -41,10 +41,21 @@ export const fetchAnnotationsAction = createAsyncThunk<APICollection<Annotation>
         });
 
         const shouldFetchReplies = isFeatureEnabled({ options: getState().options }, 'isThreadedAnnotation');
+        const shouldEnableRichText = isFeatureEnabled({ options: getState().options }, 'isRichTextEnabled');
 
         // Wrap the client request in a promise to allow it to be returned and cancelled
         return new Promise<APICollection<Annotation>>((resolve, reject) => {
-            client.getAnnotations(fileId, fileVersionId, permissions, resolve, reject, 1000, false, shouldFetchReplies);
+            client.getAnnotations(
+                fileId,
+                fileVersionId,
+                permissions,
+                resolve,
+                reject,
+                1000,
+                false,
+                shouldFetchReplies,
+                shouldEnableRichText,
+            );
         });
     },
 );


### PR DESCRIPTION
### Description

`fetchAnnotationsAction` passes `isRichTextEnabled` as the last argument to `getAnnotations`. PopupV2 reads that store collection, not the sidebar `file_activities` payload.

Quirk: the arg is optional on the client so flag-off and older callers omit the key. Create, update, and delete stay param-free.
